### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776879051,
-        "narHash": "sha256-VygjmVGXoLLGg3DH65Kd0SN1gITk6V1Me3jwY0MVQfk=",
+        "lastModified": 1776891022,
+        "narHash": "sha256-vEe2f4NEhMvaNDpM1pla4hteaIIGQyAMKUfIBPLasr0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f9d2b2da819d1428d75299582421371c1e99fc75",
+        "rev": "508daf831ab8d1b143d908239c39a7d8d39561b2",
         "type": "github"
       },
       "original": {
@@ -234,11 +234,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1776864544,
-        "narHash": "sha256-Erndbsry1Crh7t0BGGF7TC9zNcttZfAllrXEPco20iw=",
+        "lastModified": 1776889279,
+        "narHash": "sha256-oKSqtplor0a6xzWRq6KL2um504x5VZ0Afw1N6ZiiC48=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "d4dd299d8082097068d3d05bef7198424fbb8dfb",
+        "rev": "300cdb7c3241969ac04cd02a5e13010a28ebb830",
         "type": "github"
       },
       "original": {
@@ -638,11 +638,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1776864103,
-        "narHash": "sha256-osZwVCgGCfxrdi3W4x+zM31B60NvfDNe7oR3FPi+qyI=",
+        "lastModified": 1776874119,
+        "narHash": "sha256-uzwLUOyDwS1jssZgF/5IrEuphizt/djitkQ41d4NGMY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9cadaf6932b7c926e468f777549d57f04a7212da",
+        "rev": "911507e40485ac39ec4b71a3849809f50ee47a40",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776879409,
-        "narHash": "sha256-3viHU1zlCT1dJIP+8yGdOmfLZL/uKb2JHDq3LML81+A=",
+        "lastModified": 1776892179,
+        "narHash": "sha256-SJsBtqK1dOmeIqFxar+eLtwfeW/jpzYLau5UpK2RMIw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3476f6ea1a7365665503ae4fa1dd6c84e60b28d7",
+        "rev": "a04326000e547ae325d5ab4aca972e8eb40d691f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/f9d2b2d' (2026-04-22)
  → 'github:nix-community/home-manager/508daf8' (2026-04-22)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/d4dd299' (2026-04-22)
  → 'github:hyprwm/Hyprland/300cdb7' (2026-04-22)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/9cadaf6' (2026-04-22)
  → 'github:NixOS/nixpkgs/911507e' (2026-04-22)
• Updated input 'nur':
    'github:nix-community/NUR/3476f6e' (2026-04-22)
  → 'github:nix-community/NUR/a043260' (2026-04-22)
```