### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776812701,
-        "narHash": "sha256-ksCsYCLZCzbfW8JESg+GPe66tLhPJvFcUzpN6YiiZOk=",
+        "lastModified": 1776829882,
+        "narHash": "sha256-G3keSZS+I6zjBu67uk6Fw6v/IHiFuIMSUgsiC7Q31TM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fe89a94bf5cd2db24e4a7d08248bd6a6d967b338",
+        "rev": "daed3a795bd1df6f8c0e060ab3fdf2a8820d0653",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/fe89a94' (2026-04-21)
  → 'github:nix-community/NUR/daed3a7' (2026-04-22)
```