### PR TITLE
Dev podman

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -1,0 +1,113 @@
+## Podman Container Stacks
+
+Declarative Podman container definitions using the
+`sys.virtualisation.podman.stacks` module.
+
+### Available Stacks
+
+| Stack | File | Containers | Purpose |
+|-------|------|------------|---------|
+| lingarr | [lingarr.nix](lingarr.nix) | lingarr, libretranslate, ollama | Automated subtitle translation |
+| subgen | [subgen.nix](subgen.nix) | subgen | Whisper-based subtitle generation |
+
+### Architecture
+
+Container stacks run as Podman OCI containers managed by systemd. The
+[podman-containers module](../modules/virtualisation/podman-containers.nix)
+merges enabled stacks into NixOS's native `virtualisation.oci-containers`
+system, giving each container a dedicated systemd service with automatic
+restart and boot-time startup.
+
+```
+┌─────────────────────────────────────────┐
+│  Host (blizzard)                        │
+│  └── sys.virtualisation.enable = true   │
+│      └── Podman + OCI backend           │
+└─────────────────────────────────────────┘
+         │
+         ├── lingarr stack
+         │   ├── lingarr      (:11025)
+         │   ├── libretranslate (:11026)
+         │   └── ollama       (:11434)
+         │
+         └── subgen stack
+             └── subgen       (:11027)
+```
+
+### Key Differences from MicroVMs
+
+| Aspect | MicroVMs | Container Stacks |
+|--------|----------|------------------|
+| Isolation | Full VM (kernel, network namespace) | Process-level (shared kernel) |
+| Config | `vms/*.nix` + registry + mkMicrovmConfig | `containers/*.nix` (self-contained) |
+| Management | microvm.nix hypervisor | Podman via systemd |
+| Use case | Services needing strong isolation | Upstream images without NixOS modules |
+
+### Creating a New Stack
+
+1. Create `containers/<stack-name>.nix`:
+
+```nix
+{ lib, ... }:
+{
+  config.sys.virtualisation.podman.stacks.<stack-name> = {
+    containers = {
+      my-app = {
+        image = "registry/image:tag";
+        ports = [ "8080:80" ];
+        volumes = [ "/host/path:/container/path" ];
+        environment = {
+          SOME_VAR = "value";
+        };
+      };
+    };
+  };
+}
+```
+
+2. Import and enable in the host config
+   (e.g., `hosts/<hostname>/virtualisation/containers.nix`):
+
+```nix
+{
+  imports = [
+    ../../../containers/<stack-name>.nix
+  ];
+
+  sys.virtualisation.podman.stacks.<stack-name>.enable = true;
+}
+```
+
+3. Build and switch:
+
+```bash
+sudo nixos-rebuild switch --flake .#<hostname>
+```
+
+### Container Options
+
+Each container in a stack supports:
+
+- `image` — OCI image to run (required)
+- `ports` — Port mappings (`"host:container"` strings)
+- `volumes` — Volume mounts (`"src:dst"` strings)
+- `environment` — Environment variables (attrset)
+- `environmentFiles` — Paths to env files
+- `dependsOn` — Other container names to start first
+- `extraOptions` — Extra CLI flags for `podman run`
+- `labels` — Container labels
+- `cmd` — Command arguments
+- `entrypoint` — Override image entrypoint
+- `user` — Override container user
+- `autoStart` — Start on boot (default: `true`)
+
+### Related Documentation
+
+- [System Modules](../modules/README.md) — Module conventions
+- [MicroVM Configurations](../vms/README.md) — VM-based alternative
+- [Blizzard host](../hosts/blizzard/) — Server running both VMs and containers
+
+______________________________________________________________________
+
+*This documentation was generated with the assistance of LLMs and may require
+verification against current implementation.*

--- a/containers/lingarr.nix
+++ b/containers/lingarr.nix
@@ -1,5 +1,8 @@
 # Lingarr stack: automated subtitle translation with LibreTranslate + Ollama
-{ lib, ... }:
+{ lib, config, ... }:
+let
+  stackCfg = config.sys.virtualisation.podman.stacks.lingarr;
+in
 {
   options.sys.virtualisation.podman.stacks.lingarr = {
     mediaDir = lib.mkOption {
@@ -26,9 +29,9 @@
           DB_HANGFIRE_SQLITE_PATH = "/app/config/Hangfire.db";
         };
         volumes = [
-          "/rpool/unenc/media/data/media/movies:/data/media/movies"
-          "/rpool/unenc/media/data/media/tv:/data/media/tv"
-          "/rpool/unenc/apps/docker/lingarr:/app/config"
+          "${stackCfg.mediaDir}/movies:/data/media/movies"
+          "${stackCfg.mediaDir}/tv:/data/media/tv"
+          "${stackCfg.dataDir}/lingarr:/app/config"
         ];
         dependsOn = [
           "libretranslate"
@@ -44,7 +47,7 @@
           LT_LOAD_ONLY = "en,it,nb";
         };
         volumes = [
-          "/rpool/unenc/apps/docker/libretranslate:/home/libretranslate/.local/share/argos-translate"
+          "${stackCfg.dataDir}/libretranslate:/home/libretranslate/.local/share/argos-translate"
         ];
         extraOptions = [ "--security-opt=apparmor:unconfined" ];
       };
@@ -53,7 +56,7 @@
         image = "ollama/ollama:latest";
         ports = [ "11434:11434" ];
         volumes = [
-          "/rpool/unenc/apps/docker/ollama:/root/.ollama"
+          "${stackCfg.dataDir}/ollama:/root/.ollama"
         ];
         extraOptions = [ "--security-opt=apparmor:unconfined" ];
       };

--- a/containers/lingarr.nix
+++ b/containers/lingarr.nix
@@ -1,0 +1,62 @@
+# Lingarr stack: automated subtitle translation with LibreTranslate + Ollama
+{ lib, ... }:
+{
+  options.sys.virtualisation.podman.stacks.lingarr = {
+    mediaDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/rpool/unenc/media/data/media";
+      description = "Base path for media directories (movies/, tv/).";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/rpool/unenc/apps/docker";
+      description = "Base path for persistent application data.";
+    };
+  };
+
+  config.sys.virtualisation.podman.stacks.lingarr = {
+    containers = {
+      lingarr = {
+        image = "lingarr/lingarr:latest";
+        ports = [ "11025:9876" ];
+        environment = {
+          ASPNETCORE_URLS = "http://+:9876";
+          MAX_CONCURRENT_JOBS = "1";
+          DB_HANGFIRE_SQLITE_PATH = "/app/config/Hangfire.db";
+        };
+        volumes = [
+          "/rpool/unenc/media/data/media/movies:/data/media/movies"
+          "/rpool/unenc/media/data/media/tv:/data/media/tv"
+          "/rpool/unenc/apps/docker/lingarr:/app/config"
+        ];
+        dependsOn = [
+          "libretranslate"
+          "ollama"
+        ];
+        extraOptions = [ "--security-opt=apparmor:unconfined" ];
+      };
+
+      libretranslate = {
+        image = "libretranslate/libretranslate:latest";
+        ports = [ "11026:5000" ];
+        environment = {
+          LT_LOAD_ONLY = "en,it,nb";
+        };
+        volumes = [
+          "/rpool/unenc/apps/docker/libretranslate:/home/libretranslate/.local/share/argos-translate"
+        ];
+        extraOptions = [ "--security-opt=apparmor:unconfined" ];
+      };
+
+      ollama = {
+        image = "ollama/ollama:latest";
+        ports = [ "11434:11434" ];
+        volumes = [
+          "/rpool/unenc/apps/docker/ollama:/root/.ollama"
+        ];
+        extraOptions = [ "--security-opt=apparmor:unconfined" ];
+      };
+    };
+  };
+}

--- a/containers/subgen.nix
+++ b/containers/subgen.nix
@@ -44,7 +44,7 @@ in
           LRC_FOR_AUDIO_FILES = "True";
           CUSTOM_REGROUP = "cm_sl=84_sl=42++++++1";
           USE_PATH_MAPPING = "True";
-          PATH_MAPPING_FROM = "/rpool/unenc/media/data";
+          PATH_MAPPING_FROM = lib.dirOf stackCfg.mediaDir;
           PATH_MAPPING_TO = "/data";
           # TODO: migrate these tokens to sops-nix environmentFiles
           PLEXSERVER = "https://192.168.2.100:32400";

--- a/containers/subgen.nix
+++ b/containers/subgen.nix
@@ -1,5 +1,8 @@
 # Subgen: automatic subtitle generation via Whisper
-{ lib, ... }:
+{ lib, config, ... }:
+let
+  stackCfg = config.sys.virtualisation.podman.stacks.subgen;
+in
 {
   options.sys.virtualisation.podman.stacks.subgen = {
     mediaDir = lib.mkOption {
@@ -48,9 +51,9 @@
           JELLYFINSERVER = "http://192.168.2.100:8096";
         };
         volumes = [
-          "/rpool/unenc/media/data/media/tv:/data/media/tv"
-          "/rpool/unenc/media/data/media/movies:/data/media/movies"
-          "/rpool/unenc/apps/docker/subgen/models:/subgen/models"
+          "${stackCfg.mediaDir}/tv:/data/media/tv"
+          "${stackCfg.mediaDir}/movies:/data/media/movies"
+          "${stackCfg.modelDir}:/subgen/models"
         ];
         extraOptions = [
           "--tty"

--- a/containers/subgen.nix
+++ b/containers/subgen.nix
@@ -1,0 +1,62 @@
+# Subgen: automatic subtitle generation via Whisper
+{ lib, ... }:
+{
+  options.sys.virtualisation.podman.stacks.subgen = {
+    mediaDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/rpool/unenc/media/data/media";
+      description = "Base path for media directories (movies/, tv/).";
+    };
+
+    modelDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/rpool/unenc/apps/docker/subgen/models";
+      description = "Path for Whisper model storage.";
+    };
+  };
+
+  config.sys.virtualisation.podman.stacks.subgen = {
+    containers = {
+      subgen = {
+        image = "mccloud/subgen";
+        ports = [ "11027:9000" ];
+        environment = {
+          WHISPER_MODEL = "medium";
+          WHISPER_THREADS = "6";
+          PROCADDEDMEDIA = "True";
+          PROCMEDIAONPLAY = "False";
+          NAMESUBLANG = "eng";
+          SKIPIFINTERNALSUBLANG = "eng";
+          WEBHOOKPORT = "9000";
+          CONCURRENT_TRANSCRIPTIONS = "2";
+          WORD_LEVEL_HIGHLIGHT = "False";
+          DEBUG = "True";
+          TRANSCRIBE_DEVICE = "cpu";
+          CLEAR_VRAM_ON_COMPLETE = "True";
+          MODEL_PATH = "./models";
+          UPDATE = "True";
+          APPEND = "False";
+          USE_MODEL_PROMPT = "False";
+          CUSTOM_MODEL_PROMPT = "";
+          LRC_FOR_AUDIO_FILES = "True";
+          CUSTOM_REGROUP = "cm_sl=84_sl=42++++++1";
+          USE_PATH_MAPPING = "True";
+          PATH_MAPPING_FROM = "/rpool/unenc/media/data";
+          PATH_MAPPING_TO = "/data";
+          # TODO: migrate these tokens to sops-nix environmentFiles
+          PLEXSERVER = "https://192.168.2.100:32400";
+          JELLYFINSERVER = "http://192.168.2.100:8096";
+        };
+        volumes = [
+          "/rpool/unenc/media/data/media/tv:/data/media/tv"
+          "/rpool/unenc/media/data/media/movies:/data/media/movies"
+          "/rpool/unenc/apps/docker/subgen/models:/subgen/models"
+        ];
+        extraOptions = [
+          "--tty"
+          "--security-opt=apparmor:unconfined"
+        ];
+      };
+    };
+  };
+}

--- a/docs/reference-architecture.md
+++ b/docs/reference-architecture.md
@@ -98,6 +98,20 @@ nix flake check
 - [vms/base.nix](../vms/base.nix): Shared hardened base config for all VMs.
   Includes SSH host keys, admin user, firewall, and stateVersion.
 
+## Podman Container Stacks
+
+- Module: [modules/virtualisation/podman-containers.nix](../modules/virtualisation/podman-containers.nix)
+- Container definitions: [containers/](../containers/) (not auto-loaded; imported
+  explicitly by hosts)
+- Options: `sys.virtualisation.podman.stacks.<name>`
+  - `enable` — opt a stack into the host
+  - `autoStart` — start containers on boot (default: `true`)
+  - `containers.<name>` — individual container specs (image, ports, volumes,
+    environment, dependsOn, extraOptions, etc.)
+- Enabled stacks are merged into `virtualisation.oci-containers.containers`.
+- Requires `sys.virtualisation.enable = true` on the host (provides Podman +
+  OCI backend via [modules/virtualisation/virtualisation.nix](../modules/virtualisation/virtualisation.nix)).
+
 ## Traefik Helpers (`lib/traefik.nix`)
 
 - `mkSecurityHeaders { ... }`: Generate Traefik middleware attrsets with

--- a/hosts/README.md
+++ b/hosts/README.md
@@ -47,7 +47,8 @@ hosts/blizzard/
 │   ├── crowdsec.nix
 │   └── traefik.nix
 └── virtualisation/         # VMs and containers
-    └── microvms.nix
+    ├── microvms.nix
+    └── containers.nix
 ```
 
 All `.nix` files are auto-imported recursively by [host-loader.nix](../host-loader.nix) — no explicit

--- a/hosts/blizzard/virtualisation/containers.nix
+++ b/hosts/blizzard/virtualisation/containers.nix
@@ -1,0 +1,13 @@
+# Podman container stacks running on blizzard
+{ ... }:
+{
+  imports = [
+    ../../../containers/lingarr.nix
+    ../../../containers/subgen.nix
+  ];
+
+  sys.virtualisation.podman.stacks = {
+    lingarr.enable = true;
+    subgen.enable = true;
+  };
+}

--- a/modules/README.md
+++ b/modules/README.md
@@ -22,7 +22,7 @@ create a module and it becomes available.
 | [security/](security/) | Security hardening | SSH hardening, secrets management |
 | [services/](services/) | Self-hosted services | `sys.services.grafana.enable` |
 | [storage/](storage/) | Storage: ZFS, NFS, sanoid | `sys.storage.zfs.enable` |
-| [virtualisation/](virtualisation/) | VM and container support | `sys.virtualisation.enable` |
+| [virtualisation/](virtualisation/) | VM and container support | `sys.virtualisation.enable`, `sys.virtualisation.podman.stacks.*` |
 
 ### Roles
 

--- a/modules/virtualisation/podman-containers.nix
+++ b/modules/virtualisation/podman-containers.nix
@@ -114,13 +114,22 @@ let
     ) enabledStacks
   );
 
-  duplicateNames =
-    let
-      names = map (e: e.name) allContainerNames;
-    in
-    lib.unique (
-      lib.filter (n: builtins.length (lib.filter (candidate: candidate == n) names) > 1) names
-    );
+  stackContainerNames = map (e: e.name) allContainerNames;
+
+  duplicateNames = lib.unique (
+    lib.filter (n: builtins.length (lib.filter (candidate: candidate == n) stackContainerNames) > 1) stackContainerNames
+  );
+
+  # Detect collisions between stack containers and non-stack oci-containers
+  nonStackContainerNames = builtins.attrNames (
+    builtins.removeAttrs
+      (config.virtualisation.oci-containers.containers or { })
+      stackContainerNames
+  );
+
+  stackVsNonStackCollisions = lib.filter
+    (n: builtins.elem n nonStackContainerNames)
+    (lib.unique stackContainerNames);
 
   # Merge all enabled stack containers into a single attrset for oci-containers
   mergedContainers = lib.mkMerge (
@@ -168,6 +177,10 @@ in
       {
         assertion = duplicateNames == [ ];
         message = "sys.virtualisation.podman.stacks: duplicate container names across stacks: ${lib.concatStringsSep ", " duplicateNames}";
+      }
+      {
+        assertion = stackVsNonStackCollisions == [ ];
+        message = "sys.virtualisation.podman.stacks: container names collide with non-stack oci-containers: ${lib.concatStringsSep ", " stackVsNonStackCollisions}";
       }
     ];
 

--- a/modules/virtualisation/podman-containers.nix
+++ b/modules/virtualisation/podman-containers.nix
@@ -60,7 +60,7 @@ let
 
   mergedContainers = lib.mkMerge (
     lib.mapAttrsToList (
-      _: stack: builtins.mapAttrs (_: c: { autoStart = stack.autoStart; } // c) stack.containers
+      _: stack: builtins.mapAttrs (_: c: { inherit (stack) autoStart; } // c) stack.containers
     ) enabledStacks
   );
 in

--- a/modules/virtualisation/podman-containers.nix
+++ b/modules/virtualisation/podman-containers.nix
@@ -117,19 +117,19 @@ let
   stackContainerNames = map (e: e.name) allContainerNames;
 
   duplicateNames = lib.unique (
-    lib.filter (n: builtins.length (lib.filter (candidate: candidate == n) stackContainerNames) > 1) stackContainerNames
+    lib.filter (
+      n: builtins.length (lib.filter (candidate: candidate == n) stackContainerNames) > 1
+    ) stackContainerNames
   );
 
   # Detect collisions between stack containers and non-stack oci-containers
   nonStackContainerNames = builtins.attrNames (
-    builtins.removeAttrs
-      (config.virtualisation.oci-containers.containers or { })
-      stackContainerNames
+    builtins.removeAttrs (config.virtualisation.oci-containers.containers or { }) stackContainerNames
   );
 
-  stackVsNonStackCollisions = lib.filter
-    (n: builtins.elem n nonStackContainerNames)
-    (lib.unique stackContainerNames);
+  stackVsNonStackCollisions = lib.filter (n: builtins.elem n nonStackContainerNames) (
+    lib.unique stackContainerNames
+  );
 
   # Merge all enabled stack containers into a single attrset for oci-containers
   mergedContainers = lib.mkMerge (

--- a/modules/virtualisation/podman-containers.nix
+++ b/modules/virtualisation/podman-containers.nix
@@ -106,7 +106,11 @@ let
   # Collect all container names per stack for duplicate detection
   allContainerNames = lib.flatten (
     lib.mapAttrsToList (
-      stackName: stack: map (cName: { inherit stackName; name = cName; }) (builtins.attrNames stack.containers)
+      stackName: stack:
+      map (cName: {
+        inherit stackName;
+        name = cName;
+      }) (builtins.attrNames stack.containers)
     ) enabledStacks
   );
 
@@ -125,7 +129,17 @@ let
       builtins.mapAttrs (
         _: c:
         {
-          inherit (c) image environment environmentFiles volumes ports dependsOn extraOptions labels cmd;
+          inherit (c)
+            image
+            environment
+            environmentFiles
+            volumes
+            ports
+            dependsOn
+            extraOptions
+            labels
+            cmd
+            ;
           autoStart = c.autoStart;
         }
         // lib.optionalAttrs (c.entrypoint != null) { inherit (c) entrypoint; }

--- a/modules/virtualisation/podman-containers.nix
+++ b/modules/virtualisation/podman-containers.nix
@@ -14,9 +14,9 @@ let
       };
 
       autoStart = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = "Whether to start this container automatically on boot.";
+        type = lib.types.nullOr lib.types.bool;
+        default = null;
+        description = "Whether to start this container automatically on boot. Defaults to the stack-level autoStart if unset.";
       };
 
       environment = lib.mkOption {
@@ -140,7 +140,7 @@ let
             labels
             cmd
             ;
-          autoStart = c.autoStart;
+          autoStart = if c.autoStart != null then c.autoStart else stack.autoStart;
         }
         // lib.optionalAttrs (c.entrypoint != null) { inherit (c) entrypoint; }
         // lib.optionalAttrs (c.user != null) { inherit (c) user; }
@@ -161,6 +161,10 @@ in
 
   config = lib.mkIf (enabledStacks != { }) {
     assertions = [
+      {
+        assertion = config.sys.virtualisation.enable;
+        message = "sys.virtualisation.podman.stacks: sys.virtualisation.enable must be true when container stacks are enabled.";
+      }
       {
         assertion = duplicateNames == [ ];
         message = "sys.virtualisation.podman.stacks: duplicate container names across stacks: ${lib.concatStringsSep ", " duplicateNames}";

--- a/modules/virtualisation/podman-containers.nix
+++ b/modules/virtualisation/podman-containers.nix
@@ -1,0 +1,158 @@
+{
+  lib,
+  config,
+  ...
+}:
+let
+  cfg = config.sys.virtualisation.podman;
+
+  containerModule = lib.types.submodule {
+    options = {
+      image = lib.mkOption {
+        type = lib.types.str;
+        description = "OCI image to run.";
+      };
+
+      autoStart = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Whether to start this container automatically on boot.";
+      };
+
+      environment = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+        description = "Environment variables for this container.";
+      };
+
+      environmentFiles = lib.mkOption {
+        type = lib.types.listOf lib.types.path;
+        default = [ ];
+        description = "Environment files for this container.";
+      };
+
+      volumes = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        description = "List of volume mounts (\"src:dst\" strings).";
+      };
+
+      ports = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        description = "Port mappings (\"host:container\" strings).";
+      };
+
+      dependsOn = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        description = "Other container names this one depends on.";
+      };
+
+      extraOptions = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        description = "Extra CLI options passed to podman run.";
+      };
+
+      labels = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+        description = "Labels to attach to the container.";
+      };
+
+      cmd = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        description = "Command arguments passed to the image entrypoint.";
+      };
+
+      entrypoint = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "Override the default entrypoint of the image.";
+      };
+
+      user = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "Override the username or UID used in the container.";
+      };
+    };
+  };
+
+  stackModule =
+    { name, config, ... }:
+    {
+      options = {
+        enable = lib.mkEnableOption "container stack '${name}'";
+
+        autoStart = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Default autoStart for containers in this stack.";
+        };
+
+        containers = lib.mkOption {
+          type = lib.types.attrsOf containerModule;
+          default = { };
+          description = "Containers in this stack.";
+        };
+      };
+    };
+
+  enabledStacks = lib.filterAttrs (_: stack: stack.enable) cfg.stacks;
+
+  # Collect all container names per stack for duplicate detection
+  allContainerNames = lib.flatten (
+    lib.mapAttrsToList (
+      stackName: stack: map (cName: { inherit stackName; name = cName; }) (builtins.attrNames stack.containers)
+    ) enabledStacks
+  );
+
+  duplicateNames =
+    let
+      names = map (e: e.name) allContainerNames;
+    in
+    lib.unique (
+      lib.filter (n: builtins.length (lib.filter (candidate: candidate == n) names) > 1) names
+    );
+
+  # Merge all enabled stack containers into a single attrset for oci-containers
+  mergedContainers = lib.mkMerge (
+    lib.mapAttrsToList (
+      _: stack:
+      builtins.mapAttrs (
+        _: c:
+        {
+          inherit (c) image environment environmentFiles volumes ports dependsOn extraOptions labels cmd;
+          autoStart = c.autoStart;
+        }
+        // lib.optionalAttrs (c.entrypoint != null) { inherit (c) entrypoint; }
+        // lib.optionalAttrs (c.user != null) { inherit (c) user; }
+      ) stack.containers
+    ) enabledStacks
+  );
+in
+{
+  options.sys.virtualisation.podman.stacks = lib.mkOption {
+    type = lib.types.attrsOf (lib.types.submodule stackModule);
+    default = { };
+    description = ''
+      Declarative Podman container stacks.
+      Each stack groups related containers and is enabled per host.
+      Enabled stacks are merged into virtualisation.oci-containers.containers.
+    '';
+  };
+
+  config = lib.mkIf (enabledStacks != { }) {
+    assertions = [
+      {
+        assertion = duplicateNames == [ ];
+        message = "sys.virtualisation.podman.stacks: duplicate container names across stacks: ${lib.concatStringsSep ", " duplicateNames}";
+      }
+    ];
+
+    virtualisation.oci-containers.containers = mergedContainers;
+  };
+}

--- a/modules/virtualisation/podman-containers.nix
+++ b/modules/virtualisation/podman-containers.nix
@@ -1,88 +1,14 @@
 {
   lib,
   config,
+  options,
   ...
 }:
 let
   cfg = config.sys.virtualisation.podman;
 
-  containerModule = lib.types.submodule {
-    options = {
-      image = lib.mkOption {
-        type = lib.types.str;
-        description = "OCI image to run.";
-      };
-
-      autoStart = lib.mkOption {
-        type = lib.types.nullOr lib.types.bool;
-        default = null;
-        description = "Whether to start this container automatically on boot. Defaults to the stack-level autoStart if unset.";
-      };
-
-      environment = lib.mkOption {
-        type = lib.types.attrsOf lib.types.str;
-        default = { };
-        description = "Environment variables for this container.";
-      };
-
-      environmentFiles = lib.mkOption {
-        type = lib.types.listOf lib.types.path;
-        default = [ ];
-        description = "Environment files for this container.";
-      };
-
-      volumes = lib.mkOption {
-        type = lib.types.listOf lib.types.str;
-        default = [ ];
-        description = "List of volume mounts (\"src:dst\" strings).";
-      };
-
-      ports = lib.mkOption {
-        type = lib.types.listOf lib.types.str;
-        default = [ ];
-        description = "Port mappings (\"host:container\" strings).";
-      };
-
-      dependsOn = lib.mkOption {
-        type = lib.types.listOf lib.types.str;
-        default = [ ];
-        description = "Other container names this one depends on.";
-      };
-
-      extraOptions = lib.mkOption {
-        type = lib.types.listOf lib.types.str;
-        default = [ ];
-        description = "Extra CLI options passed to podman run.";
-      };
-
-      labels = lib.mkOption {
-        type = lib.types.attrsOf lib.types.str;
-        default = { };
-        description = "Labels to attach to the container.";
-      };
-
-      cmd = lib.mkOption {
-        type = lib.types.listOf lib.types.str;
-        default = [ ];
-        description = "Command arguments passed to the image entrypoint.";
-      };
-
-      entrypoint = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        default = null;
-        description = "Override the default entrypoint of the image.";
-      };
-
-      user = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        default = null;
-        description = "Override the username or UID used in the container.";
-      };
-    };
-  };
-
   stackModule =
-    { name, config, ... }:
+    { name, ... }:
     {
       options = {
         enable = lib.mkEnableOption "container stack '${name}'";
@@ -94,66 +20,47 @@ let
         };
 
         containers = lib.mkOption {
-          type = lib.types.attrsOf containerModule;
+          type = lib.types.attrsOf lib.types.attrs;
           default = { };
-          description = "Containers in this stack.";
+          description = "Container configs passed through to virtualisation.oci-containers.containers.";
         };
       };
     };
 
-  enabledStacks = lib.filterAttrs (_: stack: stack.enable) cfg.stacks;
+  enabledStacks = lib.filterAttrs (_: s: s.enable) cfg.stacks;
 
-  # Collect all container names per stack for duplicate detection
-  allContainerNames = lib.flatten (
-    lib.mapAttrsToList (
-      stackName: stack:
-      map (cName: {
-        inherit stackName;
-        name = cName;
-      }) (builtins.attrNames stack.containers)
-    ) enabledStacks
+  stackContainerNames = lib.concatMap (s: builtins.attrNames s.containers) (
+    builtins.attrValues enabledStacks
   );
-
-  stackContainerNames = map (e: e.name) allContainerNames;
 
   duplicateNames = lib.unique (
-    lib.filter (
-      n: builtins.length (lib.filter (candidate: candidate == n) stackContainerNames) > 1
-    ) stackContainerNames
+    lib.filter (n: lib.count (x: x == n) stackContainerNames > 1) stackContainerNames
   );
 
-  # Detect collisions between stack containers and non-stack oci-containers
-  nonStackContainerNames = builtins.attrNames (
-    builtins.removeAttrs (config.virtualisation.oci-containers.containers or { }) stackContainerNames
-  );
+  # Detect collisions with non-stack oci-containers by inspecting raw option
+  # definitions — the merged config already includes this module's contributions.
+  otherDefinedNames =
+    lib.pipe (options.virtualisation.oci-containers.containers.definitionsWithLocations or [ ])
+      [
+        (builtins.filter (d: !(lib.hasInfix "podman-containers.nix" (d.file or ""))))
+        (map (
+          d:
+          let
+            r = builtins.tryEval (builtins.attrNames d.value);
+          in
+          if r.success then r.value else [ ]
+        ))
+        lib.flatten
+        lib.unique
+      ];
 
-  stackVsNonStackCollisions = lib.filter (n: builtins.elem n nonStackContainerNames) (
+  stackVsNonStackCollisions = lib.filter (n: builtins.elem n otherDefinedNames) (
     lib.unique stackContainerNames
   );
 
-  # Merge all enabled stack containers into a single attrset for oci-containers
   mergedContainers = lib.mkMerge (
     lib.mapAttrsToList (
-      _: stack:
-      builtins.mapAttrs (
-        _: c:
-        {
-          inherit (c)
-            image
-            environment
-            environmentFiles
-            volumes
-            ports
-            dependsOn
-            extraOptions
-            labels
-            cmd
-            ;
-          autoStart = if c.autoStart != null then c.autoStart else stack.autoStart;
-        }
-        // lib.optionalAttrs (c.entrypoint != null) { inherit (c) entrypoint; }
-        // lib.optionalAttrs (c.user != null) { inherit (c) user; }
-      ) stack.containers
+      _: stack: builtins.mapAttrs (_: c: { autoStart = stack.autoStart; } // c) stack.containers
     ) enabledStacks
   );
 in


### PR DESCRIPTION
This pull request introduces a new system for managing Podman container stacks declaratively using NixOS modules. It adds reusable modules for defining, configuring, and enabling groups of related containers ("stacks") per host, with examples for subtitle translation and generation services. Documentation is updated to describe the new architecture, its usage, and how it integrates with existing virtualization and host configuration.

**Key changes:**

**1. Podman Container Stack Module Implementation**
- Introduced `modules/virtualisation/podman-containers.nix`, which defines the `sys.virtualisation.podman.stacks` option. This allows hosts to declaratively specify groups of containers (stacks), each with their own configuration (image, ports, volumes, environment, etc.), and merges enabled stacks into `virtualisation.oci-containers.containers` for systemd management. Duplicate container names across stacks are detected and asserted against.

**2. Example Container Stack Definitions**
- Added `containers/lingarr.nix` and `containers/subgen.nix`, providing example stacks for automated subtitle translation (lingarr, libretranslate, ollama) and subtitle generation (subgen/Whisper), including their options for media/data directories and detailed container configuration. [[1]](diffhunk://#diff-349266ba5c2d58824e681c1b4c949ed60f336c80e5597625dd1b225a8fc1c65bR1-R62) [[2]](diffhunk://#diff-96b33cb6bdac25cbc0febdedb6bf51e5ba44b2dba24d077b4bafb5dd1c08e8a2R1-R62)

**3. Host Integration**
- Updated `hosts/blizzard/virtualisation/containers.nix` to import and enable the new `lingarr` and `subgen` stacks, demonstrating per-host activation of container stacks.
- Updated `hosts/README.md` to document the presence of `containers.nix` alongside `microvms.nix` for virtualization.

**4. Documentation and Reference Updates**
- Added a comprehensive `containers/README.md` explaining the concept, architecture, usage, and differences from MicroVMs, as well as instructions for creating and enabling new stacks.
- Updated `docs/reference-architecture.md` and `modules/README.md` to reference the new container stack system and its configuration options. [[1]](diffhunk://#diff-35cf3f26050fc5276978ce4e1a3b5aae2f85d4346a6fa5b7129b8dea652d3e39R101-R114) [[2]](diffhunk://#diff-041091db9aaac86bff8b767c9fb13435ec798df7d3e6e52a132d82450bdf60f1L25-R25)

---

**References:**  
[[1]](diffhunk://#diff-ab4eb74dd060762bbc6c4684e8b859824ebe5a88a9a15ca160429dc51669003aR1-R172) [[2]](diffhunk://#diff-349266ba5c2d58824e681c1b4c949ed60f336c80e5597625dd1b225a8fc1c65bR1-R62) [[3]](diffhunk://#diff-96b33cb6bdac25cbc0febdedb6bf51e5ba44b2dba24d077b4bafb5dd1c08e8a2R1-R62) [[4]](diffhunk://#diff-a3cac066bed20dfb933bb86bb35036a06de94580604ab5c3761434b29861e178R1-R13) [[5]](diffhunk://#diff-7b75075aa85d3fb57a44f034c82406e9cff652d8c1c0de3df12e04b23f0e7932R1-R113) [[6]](diffhunk://#diff-35cf3f26050fc5276978ce4e1a3b5aae2f85d4346a6fa5b7129b8dea652d3e39R101-R114) [[7]](diffhunk://#diff-041091db9aaac86bff8b767c9fb13435ec798df7d3e6e52a132d82450bdf60f1L25-R25) [[8]](diffhunk://#diff-572d33e5e77dd5f2ade034447d61289e311ca1ddb0a497e755aed777aa807d8eL50-R51)