### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776802542,
-        "narHash": "sha256-8WtuUiFeRSr4IKcN5Utwnm449aNETbiOneWeeVnrUe0=",
+        "lastModified": 1776812701,
+        "narHash": "sha256-ksCsYCLZCzbfW8JESg+GPe66tLhPJvFcUzpN6YiiZOk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f6be801ce2dbcd3e77be762e97b238e72b2350c8",
+        "rev": "fe89a94bf5cd2db24e4a7d08248bd6a6d967b338",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/f6be801' (2026-04-21)
  → 'github:nix-community/NUR/fe89a94' (2026-04-21)
```