### PR TITLE
Dev translations

### DIFF
--- a/containers/subgen.nix
+++ b/containers/subgen.nix
@@ -53,19 +53,19 @@ in
     subtitleLanguageName = lib.mkOption {
       type = lib.types.str;
       default = "aa";
-      description = "Language code used in the output subtitle filename (e.g., en, no).";
+      description = "ISO 639-1 two-letter code used in the output subtitle filename (e.g., en, no). Defaults to 'aa' to float to the top of Plex's list.";
     };
 
     preferredAudioLanguages = lib.mkOption {
       type = lib.types.str;
       default = "eng";
-      description = "Pipe-separated ISO 639-2 codes. Prefer transcribing these audio tracks when multiple exist.";
+      description = "Pipe-separated ISO 639-2 three-letter codes (e.g., eng|nor). Prefer transcribing these audio tracks when multiple exist.";
     };
 
     forceDetectedLanguageTo = lib.mkOption {
       type = lib.types.str;
       default = "";
-      description = "Force Whisper to a specific 2-letter language code if auto-detection is unreliable.";
+      description = "Force Whisper to a specific ISO 639-1 two-letter code (e.g., en, no) if auto-detection is unreliable.";
     };
 
     whisperThreads = lib.mkOption {

--- a/containers/subgen.nix
+++ b/containers/subgen.nix
@@ -127,7 +127,7 @@ in
       }
       {
         assertion = !(cfg.transcribeOrTranslate == "translate" && lib.hasSuffix "turbo" cfg.whisperModel);
-        message = "large-v3-turbo does not support translation — use large-v3 or another model when transcribeOrTranslate is 'translate'.";
+        message = "Whisper models ending in 'turbo' do not support translation — use a non-turbo model when transcribeOrTranslate is 'translate'.";
       }
     ];
 

--- a/containers/subgen.nix
+++ b/containers/subgen.nix
@@ -38,7 +38,34 @@ in
     whisperModel = lib.mkOption {
       type = lib.types.str;
       default = "medium";
-      description = "Whisper model to use (tiny, base, small, medium, large-v3, large-v3-turbo, etc.).";
+      description = "Whisper model to use (tiny, base, small, medium, large-v3, large-v3-turbo, etc.). large-v3-turbo does not support translation.";
+    };
+
+    transcribeOrTranslate = lib.mkOption {
+      type = lib.types.enum [
+        "transcribe"
+        "translate"
+      ];
+      default = "transcribe";
+      description = "Whether to transcribe (keep original language) or translate foreign audio to English.";
+    };
+
+    subtitleLanguageName = lib.mkOption {
+      type = lib.types.str;
+      default = "aa";
+      description = "Language code used in the output subtitle filename (e.g., en, no).";
+    };
+
+    preferredAudioLanguages = lib.mkOption {
+      type = lib.types.str;
+      default = "eng";
+      description = "Pipe-separated ISO 639-2 codes. Prefer transcribing these audio tracks when multiple exist.";
+    };
+
+    forceDetectedLanguageTo = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = "Force Whisper to a specific 2-letter language code if auto-detection is unreliable.";
     };
 
     whisperThreads = lib.mkOption {
@@ -98,6 +125,10 @@ in
         assertion = !(lib.attrByPath [ "services" "subgen" "enable" ] false config);
         message = "services.subgen-container and services.subgen (subtitle-stack) cannot both be enabled — they define conflicting Subgen containers.";
       }
+      {
+        assertion = !(cfg.transcribeOrTranslate == "translate" && lib.hasSuffix "turbo" cfg.whisperModel);
+        message = "large-v3-turbo does not support translation — use large-v3 or another model when transcribeOrTranslate is 'translate'.";
+      }
     ];
 
     virtualisation.quadlet.containers.subgen-standalone = {
@@ -122,11 +153,17 @@ in
           WHISPER_MODEL = cfg.whisperModel;
           WHISPER_THREADS = toString cfg.whisperThreads;
           CONCURRENT_TRANSCRIPTIONS = toString cfg.concurrentTranscriptions;
+          TRANSCRIBE_OR_TRANSLATE = cfg.transcribeOrTranslate;
+          SUBTITLE_LANGUAGE_NAME = cfg.subtitleLanguageName;
+          PREFERRED_AUDIO_LANGUAGES = cfg.preferredAudioLanguages;
           WEBHOOKPORT = "9000";
           TRANSCRIBE_DEVICE = if cfg.gpu.enable then "cuda" else "cpu";
           CLEAR_VRAM_ON_COMPLETE = "True";
           MODEL_PATH = "./models";
           DEBUG = "True";
+        }
+        // lib.optionalAttrs (cfg.forceDetectedLanguageTo != "") {
+          FORCE_DETECTED_LANGUAGE_TO = cfg.forceDetectedLanguageTo;
         }
         // lib.optionalAttrs cfg.gpu.enable {
           CT2_CUDA_ALLOCATOR = "cub_caching";

--- a/containers/subtitle-stack.nix
+++ b/containers/subtitle-stack.nix
@@ -83,19 +83,19 @@ in
     subtitleLanguageName = lib.mkOption {
       type = lib.types.str;
       default = "aa";
-      description = "Language code used in the output subtitle filename (e.g., en, no).";
+      description = "ISO 639-1 two-letter code used in the output subtitle filename (e.g., en, no). Defaults to 'aa' to float to the top of Plex's list.";
     };
 
     preferredAudioLanguages = lib.mkOption {
       type = lib.types.str;
       default = "eng";
-      description = "Pipe-separated ISO 639-2 codes. Prefer transcribing these audio tracks when multiple exist.";
+      description = "Pipe-separated ISO 639-2 three-letter codes (e.g., eng|nor). Prefer transcribing these audio tracks when multiple exist.";
     };
 
     forceDetectedLanguageTo = lib.mkOption {
       type = lib.types.str;
       default = "";
-      description = "Force Whisper to a specific 2-letter language code if auto-detection is unreliable.";
+      description = "Force Whisper to a specific ISO 639-1 two-letter code (e.g., en, no) if auto-detection is unreliable.";
     };
   };
 

--- a/containers/subtitle-stack.nix
+++ b/containers/subtitle-stack.nix
@@ -108,7 +108,7 @@ in
             && cfgSubgen.transcribeOrTranslate == "translate"
             && lib.hasSuffix "turbo" cfgSubgen.whisperModel
           );
-        message = "large-v3-turbo does not support translation — use large-v3 or another model when transcribeOrTranslate is 'translate'.";
+        message = "Whisper models ending in 'turbo' do not support translation — use a non-turbo model when transcribeOrTranslate is 'translate'.";
       }
     ];
 

--- a/containers/subtitle-stack.nix
+++ b/containers/subtitle-stack.nix
@@ -64,9 +64,54 @@ in
       default = null;
       description = "Jellyfin server URL. Set to null to disable Jellyfin integration.";
     };
+
+    whisperModel = lib.mkOption {
+      type = lib.types.str;
+      default = "medium";
+      description = "Whisper model to use (tiny, base, small, medium, large-v3, large-v3-turbo, etc.). large-v3-turbo does not support translation.";
+    };
+
+    transcribeOrTranslate = lib.mkOption {
+      type = lib.types.enum [
+        "transcribe"
+        "translate"
+      ];
+      default = "transcribe";
+      description = "Whether to transcribe (keep original language) or translate foreign audio to English.";
+    };
+
+    subtitleLanguageName = lib.mkOption {
+      type = lib.types.str;
+      default = "aa";
+      description = "Language code used in the output subtitle filename (e.g., en, no).";
+    };
+
+    preferredAudioLanguages = lib.mkOption {
+      type = lib.types.str;
+      default = "eng";
+      description = "Pipe-separated ISO 639-2 codes. Prefer transcribing these audio tracks when multiple exist.";
+    };
+
+    forceDetectedLanguageTo = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = "Force Whisper to a specific 2-letter language code if auto-detection is unreliable.";
+    };
   };
 
   config = lib.mkIf anyEnabled {
+    assertions = [
+      {
+        assertion =
+          !(
+            cfgSubgen.enable
+            && cfgSubgen.transcribeOrTranslate == "translate"
+            && lib.hasSuffix "turbo" cfgSubgen.whisperModel
+          );
+        message = "large-v3-turbo does not support translation — use large-v3 or another model when transcribeOrTranslate is 'translate'.";
+      }
+    ];
+
     sops = lib.mkIf (hasPlex || hasJellyfin) {
       secrets = lib.mkMerge [
         (lib.mkIf hasPlex { "plex/server_token" = { }; })
@@ -161,11 +206,13 @@ in
             containerConfig = {
               image = "mccloud/subgen";
               environments = {
-                WHISPER_MODEL = "medium";
+                WHISPER_MODEL = cfgSubgen.whisperModel;
                 WHISPER_THREADS = "6";
                 PROCADDEDMEDIA = "True";
                 PROCMEDIAONPLAY = "False";
-                NAMESUBLANG = "eng";
+                TRANSCRIBE_OR_TRANSLATE = cfgSubgen.transcribeOrTranslate;
+                SUBTITLE_LANGUAGE_NAME = cfgSubgen.subtitleLanguageName;
+                PREFERRED_AUDIO_LANGUAGES = cfgSubgen.preferredAudioLanguages;
                 SKIPIFINTERNALSUBLANG = "eng";
                 WEBHOOKPORT = "9000";
                 CONCURRENT_TRANSCRIPTIONS = "2";
@@ -183,6 +230,9 @@ in
                 USE_PATH_MAPPING = "True";
                 PATH_MAPPING_FROM = lib.dirOf cfgSubgen.mediaDir;
                 PATH_MAPPING_TO = "/data";
+              }
+              // lib.optionalAttrs (cfgSubgen.forceDetectedLanguageTo != "") {
+                FORCE_DETECTED_LANGUAGE_TO = cfgSubgen.forceDetectedLanguageTo;
               }
               // lib.optionalAttrs hasPlex {
                 PLEXSERVER = cfgSubgen.plexServer;

--- a/flake.lock
+++ b/flake.lock
@@ -510,16 +510,15 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1775723509,
-        "narHash": "sha256-ddlxfsjkierAK5CTQ6fXlUs4MZsyZb3qM4mO9+Koei0=",
+        "lastModified": 1775847073,
+        "narHash": "sha256-OyRZOIQZZQNrIDN40jrhY1SFTzTNYURT5MPhZZchSbY=",
         "owner": "microvm-nix",
         "repo": "microvm.nix",
-        "rev": "0a19985c9371e3b9dc0ba0a43b0c57c39cd4397f",
+        "rev": "239045c84aa62c2ce1349fa4c1ceae9eb6ce9e85",
         "type": "github"
       },
       "original": {
         "owner": "microvm-nix",
-        "ref": "pull/502/head",
         "repo": "microvm.nix",
         "type": "github"
       }

--- a/hosts/blizzard/virtualisation/containers.nix
+++ b/hosts/blizzard/virtualisation/containers.nix
@@ -19,9 +19,13 @@ in
         enable = true;
         ollama.enable = false;
       };
+
       subgen = {
-        enable = true;
+        enable = false;
         plexServer = "https://192.168.2.100:32400";
+        transcribeOrTranslate = "translate";
+        subtitleLanguageName = "en";
+        preferredAudioLanguages = "eng|nor";
       };
     };
   };

--- a/hosts/snowfall/containers.nix
+++ b/hosts/snowfall/containers.nix
@@ -25,6 +25,12 @@ in
       subgen-container = {
         enable = true;
         gpu.enable = true;
+        whisperModel = "large-v3";
+
+        plexServer = "https://192.168.2.100:32400";
+        transcribeOrTranslate = "translate";
+        subtitleLanguageName = "en";
+        preferredAudioLanguages = "eng|nor";
       };
     };
   };

--- a/hosts/snowfall/containers.nix
+++ b/hosts/snowfall/containers.nix
@@ -26,7 +26,7 @@ in
         enable = true;
         gpu.enable = true;
         whisperModel = "large-v3";
-        mediaDir = "/home/zeno/pools/rpool/unenc/media/data/media";
+        mediaDir = "/home/${username}/pools/rpool/unenc/media/data/media";
 
         plexServer = "https://192.168.2.100:32400";
         transcribeOrTranslate = "translate";

--- a/hosts/snowfall/containers.nix
+++ b/hosts/snowfall/containers.nix
@@ -26,6 +26,7 @@ in
         enable = true;
         gpu.enable = true;
         whisperModel = "large-v3";
+        mediaDir = "/home/zeno/pools/rpool/unenc/media/data/media";
 
         plexServer = "https://192.168.2.100:32400";
         transcribeOrTranslate = "translate";

--- a/hosts/snowfall/containers.nix
+++ b/hosts/snowfall/containers.nix
@@ -12,12 +12,20 @@ in
   home-manager.users.${username} = {
     imports = [
       ../../containers/ollama.nix
+      ../../containers/subgen.nix
     ];
 
-    services.ollama-container = {
-      enable = true;
-      dataDir = "/home/${username}/.local/share/ollama";
-      gpu.enable = true;
+    services = {
+      ollama-container = {
+        enable = true;
+        dataDir = "/home/${username}/.local/share/ollama";
+        gpu.enable = true;
+      };
+
+      subgen-container = {
+        enable = true;
+        gpu.enable = true;
+      };
     };
   };
 }

--- a/hosts/snowfall/snowfall.nix
+++ b/hosts/snowfall/snowfall.nix
@@ -252,6 +252,16 @@ in
 
   services.rpcbind.enable = lib.mkDefault true;
 
+  fileSystems."/home/zeno/pools/rpool/unenc/media/data/media" = {
+    device = "192.168.2.100:/rpool/unenc/media/data/media";
+    fsType = "nfs";
+    options = [
+      "nofail"
+      "x-systemd.automount"
+      "x-systemd.idle-timeout=600"
+    ];
+  };
+
   hardware = {
     cpu.amd.updateMicrocode = lib.mkDefault true;
 

--- a/hosts/snowfall/snowfall.nix
+++ b/hosts/snowfall/snowfall.nix
@@ -252,7 +252,7 @@ in
 
   services.rpcbind.enable = lib.mkDefault true;
 
-  fileSystems."/home/zeno/pools/rpool/unenc/media/data/media" = {
+  fileSystems."/home/${VARS.users.zeno.user}/pools/rpool/unenc/media/data/media" = {
     device = "192.168.2.100:/rpool/unenc/media/data/media";
     fsType = "nfs";
     options = [


### PR DESCRIPTION
This pull request introduces several new configuration options and improvements to the subtitle generation (`subgen`) and subtitle stack containers, increasing flexibility for language handling, translation, and audio track selection. It also adds appropriate validation to prevent unsupported configurations and updates host configurations to utilize these new features.

**Key changes:**

### New configuration options for language handling and translation

* Added new options to both `subgen` and `subtitle-stack` containers: `transcribeOrTranslate`, `subtitleLanguageName`, `preferredAudioLanguages`, and `forceDetectedLanguageTo`, allowing fine-grained control over whether to transcribe or translate, output subtitle language code, preferred audio tracks, and forced language detection. [[1]](diffhunk://#diff-96b33cb6bdac25cbc0febdedb6bf51e5ba44b2dba24d077b4bafb5dd1c08e8a2L41-R68) [[2]](diffhunk://#diff-a1daf5d3719ed9d2be8c5d218f06f0235a38d54b3defaa273238bb711e5afb70R67-R114)
* Updated environment variables in container definitions to pass these new options to the underlying services. [[1]](diffhunk://#diff-96b33cb6bdac25cbc0febdedb6bf51e5ba44b2dba24d077b4bafb5dd1c08e8a2R156-R167) [[2]](diffhunk://#diff-a1daf5d3719ed9d2be8c5d218f06f0235a38d54b3defaa273238bb711e5afb70L164-R215) [[3]](diffhunk://#diff-a1daf5d3719ed9d2be8c5d218f06f0235a38d54b3defaa273238bb711e5afb70R234-R236)

### Validation and assertions

* Added assertions to both modules to prevent using the `large-v3-turbo` Whisper model with translation, since it is unsupported. This provides clear error messages for misconfiguration. [[1]](diffhunk://#diff-96b33cb6bdac25cbc0febdedb6bf51e5ba44b2dba24d077b4bafb5dd1c08e8a2R128-R131) [[2]](diffhunk://#diff-a1daf5d3719ed9d2be8c5d218f06f0235a38d54b3defaa273238bb711e5afb70R67-R114)

### Host configuration updates

* Updated `hosts/blizzard/virtualisation/containers.nix` and `hosts/snowfall/containers.nix` to use the new options, including setting `transcribeOrTranslate`, `subtitleLanguageName`, and `preferredAudioLanguages` in example configurations. [[1]](diffhunk://#diff-a3cac066bed20dfb933bb86bb35036a06de94580604ab5c3761434b29861e178R22-R28) [[2]](diffhunk://#diff-dba4ee13b29bb31c405792c6f27643f9ce125ae13cf76688d8eeadeb7c14a89dR15-R36)
* Added an NFS mount for media data in `hosts/snowfall/snowfall.nix` to support the updated `subgen-container` configuration.