### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -638,11 +638,11 @@
     },
     "nix-secrets": {
       "locked": {
-        "lastModified": 1733785914,
-        "narHash": "sha256-ZH5ose5iJGoJXvZAIYKuyu9ivACWNXhvyQXOCDNl4Hs=",
+        "lastModified": 1733998572,
+        "narHash": "sha256-7H7BkTMRV33RkvvK5hVttPOHzu+ugRvrBCSxnloDVn4=",
         "ref": "refs/heads/master",
-        "rev": "a28265e108e3f0d2538d313a8b1f937fc1ea0c02",
-        "revCount": 24,
+        "rev": "03434ee069b197d165cc5d1991d765ca4a35be73",
+        "revCount": 25,
         "type": "git",
         "url": "ssh://git@github.com/telometto/nix-secrets.git"
       },


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nix-secrets':
    'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=a28265e108e3f0d2538d313a8b1f937fc1ea0c02' (2024-12-09)
  → 'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=03434ee069b197d165cc5d1991d765ca4a35be73' (2024-12-12)
```