### PR TITLE
Dev virtualisation

### DIFF
--- a/hosts/snowfall/snowfall.nix
+++ b/hosts/snowfall/snowfall.nix
@@ -66,6 +66,8 @@ in
       ];
     };
 
+    virtualisation.libvirtd.enable = true;
+
     programs = {
       nix-ld.enable = true;
       python-venv.enable = true;
@@ -248,7 +250,10 @@ in
     };
   };
 
-  users.users.${VARS.users.zeno.user}.extraGroups = VARS.users.zeno.extraGroups ++ [ "openrazer" ];
+  users.users.${VARS.users.zeno.user}.extraGroups = VARS.users.zeno.extraGroups ++ [
+    "libvirtd"
+    "openrazer"
+  ];
 
   services.rpcbind.enable = lib.mkDefault true;
 
@@ -274,8 +279,6 @@ in
       enable32Bit = lib.mkDefault true;
     };
   };
-
-  programs.virt-manager.enable = true;
 
   system.stateVersion = "24.05";
 }

--- a/modules/virtualisation/libvirtd.nix
+++ b/modules/virtualisation/libvirtd.nix
@@ -1,3 +1,6 @@
+# NOTE: OVMF (UEFI firmware, including Secure Boot + TPM variants) is
+# automatically provided by the upstream NixOS module via the QEMU package.
+# No explicit ovmf configuration is needed.
 {
   lib,
   config,
@@ -25,20 +28,24 @@ in
         package = pkgs.qemu_kvm;
         runAsRoot = false;
         swtpm.enable = true;
+        vhostUserPackages = [ pkgs.virtiofsd ];
       };
     };
 
-    # Add virsh and virt-manager tools
-    environment.systemPackages = with pkgs; [
-      libvirt
-      virt-manager
-      virt-viewer
+    programs.virt-manager.enable = true;
+
+    # swtpm_localca needs a writable state directory owned by tss:tss
+    systemd.tmpfiles.rules = [
+      "d /var/lib/swtpm-localca 0750 tss tss -"
     ];
 
-    # Allow users in libvirtd group to manage VMs
-    users.groups.libvirtd.members = [ ];
+    environment.systemPackages = with pkgs; [
+      libvirt
+      virt-viewer
+      dnsmasq
+      virtio-win
+    ];
 
-    # Firewall rules for VM networking
     networking.firewall.trustedInterfaces = [ cfg.networkBridge ];
   };
 }


### PR DESCRIPTION
This pull request enhances virtualization support on the `snowfall` host by enabling and configuring `libvirtd`, updating user permissions, and improving the setup for virtual machine management. The changes streamline the configuration by moving `virt-manager` setup into the `libvirtd` module, ensuring proper permissions and dependencies for TPM support, and updating system packages for virtualization.

**Virtualization enhancements:**

* Enabled `virtualisation.libvirtd` on the `snowfall` host to allow for virtual machine management.
* Moved `programs.virt-manager.enable` from the host configuration into the `libvirtd` module for better modularity and maintainability. [[1]](diffhunk://#diff-493a7bf174862dec7ba050855f9f89925df850432ac3fc8a69a178511b4e912aR31-L41) [[2]](diffhunk://#diff-95f6dcd8a397e761ec67aa5a452a56fa891a0cded131795d6bf94a3990b82593L278-L279)

**User and group permissions:**

* Added the `libvirtd` group to the `zeno` user’s extra groups, granting necessary permissions to manage VMs.

**TPM and system configuration:**

* Added a `systemd.tmpfiles` rule to create a writable state directory for `swtpm_localca`, ensuring proper ownership and permissions for TPM-related functionality.
* Clarified that OVMF (UEFI firmware) is provided automatically and does not require explicit configuration.

**Package and networking updates:**

* Added `dnsmasq` and `virtio-win` to the system packages for enhanced VM networking and Windows VM support, and included `virtiofsd` for vhost-user support.