### PR TITLE
🔧 fix(security): disable AppArmor for some services

### DIFF
--- a/hosts/avalanche/avalanche.nix
+++ b/hosts/avalanche/avalanche.nix
@@ -63,10 +63,10 @@ in
     };
 
     # Pull specific packages from different nixpkgs inputs
-    # overlays.fromInputs = {
-    #   nixpkgs-unstable = [ "vscode" ];
-    #   nixpkgs-stable = [ "vesktop" ];
-    # };
+    overlays.fromInputs = {
+      nixpkgs-unstable = [ "apparmor" ];
+      # nixpkgs-stable = [ "vesktop" ];
+    };
 
     services = {
       resolved = {

--- a/hosts/kaizer/kaizer.nix
+++ b/hosts/kaizer/kaizer.nix
@@ -57,10 +57,10 @@ in
 
     boot.lanzaboote.enable = lib.mkForce false;
 
-    # overlays.fromInputs = {
-    #   nixpkgs-unstable = [ "firefox" "discord" ];
-    #   nixpkgs-stable = [ "vesktop" ];
-    # };
+    overlays.fromInputs = {
+      nixpkgs-unstable = [ "apparmor" ];
+      # nixpkgs-stable = [ "vesktop" ];
+    };
 
     hardware.nvidia = {
       enable = true;

--- a/hosts/snowfall/snowfall.nix
+++ b/hosts/snowfall/snowfall.nix
@@ -75,11 +75,11 @@ in
 
     ## Pull specific packages from different nixpkgs inputs
     overlays.fromInputs = {
-      # nixpkgs-unstable = [ "lutris" ];
-      nixpkgs-stable = [
-        "podman-desktop"
-        "teams-for-linux"
-      ];
+      nixpkgs-unstable = [ "apparmor" ];
+      # nixpkgs-stable = [
+      #   "podman-desktop"
+      #   "teams-for-linux"
+      # ];
     };
     #
     ## Add custom overlays


### PR DESCRIPTION
This pull request updates the PAM service configuration for both GNOME and KDE desktop flavors to temporarily disable AppArmor integration for certain services. This change is necessary due to a current limitation in nixpkgs unstable, which rejects PAM/AppArmor integration when the PAM stack uses relative includes like "login".

Configuration updates for PAM/AppArmor integration:

* GNOME flavor (`modules/desktop/flavors/gnome.nix`):
  - Disabled AppArmor integration (`enableAppArmor = false`) for the `gdm` and `login` PAM services, with a comment explaining the nixpkgs unstable limitation.

* KDE flavor (`modules/desktop/flavors/kde.nix`):
  - Disabled AppArmor integration (`enableAppArmor = false`) for the `login`, `sddm`, and `kwallet` PAM services, with a similar explanatory comment.