### PR TITLE
Dev matrix

### DIFF
--- a/modules/services/matrix-synapse.nix
+++ b/modules/services/matrix-synapse.nix
@@ -132,6 +132,27 @@ in
       };
     };
 
+    vacuumTimer = {
+      enable = lib.mkEnableOption "periodic VACUUM ANALYZE on the Synapse DB";
+
+      interval = lib.mkOption {
+        type = lib.types.str;
+        default = "monthly";
+        description = "systemd calendar expression for how often to run VACUUM ANALYZE.";
+        example = "weekly";
+      };
+    };
+
+    dbSizeLogger = {
+      enable = lib.mkEnableOption "periodic DB size logging to the journal";
+
+      interval = lib.mkOption {
+        type = lib.types.str;
+        default = "weekly";
+        description = "systemd calendar expression for how often to log DB size.";
+      };
+    };
+
     settings = lib.mkOption {
       type = lib.types.attrs;
       default = { };
@@ -152,6 +173,14 @@ in
                  LC_COLLATE = "C"
                  LC_CTYPE = "C";
         '';
+
+        settings = {
+          autovacuum_vacuum_scale_factor = 0.05;
+          autovacuum_analyze_scale_factor = 0.02;
+          autovacuum_naptime = "30s";
+          autovacuum_max_workers = 4;
+          autovacuum_vacuum_cost_limit = 2000;
+        };
       };
 
       matrix-synapse = {
@@ -289,6 +318,95 @@ in
       };
     };
 
+    systemd.services.matrix-synapse-pg-tuning = lib.mkIf cfg.database.createLocally {
+      description = "Apply per-table autovacuum settings for Synapse hot tables";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "matrix-synapse.service"
+        "postgresql.service"
+      ];
+      requires = [ "postgresql.service" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        User = "matrix-synapse";
+      };
+      script = ''
+        ${config.services.postgresql.package}/bin/psql \
+          -h /run/postgresql \
+          -d matrix-synapse \
+          -c "ALTER TABLE state_groups_state SET (autovacuum_vacuum_scale_factor = 0.02);" \
+          -c "ALTER TABLE event_json SET (autovacuum_vacuum_scale_factor = 0.05);" \
+          -c "ALTER TABLE event_edges SET (autovacuum_vacuum_scale_factor = 0.05);" \
+          -c "ALTER TABLE event_auth SET (autovacuum_vacuum_scale_factor = 0.05);" \
+          -c "ALTER TABLE events SET (autovacuum_vacuum_scale_factor = 0.05);"
+      '';
+    };
+
+    systemd.services.matrix-synapse-vacuum =
+      lib.mkIf (cfg.vacuumTimer.enable && cfg.database.createLocally)
+        {
+          description = "VACUUM ANALYZE the Synapse PostgreSQL database";
+          after = [
+            "matrix-synapse.service"
+            "postgresql.service"
+          ];
+          requires = [ "postgresql.service" ];
+          serviceConfig = {
+            Type = "oneshot";
+            User = "matrix-synapse";
+          };
+          script = ''
+            ${config.services.postgresql.package}/bin/psql \
+              -h /run/postgresql \
+              -d matrix-synapse \
+              -c "VACUUM (ANALYZE, VERBOSE);"
+          '';
+        };
+
+    systemd.timers.matrix-synapse-vacuum =
+      lib.mkIf (cfg.vacuumTimer.enable && cfg.database.createLocally)
+        {
+          description = "Run VACUUM ANALYZE on the Synapse DB periodically";
+          wantedBy = [ "timers.target" ];
+          timerConfig = {
+            OnCalendar = cfg.vacuumTimer.interval;
+            Persistent = true;
+            RandomizedDelaySec = "1h";
+          };
+        };
+
+    systemd.services.matrix-synapse-db-size =
+      lib.mkIf (cfg.dbSizeLogger.enable && cfg.database.createLocally)
+        {
+          description = "Log Synapse PostgreSQL database size to the journal";
+          after = [ "postgresql.service" ];
+          requires = [ "postgresql.service" ];
+          serviceConfig = {
+            Type = "oneshot";
+            User = "matrix-synapse";
+          };
+          script = ''
+            ${config.services.postgresql.package}/bin/psql \
+              -h /run/postgresql \
+              -d matrix-synapse \
+              -c "SELECT pg_size_pretty(pg_database_size('matrix-synapse')) AS db_size;" \
+              -c "SELECT relname, pg_size_pretty(pg_total_relation_size(oid)) AS total_size FROM pg_class WHERE relkind = 'r' ORDER BY pg_total_relation_size(oid) DESC LIMIT 10;"
+          '';
+        };
+
+    systemd.timers.matrix-synapse-db-size =
+      lib.mkIf (cfg.dbSizeLogger.enable && cfg.database.createLocally)
+        {
+          description = "Log Synapse DB size to the journal periodically";
+          wantedBy = [ "timers.target" ];
+          timerConfig = {
+            OnCalendar = cfg.dbSizeLogger.interval;
+            Persistent = true;
+            RandomizedDelaySec = "1h";
+          };
+        };
+
     assertions = [
       {
         assertion = !cfg.reverseProxy.enable || cfg.reverseProxy.domain != null;
@@ -305,6 +423,14 @@ in
       {
         assertion = !cfg.autoCompressor.enable || cfg.database.createLocally;
         message = "sys.services.matrix-synapse.autoCompressor requires database.createLocally = true (local PostgreSQL)";
+      }
+      {
+        assertion = !cfg.vacuumTimer.enable || cfg.database.createLocally;
+        message = "sys.services.matrix-synapse.vacuumTimer requires database.createLocally = true";
+      }
+      {
+        assertion = !cfg.dbSizeLogger.enable || cfg.database.createLocally;
+        message = "sys.services.matrix-synapse.dbSizeLogger requires database.createLocally = true";
       }
       (traefikLib.mkCfTunnelAssertion {
         name = "matrix-synapse";

--- a/modules/services/matrix-synapse.nix
+++ b/modules/services/matrix-synapse.nix
@@ -333,6 +333,8 @@ in
       };
       script = ''
         ${config.services.postgresql.package}/bin/psql \
+          --no-psqlrc \
+          --set=ON_ERROR_STOP=1 \
           -h /run/postgresql \
           -d matrix-synapse \
           -c "ALTER TABLE state_groups_state SET (autovacuum_vacuum_scale_factor = 0.02);" \
@@ -360,7 +362,7 @@ in
             ${config.services.postgresql.package}/bin/psql \
               -h /run/postgresql \
               -d matrix-synapse \
-              -c "VACUUM (ANALYZE, VERBOSE);"
+              -c "VACUUM (ANALYZE);"
           '';
         };
 
@@ -388,6 +390,8 @@ in
           };
           script = ''
             ${config.services.postgresql.package}/bin/psql \
+              --no-psqlrc \
+              --set=ON_ERROR_STOP=1 \
               -h /run/postgresql \
               -d matrix-synapse \
               -c "SELECT pg_size_pretty(pg_database_size('matrix-synapse')) AS db_size;" \

--- a/modules/services/matrix-synapse.nix
+++ b/modules/services/matrix-synapse.nix
@@ -360,6 +360,8 @@ in
           };
           script = ''
             ${config.services.postgresql.package}/bin/psql \
+              --no-psqlrc \
+              --set=ON_ERROR_STOP=1 \
               -h /run/postgresql \
               -d matrix-synapse \
               -c "VACUUM (ANALYZE);"

--- a/vms/flake-microvms.nix
+++ b/vms/flake-microvms.nix
@@ -19,16 +19,16 @@ let
   };
 
   /*
-  paperlessBuildWorkaround = {
-    nixpkgs.overlays = [
-      (_final: prev: {
-        "paperless-ngx" = prev."paperless-ngx".overrideAttrs (_old: {
-          doCheck = false;
-          doInstallCheck = false;
-        });
-      })
-    ];
-  };
+    paperlessBuildWorkaround = {
+      nixpkgs.overlays = [
+        (_final: prev: {
+          "paperless-ngx" = prev."paperless-ngx".overrideAttrs (_old: {
+            doCheck = false;
+            doInstallCheck = false;
+          });
+        })
+      ];
+    };
   */
 
   mkMicrovm =

--- a/vms/matrix-synapse.nix
+++ b/vms/matrix-synapse.nix
@@ -353,7 +353,15 @@ in
 
         database.createLocally = true;
         urlPreview.enable = true;
-        autoCompressor.enable = true;
+
+        autoCompressor = {
+          enable = true;
+          interval = "daily";
+          chunksToCompress = 1000;
+        };
+
+        vacuumTimer.enable = true;
+        dbSizeLogger.enable = true;
 
         extraConfigFiles = [
           "/run/matrix-synapse-secret/shared-secret.yaml"
@@ -384,8 +392,38 @@ in
           # Suppress warning about trusting the default matrix.org key server
           suppress_key_server_warning = true;
 
-          # Auto-purge cached remote media after 90 days to save disk
-          media_retention.remote_media_lifetime = "90d";
+          # Auto-purge media after inactivity: remote 90d, local uploads 2y
+          media_retention = {
+            remote_media_lifetime = "90d";
+            local_media_lifetime = "2y";
+          };
+
+          # Server-wide event retention: purge messages older than 2y.
+          # Does not affect state events; federated servers enforce their own policy.
+          retention = {
+            enabled = true;
+            default_policy = {
+              min_lifetime = "1d";
+              max_lifetime = "2y";
+            };
+            allowed_lifetime_min = "1d";
+            allowed_lifetime_max = "10y";
+            purge_jobs = [
+              {
+                longest_max_lifetime = "3d";
+                interval = "12h";
+              }
+              {
+                shortest_max_lifetime = "3d";
+                longest_max_lifetime = "1w";
+                interval = "1d";
+              }
+              {
+                shortest_max_lifetime = "1w";
+                interval = "2d";
+              }
+            ];
+          };
 
           # Allow uploads up to 90 MB
           max_upload_size = "90M";


### PR DESCRIPTION
This pull request introduces several improvements to the Matrix Synapse NixOS module, focusing on enhanced database maintenance, monitoring, and data retention policies. The main changes add new options and systemd timers for automatic database vacuuming and size logging, fine-tune PostgreSQL autovacuum settings, and expand event/media retention policies for better resource management and compliance.

**Database Maintenance and Monitoring:**
- Added `vacuumTimer` and `dbSizeLogger` options to enable and schedule periodic VACUUM ANALYZE operations and database size logging via systemd timers for local PostgreSQL setups. [[1]](diffhunk://#diff-9e2855f12fb93b996844f184498b5b6789515477a29bb5c6b00fdf3e262e37b0R135-R155) [[2]](diffhunk://#diff-9e2855f12fb93b996844f184498b5b6789515477a29bb5c6b00fdf3e262e37b0R321-R409)
- Introduced a systemd service (`matrix-synapse-pg-tuning`) that applies per-table autovacuum tuning for Synapse's most active tables, improving database performance.
- Set more aggressive global PostgreSQL autovacuum parameters to reduce table bloat and improve responsiveness.

**Configuration and Safety:**
- Added assertions to ensure that the new maintenance features (`vacuumTimer`, `dbSizeLogger`) are only enabled when the database is managed locally, preventing misconfiguration.

**Data Retention Policies:**
- Updated the example VM configuration to use the new options, and expanded the Synapse server configuration to include:
  - More granular media retention (separate lifetimes for remote and local media).
  - A comprehensive event retention policy with scheduled purge jobs to enforce message lifetime limits, supporting compliance and disk management.

These changes collectively make it easier to operate a healthy, well-maintained Matrix Synapse instance with automated database care and robust data retention controls.