### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776579154,
-        "narHash": "sha256-R6qzYIKs4bamkzr3IycoKY6LevhFSl9l46/2EIg3x6Y=",
+        "lastModified": 1776587421,
+        "narHash": "sha256-rO2dca1U5xao5BMg+Os2HySVmQlq5hR49NNrGc9dEkg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "603eea20d0a608ac8e54ec249f8af919d5302e6a",
+        "rev": "11f5d7471f1999a8130e953209765a19f2fb74e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/603eea2' (2026-04-19)
  → 'github:nix-community/NUR/11f5d74' (2026-04-19)
```