### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776869996,
-        "narHash": "sha256-1OBvTrMpG3aVYkfRv3reM+vGWS5zQCUpuOZ1HCc46ig=",
+        "lastModified": 1776879051,
+        "narHash": "sha256-VygjmVGXoLLGg3DH65Kd0SN1gITk6V1Me3jwY0MVQfk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "afd5607108220437abc9d9568538fdda5347a6f8",
+        "rev": "f9d2b2da819d1428d75299582421371c1e99fc75",
         "type": "github"
       },
       "original": {
@@ -622,11 +622,11 @@
     },
     "nixpkgs-stable-latest": {
       "locked": {
-        "lastModified": 1776560675,
-        "narHash": "sha256-p68udKWWh7+V4ZPpcMDq0gTHWNZJnr4JPI+kHPPE40o=",
+        "lastModified": 1776734388,
+        "narHash": "sha256-vl3dkhlE5gzsItuHoEMVe+DlonsK+0836LIRDnm6MXQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e07580dae39738e46609eaab8b154de2488133ce",
+        "rev": "10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac",
         "type": "github"
       },
       "original": {
@@ -638,11 +638,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1776791558,
-        "narHash": "sha256-NMlwGUnH5Srr+j/quFkbcgLaLvoKiX71jFFPrxLQx4k=",
+        "lastModified": 1776864103,
+        "narHash": "sha256-osZwVCgGCfxrdi3W4x+zM31B60NvfDNe7oR3FPi+qyI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8d1daef70dcad2dc6b5e52426caf744489cea4db",
+        "rev": "9cadaf6932b7c926e468f777549d57f04a7212da",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776867443,
-        "narHash": "sha256-UiZEl9wLMdnvZZIf5XvBAyX4Nh6kOB5M3FwA0rERHxY=",
+        "lastModified": 1776879409,
+        "narHash": "sha256-3viHU1zlCT1dJIP+8yGdOmfLZL/uKb2JHDq3LML81+A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "da52d331fb0d1a5f1e4a8e51f105c8c05dd45d07",
+        "rev": "3476f6ea1a7365665503ae4fa1dd6c84e60b28d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/afd5607' (2026-04-22)
  → 'github:nix-community/home-manager/f9d2b2d' (2026-04-22)
• Updated input 'nixpkgs-stable-latest':
    'github:NixOS/nixpkgs/e07580d' (2026-04-19)
  → 'github:NixOS/nixpkgs/10e7ad5' (2026-04-21)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/8d1daef' (2026-04-21)
  → 'github:NixOS/nixpkgs/9cadaf6' (2026-04-22)
• Updated input 'nur':
    'github:nix-community/NUR/da52d33' (2026-04-22)
  → 'github:nix-community/NUR/3476f6e' (2026-04-22)
```