### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776052898,
-        "narHash": "sha256-hiENI6oLdhC2MhIb3weFXeV93EVpzCSM+8v99xO6Jmo=",
+        "lastModified": 1776061382,
+        "narHash": "sha256-8M6fMQz9tWjuMb0ZoDRkpdXjUd2WHUJyLFEfO19bH3M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "35dc81ab124ac837485761c55d96becdef354b51",
+        "rev": "a568ef8a8a67af62eacdd7689a72c39ebfdf08da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/35dc81a' (2026-04-13)
  → 'github:nix-community/NUR/a568ef8' (2026-04-13)
```