### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -441,11 +441,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1733861387,
-        "narHash": "sha256-97A05r39uVo2UW0mQJvdxm5sgn2qlh3JUCtkRa7SP5s=",
+        "lastModified": 1733864105,
+        "narHash": "sha256-WjyOigIoneQijFAHxpu2xHCRdl4PcVctx0c1miPBBIA=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "d94d8b4ab26a8691a70922f43512f0484c086d85",
+        "rev": "4d05677e8d398b6fa144eae7a98ad4f2a54acb92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hyprland':
    'github:hyprwm/Hyprland/d94d8b4ab26a8691a70922f43512f0484c086d85?narHash=sha256-97A05r39uVo2UW0mQJvdxm5sgn2qlh3JUCtkRa7SP5s%3D' (2024-12-10)
  → 'github:hyprwm/Hyprland/4d05677e8d398b6fa144eae7a98ad4f2a54acb92?narHash=sha256-WjyOigIoneQijFAHxpu2xHCRdl4PcVctx0c1miPBBIA%3D' (2024-12-10)
```