### PR TITLE
fixed assertion and recursion risk

### DIFF
--- a/vms/gitea.nix
+++ b/vms/gitea.nix
@@ -2,6 +2,7 @@
   config,
   pkgs,
   lib,
+  system,
   inputs,
   VARS,
   consts,
@@ -23,7 +24,7 @@ let
     sha256 = "0sw830n4n2cx1hn6aqr9yxdyp34s67raxap6s5ir9v5bkzjd3d7y";
   };
   giteaPinnedPkgs = import giteaPinnedNixpkgs {
-    inherit (pkgs) system;
+    inherit system;
     inherit (config.nixpkgs) config;
   };
 in
@@ -55,8 +56,8 @@ in
 
   assertions = [
     {
-      assertion = lib.hasPrefix "1.26" pkgs.gitea.version;
-      message = "gitea-pin: expected 1.26.x (1.26.0+) from nixpkgs@${giteaPinRev}, got ${pkgs.gitea.version}. Delete the overlay when unstable catches up.";
+      assertion = lib.versionAtLeast pkgs.gitea.version "1.26.0";
+      message = "gitea-pin: expected >= 1.26.0 from nixpkgs@${giteaPinRev}, got ${pkgs.gitea.version}. Delete the overlay when unstable catches up.";
     }
   ];
 


### PR DESCRIPTION
This pull request makes several improvements to the `vms/gitea.nix` file, mainly focused on how the system architecture is passed to the pinned Gitea package set and how Gitea version assertions are handled. The most important changes are grouped below:

**System Architecture Handling:**

* The `system` parameter is now explicitly passed to the module, rather than being inherited from `pkgs`. This change clarifies which system architecture is used when importing the pinned Gitea Nixpkgs, making the code more robust and explicit. [[1]](diffhunk://#diff-7e8de5d54ba02db95f5bea8fb287036f6d8f4f96b4e36b41e8a869a5d89a966aR5) [[2]](diffhunk://#diff-7e8de5d54ba02db95f5bea8fb287036f6d8f4f96b4e36b41e8a869a5d89a966aL26-R27)

**Version Assertion Logic:**

* The assertion that checks the Gitea version has been updated to use `lib.versionAtLeast`, ensuring that any version `>= 1.26.0` is accepted, rather than just versions with the `1.26` prefix. This makes the check more flexible and future-proof. The assertion message was also updated accordingly.