### PR TITLE
🪄 feat(terminal.nix): add settings for atuin

### DIFF
--- a/home/programs/terminal.nix
+++ b/home/programs/terminal.nix
@@ -40,8 +40,25 @@ in
     programs = {
       atuin = {
         enable = lib.mkDefault true;
+
         enableBashIntegration = lib.mkDefault true;
         enableZshIntegration = lib.mkDefault true;
+
+        settings = {
+          auto_sync = lib.mkDefault true;
+          update_check = lib.mkDefault false;
+
+          # Prefer history discovery that works well in big git repos.
+          search_mode = lib.mkDefault "daemon-fuzzy";
+          filter_mode = lib.mkDefault "workspace";
+          workspaces = lib.mkDefault true;
+
+          style = lib.mkDefault "compact";
+          inline_height = lib.mkDefault 20;
+          show_preview = lib.mkDefault true;
+          show_help = lib.mkDefault false;
+          enter_accept = lib.mkDefault true;
+        };
       };
 
       bash = {

--- a/home/programs/terminal.nix
+++ b/home/programs/terminal.nix
@@ -11,6 +11,12 @@ in
   options.hm.programs.terminal = {
     enable = lib.mkEnableOption "Terminal tools and shell configuration";
 
+    atuin.settings = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+      description = "User overrides for Atuin settings merged on top of the module defaults.";
+    };
+
     zellij = {
       enable = lib.mkEnableOption "zellij multiplexer";
 
@@ -44,21 +50,24 @@ in
         enableBashIntegration = lib.mkDefault true;
         enableZshIntegration = lib.mkDefault true;
 
-        settings = {
-          auto_sync = lib.mkDefault true;
-          update_check = lib.mkDefault false;
+        settings = lib.mkMerge [
+          {
+            auto_sync = true;
+            update_check = false;
 
-          # Prefer history discovery that works well in big git repos.
-          search_mode = lib.mkDefault "daemon-fuzzy";
-          filter_mode = lib.mkDefault "workspace";
-          workspaces = lib.mkDefault true;
+            # Prefer history discovery that works well in big git repos.
+            search_mode = "daemon-fuzzy";
+            filter_mode = "workspace";
+            workspaces = true;
 
-          style = lib.mkDefault "compact";
-          inline_height = lib.mkDefault 20;
-          show_preview = lib.mkDefault true;
-          show_help = lib.mkDefault false;
-          enter_accept = lib.mkDefault true;
-        };
+            style = "compact";
+            inline_height = 20;
+            show_preview = true;
+            show_help = false;
+            enter_accept = true;
+          }
+          cfg.atuin.settings
+        ];
       };
 
       bash = {


### PR DESCRIPTION
This pull request enhances the configuration of the `atuin` program in the `home/programs/terminal.nix` file by adding a set of default settings to improve usability and integration. The main focus is on enabling better history search, workspace support, and user interface preferences.

**Atuin configuration improvements:**

* Added a `settings` block for `atuin` with sensible defaults, including enabling automatic sync, disabling update checks, and optimizing search and filter modes for large git repositories.
* Enabled workspace support and adjusted the UI to use a compact style, set an inline height of 20, show a preview, hide help by default, and allow pressing enter to accept selections.