### PR TITLE
Add SOPS integration for password management and persistent SSH keys

### DIFF
--- a/vms/adguard.nix
+++ b/vms/adguard.nix
@@ -172,7 +172,8 @@
         exit 1
       fi
 
-      ${pkgs.yq-go}/bin/yq -i '.users[0].password = "'"$HASH"'"' "$CONFIG"
+      export HASH
+      ${pkgs.yq-go}/bin/yq -i '.users[0].password = strenv(HASH)' "$CONFIG"
     '';
   };
 


### PR DESCRIPTION
Integrate SOPS for managing passwords and SSH keys in the AdGuard configuration. This enhancement allows for secure password injection at runtime and ensures SSH host keys persist across rebuilds.