### PR TITLE
Module override bug patch

### DIFF
--- a/modules/core/nixpkgs-module-overrides.nix
+++ b/modules/core/nixpkgs-module-overrides.nix
@@ -1,0 +1,17 @@
+# Temporary NixOS module overrides - pin a fixed module from a different
+# nixpkgs input while waiting for a fix to propagate to the primary channel.
+#
+# Pattern:
+#   disabledModules = [ "<relative/path>.nix" ];   # disable buggy version
+#   imports = [ "${inputs.<input>}/nixos/modules/<relative/path>.nix" ];
+#
+# Remove each entry once `nix flake update` picks up the upstream fix.
+{ inputs, ... }:
+{
+  # https://github.com/NixOS/nixpkgs/issues/511465
+  # pam.nix generates non-absolute PAM module paths (e.g. "login") in
+  # security.apparmor.includes; AppArmor rejects them.
+  # Fix: https://github.com/NixOS/nixpkgs/pull/511479 (merged nixos-unstable-small)
+  disabledModules = [ "security/pam.nix" ];
+  imports = [ "${inputs.nixpkgs-unstable}/nixos/modules/security/pam.nix" ];
+}

--- a/vms/flake-microvms.nix
+++ b/vms/flake-microvms.nix
@@ -35,7 +35,10 @@ let
     modules:
     nixpkgs.lib.nixosSystem {
       inherit system;
-      modules = [ fromInputsOverlays ] ++ modules;
+      modules = [
+        fromInputsOverlays
+        ../modules/core/nixpkgs-module-overrides.nix
+      ] ++ modules;
 
       specialArgs = {
         inherit inputs system VARS;

--- a/vms/flake-microvms.nix
+++ b/vms/flake-microvms.nix
@@ -38,7 +38,8 @@ let
       modules = [
         fromInputsOverlays
         ../modules/core/nixpkgs-module-overrides.nix
-      ] ++ modules;
+      ]
+      ++ modules;
 
       specialArgs = {
         inherit inputs system VARS;


### PR DESCRIPTION
This pull request introduces a temporary override for the `pam.nix` NixOS module to address a bug in the upstream `nixpkgs` channel. The override disables the current (buggy) module and imports a fixed version from the `nixpkgs-unstable` input until the fix is available in the primary channel.

Temporary module override:

* Added `modules/core/nixpkgs-module-overrides.nix` to disable the problematic `security/pam.nix` module and import a corrected version from `nixpkgs-unstable`, working around an upstream bug with non-absolute PAM module paths.