### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730135292,
-        "narHash": "sha256-CI27qHAbc3/tIe8sb37kiHNaeCqGxNimckCMj0lW5kg=",
+        "lastModified": 1734088167,
+        "narHash": "sha256-snPBgTqwn3FPZVdFC5yt7Bnk3squim1vZOZ8CObWykk=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "ab58501b2341bc5e0fc88f2f5983a679b075ddf5",
+        "rev": "65a441502c9382d41ada1adbc9bd31d6c9b00fe2",
         "type": "github"
       },
       "original": {
@@ -733,11 +733,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1734014226,
-        "narHash": "sha256-RcDCLav9GZYWYGoPcU5LzDxrqdDO+a4UYg4pSDyfV9c=",
+        "lastModified": 1734057604,
+        "narHash": "sha256-EC3eHb8Mk54jnk+C8Mtq2sRAaPJzg6zPvRY6OdNHwSc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0b04b1f3548f38d045f46821d8f41cab5680fed7",
+        "rev": "403845c37839bd698e8c36587f0601e36f76d2a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/ab58501b2341bc5e0fc88f2f5983a679b075ddf5?narHash=sha256-CI27qHAbc3/tIe8sb37kiHNaeCqGxNimckCMj0lW5kg%3D' (2024-10-28)
  → 'github:nix-community/disko/65a441502c9382d41ada1adbc9bd31d6c9b00fe2?narHash=sha256-snPBgTqwn3FPZVdFC5yt7Bnk3squim1vZOZ8CObWykk%3D' (2024-12-13)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/0b04b1f3548f38d045f46821d8f41cab5680fed7?narHash=sha256-RcDCLav9GZYWYGoPcU5LzDxrqdDO%2Ba4UYg4pSDyfV9c%3D' (2024-12-12)
  → 'github:NixOS/nixpkgs/403845c37839bd698e8c36587f0601e36f76d2a8?narHash=sha256-EC3eHb8Mk54jnk%2BC8Mtq2sRAaPJzg6zPvRY6OdNHwSc%3D' (2024-12-13)
```