### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -638,11 +638,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1776030597,
-        "narHash": "sha256-H2CYM/RmVqCo1iud5BhPp8Pim2d1ESGt2FDHjbmju8A=",
+        "lastModified": 1776145222,
+        "narHash": "sha256-Djchgl/U/iPZ7CEkh8TzQZ/4for5Eg+0TeZzhTkc/1w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c88e63f4caf12c731f61ce71f300680ce73c180e",
+        "rev": "2636ca0c159c2e5a6bfa92489938dc4e2ebc2b76",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776145564,
-        "narHash": "sha256-V2UVnqN0r6d4lrpVLMUDatD38usARN7fILi8IO4FgrI=",
+        "lastModified": 1776158259,
+        "narHash": "sha256-0amvLb6QK6ZC3sZMyOB753czdApTNdG0Fc5u0B4a+Y4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ec38f41010a1bb8a8b292f6943a9dfdb0e66d271",
+        "rev": "8d637004f6840c25dac19f0dd89e3e05e3155ebf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/c88e63f' (2026-04-12)
  → 'github:NixOS/nixpkgs/2636ca0' (2026-04-14)
• Updated input 'nur':
    'github:nix-community/NUR/ec38f41' (2026-04-14)
  → 'github:nix-community/NUR/8d63700' (2026-04-14)
```