### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776657094,
-        "narHash": "sha256-tqTMK+nr4kXUrErteg/1hrQ816Ss7+2RsPNYZiVpf0I=",
+        "lastModified": 1776661682,
+        "narHash": "sha256-X32LTSDqUdVqMy85WYdRgyt0I75wc4Lhi9j+lrCDR8w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "29f355a7338f30f32142f4ff44e805d47d0086b1",
+        "rev": "4bfce11ea820df0359f73736fd59c7e8f53641a6",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776657667,
-        "narHash": "sha256-9l5dwniI3EBHhgRAqM6EWQWOFsPnERY/R9mqWyo5+Vg=",
+        "lastModified": 1776665540,
+        "narHash": "sha256-VLPnXEAl0z7pt+cMa3XhIhDxMmqcJdXeA++sLjVVyxM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5d5835a236896741805bb70d01f15b9d561f51ab",
+        "rev": "bb37fb1bd923f447e45d0c8fc5b6fd38b0c39fdf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/29f355a' (2026-04-20)
  → 'github:nix-community/home-manager/4bfce11' (2026-04-20)
• Updated input 'nur':
    'github:nix-community/NUR/5d5835a' (2026-04-20)
  → 'github:nix-community/NUR/bb37fb1' (2026-04-20)
```