### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -866,11 +866,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733785344,
-        "narHash": "sha256-pm4cfEcPXripE36PYCl0A2Tu5ruwHEvTee+HzNk+SQE=",
+        "lastModified": 1733965552,
+        "narHash": "sha256-GZ4YtqkfyTjJFVCub5yAFWsHknG1nS/zfk7MuHht4Fs=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "a80af8929781b5fe92ddb8ae52e9027fae780d2a",
+        "rev": "2d73fc6ac4eba4b9a83d3cb8275096fbb7ab4004",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'sops-nix':
    'github:Mic92/sops-nix/a80af8929781b5fe92ddb8ae52e9027fae780d2a?narHash=sha256-pm4cfEcPXripE36PYCl0A2Tu5ruwHEvTee%2BHzNk%2BSQE%3D' (2024-12-09)
  → 'github:Mic92/sops-nix/2d73fc6ac4eba4b9a83d3cb8275096fbb7ab4004?narHash=sha256-GZ4YtqkfyTjJFVCub5yAFWsHknG1nS/zfk7MuHht4Fs%3D' (2024-12-12)
```