### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776914346,
-        "narHash": "sha256-Dfybx8+6x87gJpQE9Ex81DN8PNQzb7SfT+9upxsHHOw=",
+        "lastModified": 1776925631,
+        "narHash": "sha256-8Zm13EJYQIEQ/KTMghNKMLdDUEgXT+xZ83Egs43XVjA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "302c00d015617406b9c10f753d34c51f8a7b1b63",
+        "rev": "7e1319d6088d002c861c6e1c32f8208d39300d26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/302c00d' (2026-04-23)
  → 'github:nix-community/NUR/7e1319d' (2026-04-23)
```