### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776209235,
-        "narHash": "sha256-nQCt6zY4k1QVpFuprnOx4/uWlukwjyNwv6VcvnGvlSE=",
+        "lastModified": 1776225145,
+        "narHash": "sha256-Flj3e06EeT2wuAflcBIlt9sN/PG7lKofuWhnFWt0Zac=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b39e0ce0eaa9a774e5336d5f6d4ae8dec56c3830",
+        "rev": "a32f708808a45c60706af194d00cd89c0e374322",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/b39e0ce' (2026-04-14)
  → 'github:nix-community/NUR/a32f708' (2026-04-15)
```