### PR TITLE
🪄 feature(immich): add Immich service and VM configuration

### DIFF
--- a/hosts/blizzard/services/productivity.nix
+++ b/hosts/blizzard/services/productivity.nix
@@ -22,19 +22,5 @@
     };
 
     firefly.enable = false;
-
-    immich = {
-      enable = false;
-
-      host = "0.0.0.0";
-      port = 11007;
-      openFirewall = true;
-      mediaLocation = "/flash/enc/personal/immich-library";
-      secretsFile = "/opt/sec/immich-file";
-      environment = {
-        IMMICH_LOG_LEVEL = "verbose";
-        IMMICH_TELEMETRY_INCLUDE = "all";
-      };
-    };
   };
 }

--- a/hosts/blizzard/virtualisation/microvms.nix
+++ b/hosts/blizzard/virtualisation/microvms.nix
@@ -274,6 +274,16 @@ let
         ];
       };
     };
+
+    immich = {
+      enable = true;
+      portForwards = [ (mkPortForward "tcp" 11070 null) ];
+      ingressHosts = [ "photos" ];
+      reverseProxy = {
+        subdomain = "photos";
+        url = vmUrl "immich";
+      };
+    };
   };
 in
 {

--- a/vms/flake-microvms.nix
+++ b/vms/flake-microvms.nix
@@ -165,4 +165,10 @@ in
     sopsModule
     ./firefly-importer.nix
   ];
+
+  immich-vm = mkMicrovm [
+    microvmModule
+    sopsModule
+    ./immich.nix
+  ];
 }

--- a/vms/immich.nix
+++ b/vms/immich.nix
@@ -1,0 +1,58 @@
+{
+  inputs,
+  ...
+}:
+let
+  reg = (import ./vm-registry.nix).immich;
+in
+{
+  imports = [
+    ./base.nix
+    ../modules/services/immich.nix
+    inputs.sops-nix.nixosModules.sops
+    (import ./mkMicrovmConfig.nix (
+      reg
+      // {
+        volumes = [
+          {
+            mountPoint = "/var/lib/immich";
+            image = "immich-state.img";
+            size = 1048576;
+          }
+          {
+            mountPoint = "/var/lib/postgresql";
+            image = "postgresql-state.img";
+            size = 10240;
+          }
+        ];
+      }
+    ))
+  ];
+
+  # SOPS configuration for this MicroVM
+  # After first boot, get the VM's age key with:
+  #   ssh admin@10.100.0.70 "sudo cat /persist/ssh/ssh_host_ed25519_key" | ssh-to-age
+  # Then add it to your .sops.yaml and re-encrypt secrets
+  sops = {
+    defaultSopsFile = inputs.nix-secrets.secrets.secretsFile;
+    defaultSopsFormat = "yaml";
+    age.sshKeyPaths = [ "/persist/ssh/ssh_host_ed25519_key" ];
+    useSystemdActivation = true;
+
+    secrets = { };
+  };
+
+  networking.firewall.allowedTCPPorts = [ reg.port ];
+
+  systemd.tmpfiles.rules = [
+    "d /var/lib/immich 0700 immich immich -"
+    "d /var/lib/postgresql 0700 postgres postgres -"
+  ];
+
+  sys.services.immich = {
+    enable = true;
+    host = "0.0.0.0";
+    port = reg.port;
+    openFirewall = true;
+  };
+}

--- a/vms/vm-registry.nix
+++ b/vms/vm-registry.nix
@@ -251,4 +251,14 @@
     vcpu = 1;
     tapId = "vm-ff-import";
   };
+
+  immich = {
+    name = "immich";
+    cid = 124;
+    mac = "02:00:00:00:00:19";
+    ip = "10.100.0.70";
+    port = 11070;
+    mem = 8192;
+    vcpu = 4;
+  };
 }


### PR DESCRIPTION
This pull request migrates the deployment of the `immich` photo management service from a local service to a dedicated MicroVM, improving isolation and maintainability. The changes include configuring the new MicroVM, updating the VM registry, and removing the previous local service definition.

**MicroVM deployment and configuration:**

* Added a new `immich-vm` MicroVM definition in `vms/flake-microvms.nix`, referencing a new configuration file for the service.
* Introduced a new `vms/immich.nix` file to configure the `immich` MicroVM, including storage volumes, firewall ports, SOPS secrets management, and service parameters.
* Registered the `immich` VM in `vms/vm-registry.nix` with its own IP address, MAC address, port, and resource allocations.

**Network and service integration:**

* Updated `hosts/blizzard/virtualisation/microvms.nix` to enable the `immich` MicroVM, set up port forwarding, and configure reverse proxying under the `photos` subdomain.

**Cleanup of old configuration:**

* Removed the previous local `immich` service definition from `hosts/blizzard/services/productivity.nix`.