### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -559,11 +559,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1775490113,
-        "narHash": "sha256-2ZBhDNZZwYkRmefK5XLOusCJHnoeKkoN95hoSGgMxWM=",
+        "lastModified": 1776830795,
+        "narHash": "sha256-PAfvLwuHc1VOvsLcpk6+HDKgMEibvZjCNvbM1BJOA7o=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "c775c2772ba56e906cbeb4e0b2db19079ef11ff7",
+        "rev": "72674a6b5599e844c045ae7449ba91f803d44ebc",
         "type": "github"
       },
       "original": {
@@ -638,11 +638,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1776750258,
-        "narHash": "sha256-jab3OFEK7MpiAolaLBjvIxdf258UWvvusWxPJPE5ito=",
+        "lastModified": 1776791558,
+        "narHash": "sha256-NMlwGUnH5Srr+j/quFkbcgLaLvoKiX71jFFPrxLQx4k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8d73c2809cb39eecce6284c38100e69a6064e5d9",
+        "rev": "8d1daef70dcad2dc6b5e52426caf744489cea4db",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776829882,
-        "narHash": "sha256-G3keSZS+I6zjBu67uk6Fw6v/IHiFuIMSUgsiC7Q31TM=",
+        "lastModified": 1776838727,
+        "narHash": "sha256-e+gkJW94QCmZ4jRfOPvA+ndkjrE1midxpKTpnPdaV2k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "daed3a795bd1df6f8c0e060ab3fdf2a8820d0653",
+        "rev": "d4e914c8f759c48b4f6b002c58fe6882bd18a840",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/c775c27' (2026-04-06)
  → 'github:NixOS/nixos-hardware/72674a6' (2026-04-22)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/8d73c28' (2026-04-21)
  → 'github:NixOS/nixpkgs/8d1daef' (2026-04-21)
• Updated input 'nur':
    'github:nix-community/NUR/daed3a7' (2026-04-22)
  → 'github:nix-community/NUR/d4e914c' (2026-04-22)
```