### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777022525,
-        "narHash": "sha256-l13MwfgrQnyX8NwCBdPPtnHfCA7anIHlPNVEN+bMdvU=",
+        "lastModified": 1777023316,
+        "narHash": "sha256-zkKEQXimNybHKbdQRHbMsGMh7qDtgwCky4zI+Av6Mt0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "72cebf16808cc79262a159a4f81d8e9ba43e074f",
+        "rev": "946b6ddacf4980464792e9df227f749d30dd3e2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/72cebf1' (2026-04-24)
  → 'github:nix-community/NUR/946b6dd' (2026-04-24)
```