### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775762219,
-        "narHash": "sha256-e7BhggoWhg3Ok7dDI5kY1XZzORBQc0Rclcs3IWzux3w=",
+        "lastModified": 1775781825,
+        "narHash": "sha256-L5yKTpR+alrZU2XYYvIxCeCP4LBHU5jhwSj7H1VAavg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c975a66a56306b38eaa3108f54bbc11e213f42f6",
+        "rev": "e35c39fca04fee829cecdf839a50eb9b54d8a701",
         "type": "github"
       },
       "original": {
@@ -654,11 +654,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1775423009,
-        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775768613,
-        "narHash": "sha256-cxwWRYdaCOfyRQ/F2mbQpRRgA2Rxwc1RXQOs5qyg6eo=",
+        "lastModified": 1775801962,
+        "narHash": "sha256-UYLikHbX76MQkP/Wcp+dsWcFZe4YchavDb3LrmNjhLY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b227999d0c8ea1c469de89beb23766133af84127",
+        "rev": "d9ff309ef91647c35ad27736001d7a3b3bd56fcb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/c975a66' (2026-04-09)
  → 'github:nix-community/home-manager/e35c39f' (2026-04-10)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/68d8aa3' (2026-04-05)
  → 'github:NixOS/nixpkgs/4c1018d' (2026-04-09)
• Updated input 'nur':
    'github:nix-community/NUR/b227999' (2026-04-09)
  → 'github:nix-community/NUR/d9ff309' (2026-04-10)
```