### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -654,11 +654,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1776548001,
-        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777050782,
-        "narHash": "sha256-rourMcvw6wQiFVSsUWG6HxjN8osB6qtnQNOSZ4NCiFQ=",
+        "lastModified": 1777064643,
+        "narHash": "sha256-8nmgCkvRyjo4cshbIIRksK0iHl5WuvPo6eWynqIbm3U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bf74b124845af237ff82976a37f74367ad599f77",
+        "rev": "3424cd2c1f586d049087c1ab66152e92b2929111",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/b12141e' (2026-04-18)
  → 'github:NixOS/nixpkgs/0726a0e' (2026-04-22)
• Updated input 'nur':
    'github:nix-community/NUR/bf74b12' (2026-04-24)
  → 'github:nix-community/NUR/3424cd2' (2026-04-24)
```