### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776838727,
-        "narHash": "sha256-e+gkJW94QCmZ4jRfOPvA+ndkjrE1midxpKTpnPdaV2k=",
+        "lastModified": 1776848998,
+        "narHash": "sha256-JpJHcdFiopUZ/em5ykOyaKIlsIT53XhbnhofWSKDq50=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d4e914c8f759c48b4f6b002c58fe6882bd18a840",
+        "rev": "4370dcd45d03e8777539d943041e0d26620ee9bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/d4e914c' (2026-04-22)
  → 'github:nix-community/NUR/4370dcd' (2026-04-22)
```