### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -353,11 +353,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733873195,
-        "narHash": "sha256-dTosiZ3sZ/NKoLKQ++v8nZdEHya0eTNEsaizNp+MUPM=",
+        "lastModified": 1733951607,
+        "narHash": "sha256-CN6q6iCzxI1gkNyk4xLdwaMKi10r7n+aJkRzWj8PXwQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f26aa4b76fb7606127032d33ac73d7d507d82758",
+        "rev": "6e5b2d9e8014b5572e3367937a329e7053458d34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/f26aa4b76fb7606127032d33ac73d7d507d82758?narHash=sha256-dTosiZ3sZ/NKoLKQ%2B%2Bv8nZdEHya0eTNEsaizNp%2BMUPM%3D' (2024-12-10)
  → 'github:nix-community/home-manager/6e5b2d9e8014b5572e3367937a329e7053458d34?narHash=sha256-CN6q6iCzxI1gkNyk4xLdwaMKi10r7n%2BaJkRzWj8PXwQ%3D' (2024-12-11)
```