### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776936122,
-        "narHash": "sha256-muD54/P4wXsXDiikzziWlGNdWHuhbYkAZsyOBJuXf0Q=",
+        "lastModified": 1776944625,
+        "narHash": "sha256-ihSlvz78w6qtAFybDM3ft5iJfnw1xgLsoLHZKwvHAG4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c1bf81731871de0d39c2f7734e845edc3b8f9b2b",
+        "rev": "ef82d5c0b71c3defbb99e842bc5ffae3dc591937",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/c1bf817' (2026-04-23)
  → 'github:nix-community/NUR/ef82d5c' (2026-04-23)
```