### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -544,11 +544,11 @@
     },
     "nix-secrets": {
       "locked": {
-        "lastModified": 1776438739,
-        "narHash": "sha256-9RR/BJxs2gdklNzOIsIsQlVcM6yxxfMurGq0QY7xcF8=",
+        "lastModified": 1776679155,
+        "narHash": "sha256-0qbBG/pJw/AOEBIvxjUyoWugv2tZ135pojtosqF0ipw=",
         "ref": "refs/heads/master",
-        "rev": "012966fac62ba0027e61b007f48dfa5527fbc420",
-        "revCount": 107,
+        "rev": "ceb6f615d7c4ed34f79867ab06e1de0612d9ed04",
+        "revCount": 108,
         "type": "git",
         "url": "ssh://git@github.com/telometto/nix-secrets.git"
       },
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776676900,
-        "narHash": "sha256-6BO5V6Z+nEYt/x6uMtDpPKgenbZwTG/xgI3pxR7kpBI=",
+        "lastModified": 1776679267,
+        "narHash": "sha256-SW3OGbLSo4w0Uh6wHfD5gYnvMRYwvKLW3EBX+TBHcA4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e7a17d15785cda986a7622e260358fa82463c239",
+        "rev": "dd785f4fd2fdb039e8fe6c72a729912a0debc4ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nix-secrets':
    'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=012966fac62ba0027e61b007f48dfa5527fbc420' (2026-04-17)
  → 'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=ceb6f615d7c4ed34f79867ab06e1de0612d9ed04' (2026-04-20)
• Updated input 'nur':
    'github:nix-community/NUR/e7a17d1' (2026-04-20)
  → 'github:nix-community/NUR/dd785f4' (2026-04-20)
```