### PR TITLE
🔧 fix(openssh.nix): replace deprecated `banner` option

### DIFF
--- a/modules/services/openssh.nix
+++ b/modules/services/openssh.nix
@@ -2,7 +2,31 @@
 let
   cfg = config.sys.services.openssh;
 
+  defaultBanner = builtins.toFile "openssh-banner" ''
+    ╔═══════════════════════════════════════════════════════════════════════╗
+    ║                                                                       ║
+    ║                 ███╗   ██╗██╗██╗  ██╗ ██████╗ ███████╗                ║
+    ║                 ████╗  ██║██║╚██╗██╔╝██╔═══██╗██╔════╝                ║
+    ║                 ██╔██╗ ██║██║ ╚███╔╝ ██║   ██║███████╗                ║
+    ║                 ██║╚██╗██║██║ ██╔██╗ ██║   ██║╚════██║                ║
+    ║                 ██║ ╚████║██║██╔╝ ██╗╚██████╔╝███████║                ║
+    ║                 ╚═╝  ╚═══╝╚═╝╚═╝  ╚═╝ ╚═════╝ ╚══════╝                ║
+    ║                                                                       ║
+    ║              🔒 Secured by NixOS • Hardened by Design 🔒             ║
+    ║                                                                       ║
+    ║   ┌─────────────────────────────────────────────────────────────┐     ║
+    ║   │  Welcome back to the Matrix!                                │     ║
+    ║   │                                                             │     ║
+    ║   │    • All connections are monitored and logged               │     ║
+    ║   │    • Unauthorized access attempts will be prosecuted        │     ║
+    ║   │    • This system is protected by AppArmor MAC               │     ║
+    ║   └─────────────────────────────────────────────────────────────┘     ║
+    ║                                                                       ║
+    ╚═══════════════════════════════════════════════════════════════════════╝
+  '';
+
   defaultSettings = {
+    Banner = lib.mkDefault defaultBanner;
     X11Forwarding = lib.mkDefault false;
     PermitRootLogin = lib.mkDefault "no";
     PasswordAuthentication = lib.mkDefault false;
@@ -35,34 +59,13 @@ in
   config = lib.mkIf cfg.enable {
     services.openssh = {
       enable = true;
-      banner = lib.mkDefault ''
-        ╔═══════════════════════════════════════════════════════════════════════╗
-        ║                                                                       ║
-        ║                 ███╗   ██╗██╗██╗  ██╗ ██████╗ ███████╗                ║
-        ║                 ████╗  ██║██║╚██╗██╔╝██╔═══██╗██╔════╝                ║
-        ║                 ██╔██╗ ██║██║ ╚███╔╝ ██║   ██║███████╗                ║
-        ║                 ██║╚██╗██║██║ ██╔██╗ ██║   ██║╚════██║                ║
-        ║                 ██║ ╚████║██║██╔╝ ██╗╚██████╔╝███████║                ║
-        ║                 ╚═╝  ╚═══╝╚═╝╚═╝  ╚═╝ ╚═════╝ ╚══════╝                ║
-        ║                                                                       ║
-        ║              🔒 Secured by NixOS • Hardened by Design 🔒              ║
-        ║                                                                       ║
-        ║   ┌─────────────────────────────────────────────────────────────┐     ║
-        ║   │  Welcome back to the Matrix!                                │     ║
-        ║   │                                                             │     ║
-        ║   │    • All connections are monitored and logged               │     ║
-        ║   │    • Unauthorized access attempts will be prosecuted        │     ║
-        ║   │    • This system is protected by AppArmor MAC               │     ║
-        ║   └─────────────────────────────────────────────────────────────┘     ║
-        ║                                                                       ║
-        ╚═══════════════════════════════════════════════════════════════════════╝
 
-      '';
+      inherit (cfg) extraConfig openFirewall;
+
       settings = lib.mkMerge [
         defaultSettings
         cfg.extraSettings
       ];
-      inherit (cfg) extraConfig openFirewall;
     };
   };
 }


### PR DESCRIPTION
This pull request refactors how the default SSH login banner is defined and applied in the OpenSSH NixOS module. The main change is to move the banner definition into a reusable variable and ensure it is consistently applied as a default setting, simplifying the configuration and improving maintainability.

**Refactoring and maintainability improvements:**

* Extracted the SSH banner text into a new `defaultBanner` variable using `builtins.toFile`, making the banner easier to manage and update.
* Set the `Banner` option in `defaultSettings` to use the new `defaultBanner`, ensuring the banner is applied by default.
* Removed the inline banner text from the `services.openssh` configuration and replaced it with a reference to the new default settings, streamlining the configuration block.