### PR TITLE
Add missing SSH host keys volume for stable identity

### DIFF
--- a/vms/actual.nix
+++ b/vms/actual.nix
@@ -88,6 +88,10 @@
   };
 
   # SSH host keys on persistent storage for stable identity across rebuilds
+  systemd.tmpfiles.rules = [
+    "d /persist/ssh 0700 root root -"
+  ];
+
   services.openssh.hostKeys = [
     {
       path = "/persist/ssh/ssh_host_ed25519_key";


### PR DESCRIPTION
Include a volume for SSH host keys to ensure stable identity in the configuration.