### PR TITLE
Dev antipatterns

### DIFF
--- a/.github/workflows/cloudflare-ip-check.yml
+++ b/.github/workflows/cloudflare-ip-check.yml
@@ -73,13 +73,10 @@ jobs:
         with:
           script: |
             const title = 'Cloudflare IP ranges are stale in traefik.nix';
-            const { data: issues } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'security',
+            const { data: { items } } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "${title}"`,
             });
-            const exists = issues.some(i => i.title === title);
+            const exists = items.some(i => i.title === title);
             if (!exists) {
               await github.rest.issues.create({
                 owner: context.repo.owner,

--- a/.github/workflows/cloudflare-ip-check.yml
+++ b/.github/workflows/cloudflare-ip-check.yml
@@ -35,9 +35,15 @@ jobs:
             exit 1
           fi
 
-          # Extract hardcoded IPs from traefik.nix (skip 127.0.0.1/32)
-          hardcoded_ips=$(grep -oP '"\K[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+' \
-            hosts/blizzard/security/traefik.nix \
+          # Extract Cloudflare IPs from the forwardedHeadersTrustedIPs block only (skip 127.0.0.1/32)
+          hardcoded_ips=$(awk '
+            /forwardedHeadersTrustedIPs[[:space:]]*=/ { in_block=1 }
+            in_block {
+              print
+              if (/\][[:space:]]*;/) exit
+            }
+          ' hosts/blizzard/security/traefik.nix \
+            | grep -oP '"\K[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+' \
             | grep -v '^127\.' \
             | sort)
 

--- a/.github/workflows/cloudflare-ip-check.yml
+++ b/.github/workflows/cloudflare-ip-check.yml
@@ -1,0 +1,99 @@
+name: Cloudflare IP Staleness Check
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 1 * *"
+
+concurrency:
+  group: cloudflare-ip-check
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-cloudflare-ips:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+        with:
+          sparse-checkout: hosts/blizzard/security/traefik.nix
+          sparse-checkout-cone-mode: false
+
+      - name: Compare hardcoded IPs against Cloudflare API
+        id: check
+        run: |
+          echo "## ☁️ Cloudflare IP Staleness Check" >> $GITHUB_STEP_SUMMARY
+
+          # Fetch current Cloudflare IPv4 ranges
+          cf_ips=$(curl -sf https://www.cloudflare.com/ips-v4 | sort)
+          if [ -z "$cf_ips" ]; then
+            echo "❌ Failed to fetch Cloudflare IP ranges" >> $GITHUB_STEP_SUMMARY
+            echo "stale=error" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          # Extract hardcoded IPs from traefik.nix (skip 127.0.0.1/32)
+          hardcoded_ips=$(grep -oP '"\K[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+' \
+            hosts/blizzard/security/traefik.nix \
+            | grep -v '^127\.' \
+            | sort)
+
+          # Diff
+          missing_from_config=$(comm -23 <(echo "$cf_ips") <(echo "$hardcoded_ips"))
+          extra_in_config=$(comm -13 <(echo "$cf_ips") <(echo "$hardcoded_ips"))
+
+          if [ -z "$missing_from_config" ] && [ -z "$extra_in_config" ]; then
+            echo "✅ Cloudflare IP ranges are up to date" >> $GITHUB_STEP_SUMMARY
+            echo "stale=false" >> $GITHUB_OUTPUT
+          else
+            echo "🚨 Cloudflare IP ranges are **stale**" >> $GITHUB_STEP_SUMMARY
+            if [ -n "$missing_from_config" ]; then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "**Missing from config (new Cloudflare ranges):**" >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+              echo "$missing_from_config" >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+            fi
+            if [ -n "$extra_in_config" ]; then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "**In config but no longer in Cloudflare (stale ranges):**" >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+              echo "$extra_in_config" >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+            fi
+            echo "stale=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create issue if stale
+        if: steps.check.outputs.stale == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = 'Cloudflare IP ranges are stale in traefik.nix';
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'security',
+            });
+            const exists = issues.some(i => i.title === title);
+            if (!exists) {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body: [
+                  'The hardcoded Cloudflare IP ranges in `hosts/blizzard/security/traefik.nix`',
+                  'no longer match the live ranges from https://www.cloudflare.com/ips-v4.',
+                  '',
+                  'Please update `forwardedHeadersTrustedIPs` and consider adding IPv6 ranges',
+                  'from https://www.cloudflare.com/ips-v6.',
+                  '',
+                  'See the workflow run for details.',
+                ].join('\n'),
+                labels: ['security'],
+              });
+            }

--- a/.github/workflows/cloudflare-ip-check.yml
+++ b/.github/workflows/cloudflare-ip-check.yml
@@ -47,6 +47,11 @@ jobs:
             | grep -oP '"\K[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+' \
             | grep -v '^127\.' \
             | sort)
+          if [ -z "$hardcoded_ips" ]; then
+            echo "❌ Failed to extract hardcoded Cloudflare IP ranges from hosts/blizzard/security/traefik.nix" >> $GITHUB_STEP_SUMMARY
+            echo "stale=error" >> $GITHUB_OUTPUT
+            exit 1
+          fi
 
           # Diff
           missing_from_config=$(comm -23 <(echo "$cf_ips") <(echo "$hardcoded_ips"))
@@ -76,7 +81,7 @@ jobs:
 
       - name: Create issue if stale
         if: steps.check.outputs.stale == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const title = 'Cloudflare IP ranges are stale in traefik.nix';

--- a/.github/workflows/cloudflare-ip-check.yml
+++ b/.github/workflows/cloudflare-ip-check.yml
@@ -25,10 +25,11 @@ jobs:
       - name: Compare hardcoded IPs against Cloudflare API
         id: check
         run: |
+          set -euo pipefail
           echo "## ☁️ Cloudflare IP Staleness Check" >> $GITHUB_STEP_SUMMARY
 
           # Fetch current Cloudflare IPv4 ranges
-          cf_ips=$(curl -sf https://www.cloudflare.com/ips-v4 | sort)
+          cf_ips=$(curl -sf --max-time 30 --connect-timeout 10 --retry 3 --retry-delay 2 --location https://www.cloudflare.com/ips-v4 | sort)
           if [ -z "$cf_ips" ]; then
             echo "❌ Failed to fetch Cloudflare IP ranges" >> $GITHUB_STEP_SUMMARY
             echo "stale=error" >> $GITHUB_OUTPUT

--- a/containers/subgen.nix
+++ b/containers/subgen.nix
@@ -160,7 +160,7 @@ in
           TRANSCRIBE_DEVICE = if cfg.gpu.enable then "cuda" else "cpu";
           CLEAR_VRAM_ON_COMPLETE = "True";
           MODEL_PATH = "./models";
-          DEBUG = "True";
+          DEBUG = "False";
         }
         // lib.optionalAttrs (cfg.forceDetectedLanguageTo != "") {
           FORCE_DETECTED_LANGUAGE_TO = cfg.forceDetectedLanguageTo;

--- a/containers/subtitle-stack.nix
+++ b/containers/subtitle-stack.nix
@@ -217,7 +217,7 @@ in
                 WEBHOOKPORT = "9000";
                 CONCURRENT_TRANSCRIPTIONS = "2";
                 WORD_LEVEL_HIGHLIGHT = "False";
-                DEBUG = "True";
+                DEBUG = "False";
                 TRANSCRIBE_DEVICE = "cpu";
                 CLEAR_VRAM_ON_COMPLETE = "True";
                 MODEL_PATH = "./models";

--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,12 @@
   description = "NixOS configuration with auto-imported modules";
 
   inputs = {
+    # Primary channel - most packages come from here
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # Stable fallbacks for packages broken on unstable
     nixpkgs-stable-latest.url = "github:NixOS/nixpkgs/nixos-25.11";
     nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-24.11";
+    # Bleeding-edge channel for packages that need the latest commits
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable-small";
 
     nixos-hardware.url = "github:NixOS/nixos-hardware/master";

--- a/home/base.nix
+++ b/home/base.nix
@@ -80,7 +80,6 @@ in
 
     home = {
       stateVersion = lib.mkDefault "24.05";
-      enableDebugInfo = lib.mkDefault true;
       preferXdgDirectories = lib.mkDefault true;
 
       language = {

--- a/hosts/avalanche/avalanche.nix
+++ b/hosts/avalanche/avalanche.nix
@@ -84,7 +84,8 @@ in
 
       cloudflareAccessIpUpdater = {
         enable = true;
-        inherit (consts.cloudflare) accountId policyId;
+        accountIdFile = config.sops.secrets."cloudflare/accountId".path;
+        policyIdFile = config.sops.secrets."cloudflare/policyId".path;
         apiTokenFile = config.sops.secrets."cloudflare/access_api_token".path;
         interval = "30min";
       };

--- a/hosts/avalanche/avalanche.nix
+++ b/hosts/avalanche/avalanche.nix
@@ -84,9 +84,9 @@ in
 
       cloudflareAccessIpUpdater = {
         enable = true;
-        accountIdFile = config.sops.secrets."cloudflare/accountId".path;
-        policyIdFile = config.sops.secrets."cloudflare/policyId".path;
-        apiTokenFile = config.sops.secrets."cloudflare/access_api_token".path;
+        accountIdFile = config.sys.secrets.cloudflareAccountIdFile;
+        policyIdFile = config.sys.secrets.cloudflarePolicyIdFile;
+        apiTokenFile = config.sys.secrets.cloudflareAccessApiTokenFile;
         interval = "30min";
       };
 

--- a/hosts/snowfall/snowfall.nix
+++ b/hosts/snowfall/snowfall.nix
@@ -107,7 +107,8 @@ in
 
       cloudflareAccessIpUpdater = {
         enable = true;
-        inherit (consts.cloudflare) accountId policyId;
+        accountIdFile = config.sops.secrets."cloudflare/accountId".path;
+        policyIdFile = config.sops.secrets."cloudflare/policyId".path;
         apiTokenFile = config.sops.secrets."cloudflare/access_api_token".path;
         interval = "30min";
       };

--- a/hosts/snowfall/snowfall.nix
+++ b/hosts/snowfall/snowfall.nix
@@ -107,9 +107,9 @@ in
 
       cloudflareAccessIpUpdater = {
         enable = true;
-        accountIdFile = config.sops.secrets."cloudflare/accountId".path;
-        policyIdFile = config.sops.secrets."cloudflare/policyId".path;
-        apiTokenFile = config.sops.secrets."cloudflare/access_api_token".path;
+        accountIdFile = config.sys.secrets.cloudflareAccountIdFile;
+        policyIdFile = config.sys.secrets.cloudflarePolicyIdFile;
+        apiTokenFile = config.sys.secrets.cloudflareAccessApiTokenFile;
         interval = "30min";
       };
 

--- a/lib/constants.nix
+++ b/lib/constants.nix
@@ -2,9 +2,4 @@
 # For secrets use sops-nix; for per-host data use host configs.
 {
   tailscale.suffix = "mole-delta.ts.net";
-
-  cloudflare = {
-    accountId = "1f65156829c5e18a3648609b381dec9c";
-    policyId = "897e5beb-2937-448f-a444-4b51ff7479b0";
-  };
 }

--- a/modules/core/sops.nix
+++ b/modules/core/sops.nix
@@ -100,6 +100,8 @@ in
       }
       // whenEnabled hasCloudflareAccessIpUpdater {
         "cloudflare/access_api_token" = { };
+        "cloudflare/accountId" = { };
+        "cloudflare/policyId" = { };
       }
       # UPS monitoring password (for NUT upsmon)
       // whenEnabled hasUps {
@@ -226,6 +228,8 @@ in
     }
     // whenEnabled hasCloudflareAccessIpUpdater {
       cloudflareAccessApiTokenFile = toString config.sops.secrets."cloudflare/access_api_token".path;
+      cloudflareAccountIdFile = toString config.sops.secrets."cloudflare/accountId".path;
+      cloudflarePolicyIdFile = toString config.sops.secrets."cloudflare/policyId".path;
     }
     # UPS monitoring password
     // whenEnabled hasUps {

--- a/modules/security/secrets.nix
+++ b/modules/security/secrets.nix
@@ -162,6 +162,24 @@
       '';
     };
 
+    cloudflareAccountIdFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.str; # runtime path string
+      default = null;
+      description = ''
+        Path to a file containing the Cloudflare Account ID.
+        Used by cloudflare-access-ip-updater service. Mapped from SOPS in core/sops.nix.
+      '';
+    };
+
+    cloudflarePolicyIdFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.str; # runtime path string
+      default = null;
+      description = ''
+        Path to a file containing the Cloudflare Access Policy ID.
+        Used by cloudflare-access-ip-updater service. Mapped from SOPS in core/sops.nix.
+      '';
+    };
+
     upsmonPasswordFile = lib.mkOption {
       type = lib.types.nullOr lib.types.str; # runtime path string
       default = null;

--- a/modules/services/cloudflare-access-ip-updater.nix
+++ b/modules/services/cloudflare-access-ip-updater.nix
@@ -20,20 +20,21 @@ let
   updateScript = pkgs.writeShellScript "cloudflare-access-ip-updater" ''
     set -euo pipefail
 
+    # Validate secret files exist before reading
+    for secret_file in "${cfg.accountIdFile}" "${cfg.policyIdFile}" "${cfg.apiTokenFile}"; do
+      if [[ ! -f "$secret_file" ]]; then
+        echo "Error: Required secret file not found: $secret_file"
+        exit 1
+      fi
+    done
+
     # Read secrets from files at runtime
     ACCOUNT_ID=$(${pkgs.coreutils}/bin/cat "${cfg.accountIdFile}" | ${pkgs.coreutils}/bin/tr -d '[:space:]')
     ${lib.optionalString (cfg.appId != null) ''APP_ID="${cfg.appId}"''}
     POLICY_ID=$(${pkgs.coreutils}/bin/cat "${cfg.policyIdFile}" | ${pkgs.coreutils}/bin/tr -d '[:space:]')
-    API_TOKEN_FILE="${cfg.apiTokenFile}"
+    API_TOKEN=$(${pkgs.coreutils}/bin/cat "${cfg.apiTokenFile}" | ${pkgs.coreutils}/bin/tr -d '[:space:]')
     STATE_FILE="/var/lib/cloudflare-access-ip-updater/last-ip"
     API_ENDPOINT="${apiEndpoint}"
-
-    # Read API token
-    if [[ ! -f "$API_TOKEN_FILE" ]]; then
-      echo "Error: API token file not found: $API_TOKEN_FILE"
-      exit 1
-    fi
-    API_TOKEN=$(${pkgs.coreutils}/bin/cat "$API_TOKEN_FILE" | ${pkgs.coreutils}/bin/tr -d '[:space:]')
 
     # Get current public IP
     CURRENT_IP=$(${pkgs.curl}/bin/curl -sf ${lib.escapeShellArg cfg.ipService} | ${pkgs.coreutils}/bin/tr -d '[:space:]')

--- a/modules/services/cloudflare-access-ip-updater.nix
+++ b/modules/services/cloudflare-access-ip-updater.nix
@@ -10,11 +10,11 @@ let
   # Determine API endpoint based on whether appId is provided
   # Reusable policy: /accounts/{account_id}/access/policies/{policy_id}
   # App-specific:    /accounts/{account_id}/access/apps/{app_id}/policies/{policy_id}
-  apiEndpoint =
+  apiEndpointTemplate =
     if cfg.appId == null then
-      "https://api.cloudflare.com/client/v4/accounts/\$ACCOUNT_ID/access/policies/\$POLICY_ID"
+      "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/access/policies/$POLICY_ID"
     else
-      "https://api.cloudflare.com/client/v4/accounts/\$ACCOUNT_ID/access/apps/\$APP_ID/policies/\$POLICY_ID";
+      "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/access/apps/$APP_ID/policies/$POLICY_ID";
 
   # Script to update Cloudflare Access policy with current IP
   updateScript = pkgs.writeShellScript "cloudflare-access-ip-updater" ''
@@ -34,7 +34,7 @@ let
     POLICY_ID=$(${pkgs.coreutils}/bin/cat "${cfg.policyIdFile}" | ${pkgs.coreutils}/bin/tr -d '[:space:]')
     API_TOKEN=$(${pkgs.coreutils}/bin/cat "${cfg.apiTokenFile}" | ${pkgs.coreutils}/bin/tr -d '[:space:]')
     STATE_FILE="/var/lib/cloudflare-access-ip-updater/last-ip"
-    API_ENDPOINT="${apiEndpoint}"
+    API_ENDPOINT="${apiEndpointTemplate}"
 
     # Get current public IP
     CURRENT_IP=$(${pkgs.curl}/bin/curl -sf ${lib.escapeShellArg cfg.ipService} | ${pkgs.coreutils}/bin/tr -d '[:space:]')

--- a/modules/services/cloudflare-access-ip-updater.nix
+++ b/modules/services/cloudflare-access-ip-updater.nix
@@ -20,10 +20,10 @@ let
   updateScript = pkgs.writeShellScript "cloudflare-access-ip-updater" ''
     set -euo pipefail
 
-    # Configuration
-    ACCOUNT_ID="${cfg.accountId}"
+    # Read secrets from files at runtime
+    ACCOUNT_ID=$(${pkgs.coreutils}/bin/cat "${cfg.accountIdFile}" | ${pkgs.coreutils}/bin/tr -d '[:space:]')
     ${lib.optionalString (cfg.appId != null) ''APP_ID="${cfg.appId}"''}
-    POLICY_ID="${cfg.policyId}"
+    POLICY_ID=$(${pkgs.coreutils}/bin/cat "${cfg.policyIdFile}" | ${pkgs.coreutils}/bin/tr -d '[:space:]')
     API_TOKEN_FILE="${cfg.apiTokenFile}"
     STATE_FILE="/var/lib/cloudflare-access-ip-updater/last-ip"
     API_ENDPOINT="${apiEndpoint}"
@@ -117,10 +117,13 @@ in
   options.sys.services.cloudflareAccessIpUpdater = {
     enable = lib.mkEnableOption "Cloudflare Access IP Updater";
 
-    accountId = lib.mkOption {
-      type = lib.types.str;
-      description = "Cloudflare Account ID";
-      example = "abcdef1234567890abcdef1234567890";
+    accountIdFile = lib.mkOption {
+      type = lib.types.path;
+      description = ''
+        Path to file containing the Cloudflare Account ID.
+        Use sops.secrets.*.path for secure storage.
+      '';
+      example = "/run/secrets/cloudflare-account-id";
     };
 
     appId = lib.mkOption {
@@ -134,10 +137,13 @@ in
       example = "12345678-1234-1234-1234-123456789012";
     };
 
-    policyId = lib.mkOption {
-      type = lib.types.str;
-      description = "Cloudflare Access Policy ID to update with dynamic IP";
-      example = "87654321-4321-4321-4321-210987654321";
+    policyIdFile = lib.mkOption {
+      type = lib.types.path;
+      description = ''
+        Path to file containing the Cloudflare Access Policy ID to update with dynamic IP.
+        Use sops.secrets.*.path for secure storage.
+      '';
+      example = "/run/secrets/cloudflare-policy-id";
     };
 
     apiTokenFile = lib.mkOption {

--- a/modules/services/cloudflare-access-ip-updater.nix
+++ b/modules/services/cloudflare-access-ip-updater.nix
@@ -119,7 +119,7 @@ in
     enable = lib.mkEnableOption "Cloudflare Access IP Updater";
 
     accountIdFile = lib.mkOption {
-      type = lib.types.path;
+      type = lib.types.str; # runtime path string (do not coerce into store)
       description = ''
         Path to file containing the Cloudflare Account ID.
         Use sops.secrets.*.path for secure storage.
@@ -139,7 +139,7 @@ in
     };
 
     policyIdFile = lib.mkOption {
-      type = lib.types.path;
+      type = lib.types.str; # runtime path string (do not coerce into store)
       description = ''
         Path to file containing the Cloudflare Access Policy ID to update with dynamic IP.
         Use sops.secrets.*.path for secure storage.
@@ -148,7 +148,7 @@ in
     };
 
     apiTokenFile = lib.mkOption {
-      type = lib.types.path;
+      type = lib.types.str; # runtime path string (do not coerce into store)
       description = ''
         Path to file containing Cloudflare API token.
         Token needs "Zero Trust: Edit" permission.
@@ -198,8 +198,12 @@ in
       # Main service
       services.cloudflare-access-ip-updater = {
         description = "Update Cloudflare Access policy with current public IP";
-        after = [ "network-online.target" ];
+        after = [
+          "network-online.target"
+          "sops-install-secrets.service"
+        ];
         wants = [ "network-online.target" ];
+        requires = [ "sops-install-secrets.service" ];
 
         serviceConfig = {
           Type = "oneshot";

--- a/modules/services/cloudflare-access-ip-updater.nix
+++ b/modules/services/cloudflare-access-ip-updater.nix
@@ -122,7 +122,8 @@ in
       type = lib.types.str; # runtime path string (do not coerce into store)
       description = ''
         Path to file containing the Cloudflare Account ID.
-        Use sops.secrets.*.path for secure storage.
+        Use config.sys.secrets.cloudflareAccountIdFile (preferred) or
+        toString config.sops.secrets."cloudflare/accountId".path.
       '';
       example = "/run/secrets/cloudflare-account-id";
     };
@@ -142,7 +143,8 @@ in
       type = lib.types.str; # runtime path string (do not coerce into store)
       description = ''
         Path to file containing the Cloudflare Access Policy ID to update with dynamic IP.
-        Use sops.secrets.*.path for secure storage.
+        Use config.sys.secrets.cloudflarePolicyIdFile (preferred) or
+        toString config.sops.secrets."cloudflare/policyId".path.
       '';
       example = "/run/secrets/cloudflare-policy-id";
     };
@@ -152,7 +154,8 @@ in
       description = ''
         Path to file containing Cloudflare API token.
         Token needs "Zero Trust: Edit" permission.
-        Use sops.secrets.*.path for secure storage.
+        Use config.sys.secrets.cloudflareAccessApiTokenFile (preferred) or
+        toString config.sops.secrets."cloudflare/access_api_token".path.
       '';
       example = "/run/secrets/cloudflare-access-api-token";
     };

--- a/modules/services/maintenance.nix
+++ b/modules/services/maintenance.nix
@@ -9,7 +9,7 @@ in
     services = {
       fstrim.enable = true;
       fwupd.enable = true;
-      devmon.enable = true; # FIXME: udevil GCC 15 fix applied via overlay in overlays.nix due to udevil build failure - https://github.com/NixOS/nixpkgs/issues/475479
+      devmon.enable = true;
       gvfs.enable = true;
       udisks2.enable = true;
       zram-generator.enable = true;


### PR DESCRIPTION
This pull request introduces several security and maintainability improvements, primarily focused on how Cloudflare credentials are managed and checked. Notably, Cloudflare secrets are now read from files managed by sops-nix rather than being hardcoded, and a new GitHub Actions workflow checks for staleness in Cloudflare IP ranges. Additionally, debugging is disabled in several services, and minor documentation and configuration cleanups are included.

**Cloudflare credentials management:**
* Refactored `cloudflareAccessIpUpdater` to read `accountId` and `policyId` from secret files (`accountIdFile`, `policyIdFile`) instead of hardcoding values, improving security and flexibility. (`hosts/avalanche/avalanche.nix`, `hosts/snowfall/snowfall.nix`, `modules/services/cloudflare-access-ip-updater.nix`, `lib/constants.nix`, [[1]](diffhunk://#diff-90b9d34009aa37e9200e2cdbe3fcb6442bcffc1ec2d7aec969f52c9d702c07deL23-R26) [[2]](diffhunk://#diff-90b9d34009aa37e9200e2cdbe3fcb6442bcffc1ec2d7aec969f52c9d702c07deL120-R126) [[3]](diffhunk://#diff-90b9d34009aa37e9200e2cdbe3fcb6442bcffc1ec2d7aec969f52c9d702c07deL137-R146) [[4]](diffhunk://#diff-369ff211f1cf28e6fd3ef72a237b84b414d820e04f8557b52420a620d85e5dedL87-R88) [[5]](diffhunk://#diff-95f6dcd8a397e761ec67aa5a452a56fa891a0cded131795d6bf94a3990b82593L110-R111) [[6]](diffhunk://#diff-37cb401bdbac074b187873e92a1ebbaf3f51e762f6be19938fa4742f60914ef1L5-L9)
* Updated sops-nix integration to manage `cloudflare/accountId` and `cloudflare/policyId` secrets, and exposed their paths as module outputs. (`modules/core/sops.nix`, [[1]](diffhunk://#diff-9179b2d010d37b1edd7922a6936a0486d6ec7ea9f5928f047b44998b2baeed09R103-R104) [[2]](diffhunk://#diff-9179b2d010d37b1edd7922a6936a0486d6ec7ea9f5928f047b44998b2baeed09R231-R232)

**Cloudflare IP staleness monitoring:**
* Added `.github/workflows/cloudflare-ip-check.yml` workflow to compare hardcoded Cloudflare IPs in `traefik.nix` with the official list, and automatically open an issue if they are stale. (`.github/workflows/cloudflare-ip-check.yml`, [.github/workflows/cloudflare-ip-check.ymlR1-R99](diffhunk://#diff-b99c2d4fc2021c0eca1c93e6cf937e72b0be1630f3ee2c19164c3c97e5d33805R1-R99))

**Debug and configuration cleanup:**
* Disabled debug mode in `subgen.nix` and `subtitle-stack.nix` containers for less verbose logs in production. (`containers/subgen.nix`, `containers/subtitle-stack.nix`, [[1]](diffhunk://#diff-96b33cb6bdac25cbc0febdedb6bf51e5ba44b2dba24d077b4bafb5dd1c08e8a2L163-R163) [[2]](diffhunk://#diff-a1daf5d3719ed9d2be8c5d218f06f0235a38d54b3defaa273238bb711e5afb70L220-R220)
* Removed `enableDebugInfo` default from `home/base.nix` for a cleaner configuration. (`home/base.nix`, [home/base.nixL83](diffhunk://#diff-5ddd63dbc5736b6d8f7b472550bf5a07c2a1714d39c27c68434c53fef8d64bfeL83))

**Documentation and comments:**
* Improved comments in `flake.nix` for Nixpkgs channel inputs. (`flake.nix`, [flake.nixR5-R10](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R5-R10))
* Removed outdated workaround comment in `maintenance.nix`. (`modules/services/maintenance.nix`, [modules/services/maintenance.nixL12-R12](diffhunk://#diff-113ae590df4f6900de39c24fc6453cefa11abde21c971b34fb03fa6930e4073aL12-R12))