### PR TITLE
Update TLS configuration to use SOPS for certificate management

### DIFF
--- a/modules/services/adguardhome.nix
+++ b/modules/services/adguardhome.nix
@@ -100,7 +100,7 @@ let
 
     tls = {
       enabled = true;
-      server_name = "adguard.${VARS.domains.public}";
+      server_name = "";
       force_https = true;
       port_https = 443;
       port_dns_over_tls = 853;
@@ -108,8 +108,8 @@ let
       port_dnscrypt = 0;
       dnscrypt_config_file = "";
       allow_unencrypted_doh = false;
-      certificate_chain = VARS.svc.agh.fullchain;
-      private_key = VARS.svc.agh.privkey;
+      certificate_chain = "";
+      private_key = "";
       certificate_path = "";
       private_key_path = "";
       strict_sni_check = false;

--- a/vms/adguard.nix
+++ b/vms/adguard.nix
@@ -29,6 +29,14 @@
     owner = "root";
   };
 
+  sops.secrets."adguard/fullchain" = {
+    mode = "0444";
+  };
+
+  sops.secrets."adguard/privkey" = {
+    mode = "0400";
+  };
+
   networking.hostName = "adguard-vm";
 
   # MicroVM-specific configuration
@@ -128,6 +136,15 @@
     # Workaround for AdGuard Home v0.107.71 dual-stack DoT bind issue
     # (https://github.com/AdguardTeam/AdGuardHome/discussions/7395)
     settings.dns.bind_hosts = lib.mkForce [ "10.100.0.10" ];
+
+    # TLS certificates from SOPS (using file paths instead of inline content)
+    settings.tls = {
+      server_name = "adguard.${VARS.domains.public}";
+      certificate_chain = "";
+      private_key = "";
+      certificate_path = config.sops.secrets."adguard/fullchain".path;
+      private_key_path = config.sops.secrets."adguard/privkey".path;
+    };
   };
 
   # SSH host keys on persistent storage for stable identity across rebuilds


### PR DESCRIPTION
Refactor the TLS configuration to utilize SOPS for managing certificate paths, enhancing security and maintainability. This change removes inline certificate content and specifies file paths for the certificate chain and private key.