### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776136094,
-        "narHash": "sha256-vuG+L1ZiACfH1GNh1r2pYuFFxZXv6Rw/Enp/Fp7B2+M=",
+        "lastModified": 1776145564,
+        "narHash": "sha256-V2UVnqN0r6d4lrpVLMUDatD38usARN7fILi8IO4FgrI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "989dc45ee3c0fbadba088f779e0a01d9bd1dc2bf",
+        "rev": "ec38f41010a1bb8a8b292f6943a9dfdb0e66d271",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/989dc45' (2026-04-14)
  → 'github:nix-community/NUR/ec38f41' (2026-04-14)
```