### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -441,11 +441,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1733864105,
-        "narHash": "sha256-WjyOigIoneQijFAHxpu2xHCRdl4PcVctx0c1miPBBIA=",
+        "lastModified": 1733938069,
+        "narHash": "sha256-k2R2/rI4+A2bAyjCSwD//vCWZZnQcl38j/DiZzsNCHk=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "4d05677e8d398b6fa144eae7a98ad4f2a54acb92",
+        "rev": "df956a0f6fbcfd7397b2d7b86883c0936c7795ec",
         "type": "github"
       },
       "original": {
@@ -733,11 +733,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1733881728,
-        "narHash": "sha256-E/NfKTNHvBBjBHdSv1Dgn5kRzJcymH/xgXZ3sGoHmV8=",
+        "lastModified": 1733925265,
+        "narHash": "sha256-SD/Gr1y7fhndRohoZy/edif3RM3+W84E4Vlzzejn0bI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "26baeceed3a5ab67791b1456ff710fe97b661639",
+        "rev": "8cd84794deeea7d0d03c4bd3d0f6fdc32d806582",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hyprland':
    'github:hyprwm/Hyprland/4d05677e8d398b6fa144eae7a98ad4f2a54acb92?narHash=sha256-WjyOigIoneQijFAHxpu2xHCRdl4PcVctx0c1miPBBIA%3D' (2024-12-10)
  → 'github:hyprwm/Hyprland/df956a0f6fbcfd7397b2d7b86883c0936c7795ec?narHash=sha256-k2R2/rI4%2BA2bAyjCSwD//vCWZZnQcl38j/DiZzsNCHk%3D' (2024-12-11)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/26baeceed3a5ab67791b1456ff710fe97b661639?narHash=sha256-E/NfKTNHvBBjBHdSv1Dgn5kRzJcymH/xgXZ3sGoHmV8%3D' (2024-12-11)
  → 'github:NixOS/nixpkgs/8cd84794deeea7d0d03c4bd3d0f6fdc32d806582?narHash=sha256-SD/Gr1y7fhndRohoZy/edif3RM3%2BW84E4Vlzzejn0bI%3D' (2024-12-11)
```