### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -353,11 +353,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733769654,
-        "narHash": "sha256-aVvYDt8eitZVF6fdOrSoIzYRkQ5Gh6kfRvqkiaDRLL0=",
+        "lastModified": 1733873195,
+        "narHash": "sha256-dTosiZ3sZ/NKoLKQ++v8nZdEHya0eTNEsaizNp+MUPM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e952e94955dcc6fa2120c1430789fc41363f5237",
+        "rev": "f26aa4b76fb7606127032d33ac73d7d507d82758",
         "type": "github"
       },
       "original": {
@@ -623,11 +623,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1733796600,
-        "narHash": "sha256-scaQMTs4NnGkd9SZWROr5m0vOZIIhRkk5N7Q+S9zhXQ=",
+        "lastModified": 1733868086,
+        "narHash": "sha256-CeYsC8J2dNiV2FCQOxK1oZ/jNpOF2io7aCEFHmfi95U=",
         "owner": "astro",
         "repo": "microvm.nix",
-        "rev": "e08aed6e3a32e47e21e57bd2791326ea3f7647be",
+        "rev": "870cb181719aa12baf478d7cde6068ec7ed144ae",
         "type": "github"
       },
       "original": {
@@ -717,11 +717,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1733550349,
-        "narHash": "sha256-NcGumB4Lr6KSDq+nIqXtNA8QwAQKDSZT7N9OTGWbTrs=",
+        "lastModified": 1733808091,
+        "narHash": "sha256-KWwINTQelKOoQgrXftxoqxmKFZb9pLVfnRvK270nkVk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2605d0744c2417b09f8bf850dfca42fcf537d34",
+        "rev": "a0f3e10d94359665dba45b71b4227b0aeb851f8e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/e952e94955dcc6fa2120c1430789fc41363f5237?narHash=sha256-aVvYDt8eitZVF6fdOrSoIzYRkQ5Gh6kfRvqkiaDRLL0%3D' (2024-12-09)
  → 'github:nix-community/home-manager/f26aa4b76fb7606127032d33ac73d7d507d82758?narHash=sha256-dTosiZ3sZ/NKoLKQ%2B%2Bv8nZdEHya0eTNEsaizNp%2BMUPM%3D' (2024-12-10)
• Updated input 'microvm':
    'github:astro/microvm.nix/e08aed6e3a32e47e21e57bd2791326ea3f7647be?narHash=sha256-scaQMTs4NnGkd9SZWROr5m0vOZIIhRkk5N7Q%2BS9zhXQ%3D' (2024-12-10)
  → 'github:astro/microvm.nix/870cb181719aa12baf478d7cde6068ec7ed144ae?narHash=sha256-CeYsC8J2dNiV2FCQOxK1oZ/jNpOF2io7aCEFHmfi95U%3D' (2024-12-10)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/e2605d0744c2417b09f8bf850dfca42fcf537d34?narHash=sha256-NcGumB4Lr6KSDq%2BnIqXtNA8QwAQKDSZT7N9OTGWbTrs%3D' (2024-12-07)
  → 'github:NixOS/nixpkgs/a0f3e10d94359665dba45b71b4227b0aeb851f8e?narHash=sha256-KWwINTQelKOoQgrXftxoqxmKFZb9pLVfnRvK270nkVk%3D' (2024-12-10)
```