### PR TITLE
🔧 refactor: update GitHub token to use PAT for repository access

### DIFF
--- a/.github/workflows/update-nix-lock.yml
+++ b/.github/workflows/update-nix-lock.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout main repository
         uses: actions/checkout@v6.0.2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN }}
           fetch-depth: 0
 
       - name: Install Nix
@@ -42,7 +42,7 @@ jobs:
             ```
           pr-title: "🧹 chore(flake.lock): update"
           pr-labels: auto-merge
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Get commit message for compare URLs
         if: steps.update-flake-lock.outputs.pull-request-operation == 'created' || steps.update-flake-lock.outputs.pull-request-operation == 'updated'


### PR DESCRIPTION
This pull request updates the authentication method used in the GitHub Actions workflow for updating the Nix lock file. The workflow now uses a personal access token instead of the default GitHub token for improved permissions and flexibility.

Workflow authentication updates:

* Changed the `token` parameter from `${{ secrets.GITHUB_TOKEN }}` to `${{ secrets.PAT_TOKEN }}` in both the repository checkout step and the pull request creation step of `.github/workflows/update-nix-lock.yml`. [[1]](diffhunk://#diff-5ed3726aaf789a34b276fd5e8db3d5fb7edb6a18123143ba6d1a6e393ff12b87L28-R28) [[2]](diffhunk://#diff-5ed3726aaf789a34b276fd5e8db3d5fb7edb6a18123143ba6d1a6e393ff12b87L45-R45)