### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776187374,
-        "narHash": "sha256-rB4dY5T1xteT9OS50RE7FVIaEDns+8CH6w6ERDKUJvM=",
+        "lastModified": 1776200835,
+        "narHash": "sha256-ygltUnTORaKze1J1n5RlSXPrnoEQKE/Ti16bhNY9EtI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3a89df54430ae429bb4daf48bc82c34157cb1adf",
+        "rev": "a370494046dac393b662c0b2a8d3c707578d3403",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/3a89df5' (2026-04-14)
  → 'github:nix-community/NUR/a370494' (2026-04-14)
```