### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776076295,
-        "narHash": "sha256-Rq+SMd1eBfPdoAUYI/WqPvmKevxTenrXLs/yKh6pGps=",
+        "lastModified": 1776089850,
+        "narHash": "sha256-vzGz3haN3trCxbGaAKWuanyYCNbD4D5CDDxDNQCArOk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b23768b54dbf2384e74e54236be59f53e5a3562b",
+        "rev": "677d333b7335ba791df21d198ad15d82ff15f70d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/b23768b' (2026-04-13)
  → 'github:nix-community/NUR/677d333' (2026-04-13)
```