### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776661682,
-        "narHash": "sha256-X32LTSDqUdVqMy85WYdRgyt0I75wc4Lhi9j+lrCDR8w=",
+        "lastModified": 1776698769,
+        "narHash": "sha256-GelwBD5XrSO9/bpcVrB4QZfXYJf4EUsiu+zgQoGeYQw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4bfce11ea820df0359f73736fd59c7e8f53641a6",
+        "rev": "1072f064e2c47a249f09800e7c0fe4e96ab9b433",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776679267,
-        "narHash": "sha256-SW3OGbLSo4w0Uh6wHfD5gYnvMRYwvKLW3EBX+TBHcA4=",
+        "lastModified": 1776696950,
+        "narHash": "sha256-aNRcVtCIEko2txSq/gBWGpk+S1HgUxgrauZFtZrvQQ0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dd785f4fd2fdb039e8fe6c72a729912a0debc4ce",
+        "rev": "71fa953456c79288c8a76449b80827ecea0fc2b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/4bfce11' (2026-04-20)
  → 'github:nix-community/home-manager/1072f06' (2026-04-20)
• Updated input 'nur':
    'github:nix-community/NUR/dd785f4' (2026-04-20)
  → 'github:nix-community/NUR/71fa953' (2026-04-20)
```