### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -353,11 +353,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733951607,
-        "narHash": "sha256-CN6q6iCzxI1gkNyk4xLdwaMKi10r7n+aJkRzWj8PXwQ=",
+        "lastModified": 1734031102,
+        "narHash": "sha256-6RDywJJ1AuG2NflpXaWgNDYOOLGCqgTezUuc0RiEYzA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6e5b2d9e8014b5572e3367937a329e7053458d34",
+        "rev": "15151bb5e7d6e352247ecaeeeefc34d0f306b287",
         "type": "github"
       },
       "original": {
@@ -733,11 +733,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1733925265,
-        "narHash": "sha256-SD/Gr1y7fhndRohoZy/edif3RM3+W84E4Vlzzejn0bI=",
+        "lastModified": 1734014226,
+        "narHash": "sha256-RcDCLav9GZYWYGoPcU5LzDxrqdDO+a4UYg4pSDyfV9c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8cd84794deeea7d0d03c4bd3d0f6fdc32d806582",
+        "rev": "0b04b1f3548f38d045f46821d8f41cab5680fed7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/6e5b2d9e8014b5572e3367937a329e7053458d34?narHash=sha256-CN6q6iCzxI1gkNyk4xLdwaMKi10r7n%2BaJkRzWj8PXwQ%3D' (2024-12-11)
  → 'github:nix-community/home-manager/15151bb5e7d6e352247ecaeeeefc34d0f306b287?narHash=sha256-6RDywJJ1AuG2NflpXaWgNDYOOLGCqgTezUuc0RiEYzA%3D' (2024-12-12)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/8cd84794deeea7d0d03c4bd3d0f6fdc32d806582?narHash=sha256-SD/Gr1y7fhndRohoZy/edif3RM3%2BW84E4Vlzzejn0bI%3D' (2024-12-11)
  → 'github:NixOS/nixpkgs/0b04b1f3548f38d045f46821d8f41cab5680fed7?narHash=sha256-RcDCLav9GZYWYGoPcU5LzDxrqdDO%2Ba4UYg4pSDyfV9c%3D' (2024-12-12)
```