### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777004352,
-        "narHash": "sha256-SV+9PgNwZ8jHVCjK6YaCBzaheLSW7cDnm5DpOYrD8Vw=",
+        "lastModified": 1777054018,
+        "narHash": "sha256-tTNS7V6xN/LX1KZ0TrdOnj375ZrsUlLoce4qxZwDN9U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6012cf1fed3eba66115f3fd117b9be6bd2a15b2f",
+        "rev": "ffbd94a1c9d7d3e1258e51c084ab2109da04f2b1",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777039524,
-        "narHash": "sha256-B8JItJqoioKiNMtVE5sCZC7EPH6xQ5XB93o19cO8HWs=",
+        "lastModified": 1777050782,
+        "narHash": "sha256-rourMcvw6wQiFVSsUWG6HxjN8osB6qtnQNOSZ4NCiFQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2bb24bf6cc7c6f9cbe547b02b359090cf79b57fe",
+        "rev": "bf74b124845af237ff82976a37f74367ad599f77",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/6012cf1' (2026-04-24)
  → 'github:nix-community/home-manager/ffbd94a' (2026-04-24)
• Updated input 'nur':
    'github:nix-community/NUR/2bb24bf' (2026-04-24)
  → 'github:nix-community/NUR/bf74b12' (2026-04-24)
```