### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776046499,
-        "narHash": "sha256-Wzc4nn07/0RL21ypPHRzNDQZcjhIC8LaYo7QJQjM5T4=",
+        "lastModified": 1776114641,
+        "narHash": "sha256-VJMt3n9zGRzupzvlhcKIz4SpWflKh0rWfYTgmkmun0Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "287f84846c1eb3b72c986f5f6bebcff0bd67440d",
+        "rev": "2de7205ce6e10b031151033e69b7ef89708dc282",
         "type": "github"
       },
       "original": {
@@ -622,11 +622,11 @@
     },
     "nixpkgs-stable-latest": {
       "locked": {
-        "lastModified": 1775811116,
-        "narHash": "sha256-t+HZK42pB6N+i5RGbuy7Xluez/VvWbembBdvzsc23Ss=",
+        "lastModified": 1776067740,
+        "narHash": "sha256-B35lpsqnSZwn1Lmz06BpwF7atPgFmUgw1l8KAV3zpVQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "54170c54449ea4d6725efd30d719c5e505f1c10e",
+        "rev": "7e495b747b51f95ae15e74377c5ce1fe69c1765f",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776104072,
-        "narHash": "sha256-A3Ys2NSZsCFR0qII7XIsa542uBGO7JXE81f13zAQmEI=",
+        "lastModified": 1776114134,
+        "narHash": "sha256-A5P8S73XZKnuqDjwJ7dYbE3FthF4GVk76f8pwwa+wsg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "25c263e475f420e3f05a8571d346229497bfaf50",
+        "rev": "29213f0bac84452593991be2f443b7f392ebec22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/287f848' (2026-04-13)
  → 'github:nix-community/home-manager/2de7205' (2026-04-13)
• Updated input 'nixpkgs-stable-latest':
    'github:NixOS/nixpkgs/54170c5' (2026-04-10)
  → 'github:NixOS/nixpkgs/7e495b7' (2026-04-13)
• Updated input 'nur':
    'github:nix-community/NUR/25c263e' (2026-04-13)
  → 'github:nix-community/NUR/29213f0' (2026-04-13)
```