### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776030105,
-        "narHash": "sha256-b4cNpWPDSH+/CTTiw8++yGh1UYG2kQNrbIehV2iGoeo=",
+        "lastModified": 1776046499,
+        "narHash": "sha256-Wzc4nn07/0RL21ypPHRzNDQZcjhIC8LaYo7QJQjM5T4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "49088dc2e7a876e338e510c5f5f60f659819c650",
+        "rev": "287f84846c1eb3b72c986f5f6bebcff0bd67440d",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776036341,
-        "narHash": "sha256-1MYezGclicV9sAATHdEmTodzxS0+q472+5PQyIKDOio=",
+        "lastModified": 1776052898,
+        "narHash": "sha256-hiENI6oLdhC2MhIb3weFXeV93EVpzCSM+8v99xO6Jmo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1e7b71ee34f4b2d3634483212c7f5da55c2bd619",
+        "rev": "35dc81ab124ac837485761c55d96becdef354b51",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/49088dc' (2026-04-12)
  → 'github:nix-community/home-manager/287f848' (2026-04-13)
• Updated input 'nur':
    'github:nix-community/NUR/1e7b71e' (2026-04-12)
  → 'github:nix-community/NUR/35dc81a' (2026-04-13)
```