### PR TITLE
Dev grafana

### DIFF
--- a/dashboards/shared/arr-services.json
+++ b/dashboards/shared/arr-services.json
@@ -1,0 +1,2019 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Service Status",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "Down"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "Up"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "color": "gray",
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "up{job=\"arr-exporter\",arr_service=\"sonarr\"}",
+          "instant": true,
+          "legendFormat": "Sonarr",
+          "refId": "A"
+        }
+      ],
+      "title": "Sonarr",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "Down"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "Up"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "color": "gray",
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "up{job=\"arr-exporter\",arr_service=\"radarr\"}",
+          "instant": true,
+          "legendFormat": "Radarr",
+          "refId": "A"
+        }
+      ],
+      "title": "Radarr",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "Down"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "Up"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "color": "gray",
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "up{job=\"arr-exporter\",arr_service=\"prowlarr\"}",
+          "instant": true,
+          "legendFormat": "Prowlarr",
+          "refId": "A"
+        }
+      ],
+      "title": "Prowlarr",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "Down"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "Up"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "color": "gray",
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "up{job=\"arr-exporter\",arr_service=\"bazarr\"}",
+          "instant": true,
+          "legendFormat": "Bazarr",
+          "refId": "A"
+        }
+      ],
+      "title": "Bazarr",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "Down"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "Up"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "color": "gray",
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "up{job=\"arr-exporter\",arr_service=\"readarr\"}",
+          "instant": true,
+          "legendFormat": "Readarr",
+          "refId": "A"
+        }
+      ],
+      "title": "Readarr",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "Down"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "Up"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "color": "gray",
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "up{job=\"arr-exporter\",arr_service=\"lidarr\"}",
+          "instant": true,
+          "legendFormat": "Lidarr",
+          "refId": "A"
+        }
+      ],
+      "title": "Lidarr",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 8,
+      "panels": [],
+      "title": "Sonarr",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 5
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sonarr_series_total{job=\"arr-exporter\"}",
+          "instant": true,
+          "legendFormat": "Series",
+          "refId": "A"
+        }
+      ],
+      "title": "Series",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 5
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sonarr_episode_monitored_total{job=\"arr-exporter\"}",
+          "instant": true,
+          "legendFormat": "Monitored Episodes",
+          "refId": "A"
+        }
+      ],
+      "title": "Monitored Episodes",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 5
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sonarr_queue_total{job=\"arr-exporter\"}",
+          "instant": true,
+          "legendFormat": "Queue",
+          "refId": "A"
+        }
+      ],
+      "title": "Queue",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 5
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sonarr_episode_missing_total{job=\"arr-exporter\"}",
+          "instant": true,
+          "legendFormat": "Missing Episodes",
+          "refId": "A"
+        }
+      ],
+      "title": "Missing Episodes",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 13,
+      "panels": [],
+      "title": "Radarr",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 10
+      },
+      "id": 14,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "radarr_movie_total{job=\"arr-exporter\"}",
+          "instant": true,
+          "legendFormat": "Movies",
+          "refId": "A"
+        }
+      ],
+      "title": "Movies",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 10
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "radarr_movie_downloaded_total{job=\"arr-exporter\"}",
+          "instant": true,
+          "legendFormat": "Downloaded",
+          "refId": "A"
+        }
+      ],
+      "title": "Downloaded",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 3
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 10
+      },
+      "id": 16,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "radarr_queue_total{job=\"arr-exporter\"}",
+          "instant": true,
+          "legendFormat": "Queue",
+          "refId": "A"
+        }
+      ],
+      "title": "Queue",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 10
+      },
+      "id": 17,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "radarr_movie_missing_total{job=\"arr-exporter\"}",
+          "instant": true,
+          "legendFormat": "Missing",
+          "refId": "A"
+        }
+      ],
+      "title": "Missing Movies",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 18,
+      "panels": [],
+      "title": "Prowlarr",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 15
+      },
+      "id": 19,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "prowlarr_indexer_count{job=\"arr-exporter\",status=\"enabled\"}",
+          "instant": true,
+          "legendFormat": "Enabled Indexers",
+          "refId": "A"
+        }
+      ],
+      "title": "Enabled Indexers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1000
+              },
+              {
+                "color": "red",
+                "value": 5000
+              }
+            ]
+          },
+          "unit": "ms",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 15
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "avg(prowlarr_indexer_average_response_time_ms{job=\"arr-exporter\"})",
+          "instant": true,
+          "legendFormat": "Avg Response Time",
+          "refId": "A"
+        }
+      ],
+      "title": "Avg Indexer Response",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 15
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "rate(prowlarr_indexer_query_count{job=\"arr-exporter\"}[5m])",
+          "instant": false,
+          "range": true,
+          "legendFormat": "{{indexer}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Indexer Query Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 22,
+      "panels": [],
+      "title": "Bazarr",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 23,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "bazarr_movies_missing_subtitles_total{job=\"arr-exporter\"}",
+          "instant": true,
+          "legendFormat": "Movies Missing Subs",
+          "refId": "A"
+        }
+      ],
+      "title": "Movies Missing Subtitles",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 24,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "bazarr_series_missing_subtitles_total{job=\"arr-exporter\"}",
+          "instant": true,
+          "legendFormat": "Series Missing Subs",
+          "refId": "A"
+        }
+      ],
+      "title": "Series Missing Subtitles",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 25,
+      "panels": [],
+      "title": "Readarr",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 25
+      },
+      "id": 26,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "readarr_author_total{job=\"arr-exporter\"}",
+          "instant": true,
+          "legendFormat": "Authors",
+          "refId": "A"
+        }
+      ],
+      "title": "Authors",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 25
+      },
+      "id": 27,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "readarr_book_total{job=\"arr-exporter\"}",
+          "instant": true,
+          "legendFormat": "Books",
+          "refId": "A"
+        }
+      ],
+      "title": "Books",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 3
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 25
+      },
+      "id": 28,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "readarr_queue_total{job=\"arr-exporter\"}",
+          "instant": true,
+          "legendFormat": "Queue",
+          "refId": "A"
+        }
+      ],
+      "title": "Queue",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 25
+      },
+      "id": 29,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "readarr_book_missing_total{job=\"arr-exporter\"}",
+          "instant": true,
+          "legendFormat": "Missing Books",
+          "refId": "A"
+        }
+      ],
+      "title": "Missing Books",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 30,
+      "panels": [],
+      "title": "Lidarr",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 30
+      },
+      "id": 31,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "lidarr_artist_total{job=\"arr-exporter\"}",
+          "instant": true,
+          "legendFormat": "Artists",
+          "refId": "A"
+        }
+      ],
+      "title": "Artists",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 30
+      },
+      "id": 32,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "lidarr_album_total{job=\"arr-exporter\"}",
+          "instant": true,
+          "legendFormat": "Albums",
+          "refId": "A"
+        }
+      ],
+      "title": "Albums",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 3
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 30
+      },
+      "id": 33,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "lidarr_queue_total{job=\"arr-exporter\"}",
+          "instant": true,
+          "legendFormat": "Queue",
+          "refId": "A"
+        }
+      ],
+      "title": "Queue",
+      "type": "stat"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "arr",
+    "media"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Arr Services",
+  "uid": "arr-services",
+  "version": 0
+}

--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1776635034,
-        "narHash": "sha256-OEOJrT3ZfwbChzODfIH4GzlNTtOFuZFWPtW7jIeR8xU=",
+        "lastModified": 1777242778,
+        "narHash": "sha256-VWTeqWeb8Sel/QiWyaPvCa9luAbcGawR+Rw09FJoHz0=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "dc7496d8ea6e526b1254b55d09b966e94673750f",
+        "rev": "ad8b31ad0ba8448bd958d7a5d50d811dc5d271c0",
         "type": "github"
       },
       "original": {
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777258755,
-        "narHash": "sha256-EC07KwADRE2LdIk7vEDyAaD3I0ZUq24T9jQF9L0iEPk=",
+        "lastModified": 1777308348,
+        "narHash": "sha256-DJx9wnerjsOqKOo8I7/u5ENRhRWFF2mbYcACF+mn5LU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7f8bbc93d63401e41368d6ddc46a4f631610fa90",
+        "rev": "a28e848a01044f47679453aae75f6253bef7903e",
         "type": "github"
       },
       "original": {
@@ -234,11 +234,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1777292678,
-        "narHash": "sha256-ysMNHf0q8VULXpBE/OTPKddKwAOXYAApp2kWHmvnaP0=",
+        "lastModified": 1777300178,
+        "narHash": "sha256-T/iptpy2nXKpJq9Owp0m7mqE3L4icz+OBW8JVe0r3PM=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "9e357f2481fedfa75899d9721fe1cfc581b3bfc0",
+        "rev": "5419ea6a448fcf6aa86bb2c319f94857b55feeaf",
         "type": "github"
       },
       "original": {
@@ -488,11 +488,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1776797459,
-        "narHash": "sha256-utv296Xwk0PwjONe9dsyKx+9Z5xAB70aAsMI//aakpg=",
+        "lastModified": 1777299656,
+        "narHash": "sha256-c0r3xXp2+xFJwkryS+nhyQwoACbFzSt4C1TVs3QMh8E=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "4eda91dd5abd2157a2c7bfb33142fc64da668b0a",
+        "rev": "079c608988c2747db3902c9de033572cd50e8656",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777285091,
-        "narHash": "sha256-o0jvaxiHW2X8+pJcVw75KhSMmfmAjeH9vSRzUYh5wtw=",
+        "lastModified": 1777310681,
+        "narHash": "sha256-aH8jCEMx+Yu5DlK57WosQuQ0N5Mjw9Adi4lWxetb3Hk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9e5cd1c163821839337ba993f895fa8109f93dec",
+        "rev": "4f4c34c2045792976d5d41f6176f476662b109b5",
         "type": "github"
       },
       "original": {
@@ -703,11 +703,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775585728,
-        "narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
+        "lastModified": 1776796298,
+        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
+        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
         "type": "github"
       },
       "original": {
@@ -788,11 +788,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776741231,
-        "narHash": "sha256-k9G98qzn+7npROUaks8VqCFm7cFtEG8ulQLBBo5lItg=",
+        "lastModified": 1777173302,
+        "narHash": "sha256-ERiu3cbxvnTDxiDcimRA7af7xp6x1y0sRyLGm28Qzz8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "02061303f7c4c964f7b4584dabd9e985b4cd442b",
+        "rev": "aaec8c50baeaf2f2ba653e8aae71778a2bbbac94",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1777248628,
-        "narHash": "sha256-3RoogdcCOknnzMCNw4MxQBHlAL0qXZw/Jk1fN4Hm8jE=",
+        "lastModified": 1777292678,
+        "narHash": "sha256-ysMNHf0q8VULXpBE/OTPKddKwAOXYAApp2kWHmvnaP0=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "80763b13ff9b8abb94654d9f5ca635003c0b5d84",
+        "rev": "9e357f2481fedfa75899d9721fe1cfc581b3bfc0",
         "type": "github"
       },
       "original": {
@@ -638,11 +638,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1777238095,
-        "narHash": "sha256-wyaAOqFhxYmtTb/Gb/+hegVJ3MnwOJjX9aqsQT3+R38=",
+        "lastModified": 1777282418,
+        "narHash": "sha256-d9n+0hStOP1OsXshp11saXi6Pj2e+OaDQSJJoT9x66E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c4073437f5ffeaeee270c37a2eddf370658d1332",
+        "rev": "dfa1e6982e80e1b6a887a4e8d9f45dc9c98ede4d",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777280630,
-        "narHash": "sha256-NmZ2s44S1uZARLt1amf9aqxRl96itXTEQyC02SltDgk=",
+        "lastModified": 1777285091,
+        "narHash": "sha256-o0jvaxiHW2X8+pJcVw75KhSMmfmAjeH9vSRzUYh5wtw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "af6f120e4b97be2937a45401ec4c02b4ccaddff0",
+        "rev": "9e5cd1c163821839337ba993f895fa8109f93dec",
         "type": "github"
       },
       "original": {

--- a/hosts/blizzard/monitoring/grafana.nix
+++ b/hosts/blizzard/monitoring/grafana.nix
@@ -17,6 +17,7 @@ in
     domain = "metrics.${VARS.domains.public}";
 
     provision.dashboards = {
+      "arr-services" = grafanaDashboards.custom.arr-services;
       "kubernetes-cluster" = grafanaDashboards.community.kubernetes-cluster;
       "zfs-overview" = grafanaDashboards.custom.zfs-overview;
       "power-consumption" = grafanaDashboards.custom.power-consumption;

--- a/hosts/blizzard/monitoring/prometheus.nix
+++ b/hosts/blizzard/monitoring/prometheus.nix
@@ -63,6 +63,35 @@
         ];
       }
       {
+        job_name = "arr-exporter";
+        static_configs = [
+          {
+            targets = [ "10.100.0.21:9707" ];
+            labels.arr_service = "sonarr";
+          }
+          {
+            targets = [ "10.100.0.22:9708" ];
+            labels.arr_service = "radarr";
+          }
+          {
+            targets = [ "10.100.0.26:9709" ];
+            labels.arr_service = "lidarr";
+          }
+          {
+            targets = [ "10.100.0.24:9710" ];
+            labels.arr_service = "readarr";
+          }
+          {
+            targets = [ "10.100.0.23:9711" ];
+            labels.arr_service = "bazarr";
+          }
+          {
+            targets = [ "10.100.0.20:9712" ];
+            labels.arr_service = "prowlarr";
+          }
+        ];
+      }
+      {
         job_name = "ups";
         metrics_path = "/ups_metrics";
         static_configs = [

--- a/lib/grafana-dashboards.nix
+++ b/lib/grafana-dashboards.nix
@@ -31,6 +31,7 @@ rec {
   };
 
   custom = {
+    arr-services = ../dashboards/shared/arr-services.json;
     zfs-overview = ../dashboards/host/blizzard/zfs-overview.json;
     power-consumption = ../dashboards/shared/power-consumption.json;
     power-consumption-historical = ../dashboards/host/blizzard/power-consumption-historical.json;

--- a/modules/services/arr-exporter.nix
+++ b/modules/services/arr-exporter.nix
@@ -58,50 +58,48 @@ let
     };
   };
 
-  mkOptions =
-    name: spec:
-    {
-      enable = lib.mkEnableOption "${name} Prometheus exporter (exportarr)";
+  mkOptions = name: spec: {
+    enable = lib.mkEnableOption "${name} Prometheus exporter (exportarr)";
 
-      port = lib.mkOption {
-        type = lib.types.port;
-        default = spec.defaultPort;
-        description = "Port the exportarr exporter for ${name} listens on.";
-      };
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = spec.defaultPort;
+      description = "Port the exportarr exporter for ${name} listens on.";
+    };
 
-      listenAddress = lib.mkOption {
-        type = lib.types.str;
-        default = "0.0.0.0";
-        description = "Address the exporter binds to inside the VM.";
-      };
+    listenAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "0.0.0.0";
+      description = "Address the exporter binds to inside the VM.";
+    };
 
-      arrPort = lib.mkOption {
-        type = lib.types.port;
-        default = spec.defaultArrPort;
-        description = "Port the ${name} service listens on (used to build the exporter URL). Must be set explicitly when using a non-default port.";
-      };
+    arrPort = lib.mkOption {
+      type = lib.types.port;
+      default = spec.defaultArrPort;
+      description = "Port the ${name} service listens on (used to build the exporter URL). Must be set explicitly when using a non-default port.";
+    };
 
-      configFile = lib.mkOption {
-        type = lib.types.str;
-        default = "/var/lib/${name}/${spec.configSubPath}";
-        description = "Absolute path to the ${name} config file containing the API key.";
-      };
+    configFile = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/${name}/${spec.configSubPath}";
+      description = "Absolute path to the ${name} config file containing the API key.";
+    };
 
-      extraEnvironment = lib.mkOption {
-        type = lib.types.attrsOf lib.types.str;
-        default = { };
-        description = "Extra environment variables for the exporter (e.g. ENABLE_ADDITIONAL_METRICS=true).";
-        example = {
-          ENABLE_ADDITIONAL_METRICS = "true";
-        };
-      };
-
-      openFirewall = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = "Open a firewall port for the exporter so Prometheus can scrape it.";
+    extraEnvironment = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      description = "Extra environment variables for the exporter (e.g. ENABLE_ADDITIONAL_METRICS=true).";
+      example = {
+        ENABLE_ADDITIONAL_METRICS = "true";
       };
     };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Open a firewall port for the exporter so Prometheus can scrape it.";
+    };
+  };
 
   mkConfig =
     name: spec:

--- a/modules/services/arr-exporter.nix
+++ b/modules/services/arr-exporter.nix
@@ -110,6 +110,13 @@ let
       keyFile = "/run/${name}-exporter/api-key";
     in
     lib.mkIf scfg.enable {
+      assertions = [
+        {
+          assertion = config.services.${name}.enable;
+          message = "sys.services.arrExporter.${name} requires the ${name} service to be enabled (services.${name}.enable = true).";
+        }
+      ];
+
       # Oneshot that reads the API key from the *arr config file into a root-owned
       # tmpfs path. LoadCredential (run by PID 1) can read it regardless of
       # DynamicUser; the key never touches the Nix store.
@@ -130,6 +137,10 @@ let
               [ -s "${scfg.configFile}" ] && break
               sleep 1
             done
+            [ -s "${scfg.configFile}" ] || {
+              echo "Timed out waiting for ${scfg.configFile} to appear" >&2
+              exit 1
+            }
             key=$(${spec.extractKey scfg.configFile})
             [ -n "$key" ] || {
               echo "No API key found in ${scfg.configFile}" >&2

--- a/modules/services/arr-exporter.nix
+++ b/modules/services/arr-exporter.nix
@@ -93,7 +93,7 @@ let
 
       openFirewall = lib.mkOption {
         type = lib.types.bool;
-        default = true;
+        default = false;
         description = "Open a firewall port for the exporter so Prometheus can scrape it.";
       };
     };

--- a/modules/services/arr-exporter.nix
+++ b/modules/services/arr-exporter.nix
@@ -142,8 +142,8 @@ let
       # DynamicUser process receives the key securely via $CREDENTIALS_DIRECTORY.
       services.prometheus.exporters."exportarr-${name}" = {
         enable = true;
-        port = scfg.port;
-        listenAddress = scfg.listenAddress;
+
+        inherit (scfg) port listenAddress;
         url = "http://127.0.0.1:${toString scfg.arrPort}";
         apiKeyFile = keyFile;
         environment = scfg.extraEnvironment;

--- a/modules/services/arr-exporter.nix
+++ b/modules/services/arr-exporter.nix
@@ -1,0 +1,163 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.sys.services.arrExporter;
+
+  # Per-service static metadata: default port, config file sub-path, and a
+  # function that produces the shell expression to extract the API key.
+  serviceSpecs = {
+    sonarr = {
+      defaultPort = 9707;
+      configSubPath = "config.xml";
+      extractKey =
+        configFile: ''${pkgs.gnused}/bin/sed -n 's|.*<ApiKey>\(.*\)</ApiKey>.*|\1|p' "${configFile}"'';
+    };
+    radarr = {
+      defaultPort = 9708;
+      configSubPath = "config.xml";
+      extractKey =
+        configFile: ''${pkgs.gnused}/bin/sed -n 's|.*<ApiKey>\(.*\)</ApiKey>.*|\1|p' "${configFile}"'';
+    };
+    lidarr = {
+      defaultPort = 9709;
+      configSubPath = "config.xml";
+      extractKey =
+        configFile: ''${pkgs.gnused}/bin/sed -n 's|.*<ApiKey>\(.*\)</ApiKey>.*|\1|p' "${configFile}"'';
+    };
+    readarr = {
+      defaultPort = 9710;
+      configSubPath = "config.xml";
+      extractKey =
+        configFile: ''${pkgs.gnused}/bin/sed -n 's|.*<ApiKey>\(.*\)</ApiKey>.*|\1|p' "${configFile}"'';
+    };
+    bazarr = {
+      defaultPort = 9711;
+      # Bazarr stores settings in an INI file, not config.xml
+      configSubPath = "config/config.ini";
+      extractKey =
+        configFile:
+        ''${pkgs.gnused}/bin/sed -n 's/^apikey[[:space:]]*=[[:space:]]*\(.*\)/\1/p' "${configFile}" | ${pkgs.coreutils}/bin/head -1'';
+    };
+    prowlarr = {
+      defaultPort = 9712;
+      configSubPath = "config.xml";
+      extractKey =
+        configFile: ''${pkgs.gnused}/bin/sed -n 's|.*<ApiKey>\(.*\)</ApiKey>.*|\1|p' "${configFile}"'';
+    };
+  };
+
+  mkOptions =
+    name: spec:
+    let
+      svcCfg = config.sys.services.${name};
+    in
+    {
+      enable = lib.mkEnableOption "${name} Prometheus exporter (exportarr)";
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = spec.defaultPort;
+        description = "Port the exportarr exporter for ${name} listens on.";
+      };
+
+      listenAddress = lib.mkOption {
+        type = lib.types.str;
+        default = "0.0.0.0";
+        description = "Address the exporter binds to inside the VM.";
+      };
+
+      arrPort = lib.mkOption {
+        type = lib.types.port;
+        default = svcCfg.port;
+        description = "Port the ${name} service listens on (used to build the exporter URL).";
+      };
+
+      configFile = lib.mkOption {
+        type = lib.types.str;
+        default = "${svcCfg.dataDir}/${spec.configSubPath}";
+        description = "Absolute path to the ${name} config file containing the API key.";
+      };
+
+      extraEnvironment = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+        description = "Extra environment variables for the exporter (e.g. ENABLE_ADDITIONAL_METRICS=true).";
+        example = {
+          ENABLE_ADDITIONAL_METRICS = "true";
+        };
+      };
+
+      openFirewall = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Open a firewall port for the exporter so Prometheus can scrape it.";
+      };
+    };
+
+  mkConfig =
+    name: spec:
+    let
+      scfg = cfg.${name};
+      keyseedSvc = "${name}-exporter-keyseed";
+      exporterSvc = "prometheus-exportarr-${name}-exporter";
+      keyFile = "/run/${name}-exporter/api-key";
+    in
+    lib.mkIf scfg.enable {
+      # Oneshot that reads the API key from the *arr config file into a root-owned
+      # tmpfs path. LoadCredential (run by PID 1) can read it regardless of
+      # DynamicUser; the key never touches the Nix store.
+      systemd.services.${keyseedSvc} = {
+        description = "Extract API key for ${name} exportarr exporter";
+        wantedBy = [ "multi-user.target" ];
+        wants = [ "${name}.service" ];
+        after = [ "${name}.service" ];
+        before = [ "${exporterSvc}.service" ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          RuntimeDirectory = "${name}-exporter";
+          RuntimeDirectoryMode = "0700";
+          ExecStart = pkgs.writeShellScript "${keyseedSvc}" ''
+            set -euo pipefail
+            for i in $(seq 1 60); do
+              [ -s "${scfg.configFile}" ] && break
+              sleep 1
+            done
+            key=$(${spec.extractKey scfg.configFile})
+            [ -n "$key" ] || {
+              echo "No API key found in ${scfg.configFile}" >&2
+              exit 1
+            }
+            printf '%s' "$key" > "${keyFile}"
+            chmod 0400 "${keyFile}"
+          '';
+        };
+      };
+
+      # The upstream module turns apiKeyFile into a LoadCredential entry so the
+      # DynamicUser process receives the key securely via $CREDENTIALS_DIRECTORY.
+      services.prometheus.exporters."exportarr-${name}" = {
+        enable = true;
+        port = scfg.port;
+        listenAddress = scfg.listenAddress;
+        url = "http://127.0.0.1:${toString scfg.arrPort}";
+        apiKeyFile = keyFile;
+        environment = scfg.extraEnvironment;
+      };
+
+      systemd.services.${exporterSvc} = {
+        requires = [ "${keyseedSvc}.service" ];
+        after = [ "${keyseedSvc}.service" ];
+      };
+
+      networking.firewall.allowedTCPPorts = lib.mkIf scfg.openFirewall [ scfg.port ];
+    };
+in
+{
+  options.sys.services.arrExporter = lib.mapAttrs mkOptions serviceSpecs;
+  config = lib.mkMerge (lib.mapAttrsToList mkConfig serviceSpecs);
+}

--- a/modules/services/arr-exporter.nix
+++ b/modules/services/arr-exporter.nix
@@ -7,35 +7,42 @@
 let
   cfg = config.sys.services.arrExporter;
 
-  # Per-service static metadata: default port, config file sub-path, and a
-  # function that produces the shell expression to extract the API key.
+  # Per-service static metadata: exporter port, upstream *arr default port,
+  # config file sub-path, and a function that extracts the API key from the config.
+  # defaultArrPort is the upstream service default — each VM must override arrPort
+  # with the actual port from vm-registry since non-standard ports are used.
   serviceSpecs = {
     sonarr = {
       defaultPort = 9707;
+      defaultArrPort = 8989;
       configSubPath = "config.xml";
       extractKey =
         configFile: ''${pkgs.gnused}/bin/sed -n 's|.*<ApiKey>\(.*\)</ApiKey>.*|\1|p' "${configFile}"'';
     };
     radarr = {
       defaultPort = 9708;
+      defaultArrPort = 7878;
       configSubPath = "config.xml";
       extractKey =
         configFile: ''${pkgs.gnused}/bin/sed -n 's|.*<ApiKey>\(.*\)</ApiKey>.*|\1|p' "${configFile}"'';
     };
     lidarr = {
       defaultPort = 9709;
+      defaultArrPort = 8686;
       configSubPath = "config.xml";
       extractKey =
         configFile: ''${pkgs.gnused}/bin/sed -n 's|.*<ApiKey>\(.*\)</ApiKey>.*|\1|p' "${configFile}"'';
     };
     readarr = {
       defaultPort = 9710;
+      defaultArrPort = 8787;
       configSubPath = "config.xml";
       extractKey =
         configFile: ''${pkgs.gnused}/bin/sed -n 's|.*<ApiKey>\(.*\)</ApiKey>.*|\1|p' "${configFile}"'';
     };
     bazarr = {
       defaultPort = 9711;
+      defaultArrPort = 6767;
       # Bazarr stores settings in an INI file, not config.xml
       configSubPath = "config/config.ini";
       extractKey =
@@ -44,6 +51,7 @@ let
     };
     prowlarr = {
       defaultPort = 9712;
+      defaultArrPort = 9696;
       configSubPath = "config.xml";
       extractKey =
         configFile: ''${pkgs.gnused}/bin/sed -n 's|.*<ApiKey>\(.*\)</ApiKey>.*|\1|p' "${configFile}"'';
@@ -52,9 +60,6 @@ let
 
   mkOptions =
     name: spec:
-    let
-      svcCfg = config.sys.services.${name};
-    in
     {
       enable = lib.mkEnableOption "${name} Prometheus exporter (exportarr)";
 
@@ -72,13 +77,13 @@ let
 
       arrPort = lib.mkOption {
         type = lib.types.port;
-        default = svcCfg.port;
-        description = "Port the ${name} service listens on (used to build the exporter URL).";
+        default = spec.defaultArrPort;
+        description = "Port the ${name} service listens on (used to build the exporter URL). Must be set explicitly when using a non-default port.";
       };
 
       configFile = lib.mkOption {
         type = lib.types.str;
-        default = "${svcCfg.dataDir}/${spec.configSubPath}";
+        default = "/var/lib/${name}/${spec.configSubPath}";
         description = "Absolute path to the ${name} config file containing the API key.";
       };
 

--- a/vms/base.nix
+++ b/vms/base.nix
@@ -8,6 +8,7 @@
 {
   imports = [
     ../modules/security/secrets.nix
+    ../modules/services/arr-exporter.nix
     ../modules/services/nfs.nix
     ../modules/services/traefik.nix
   ];

--- a/vms/bazarr.nix
+++ b/vms/bazarr.nix
@@ -43,5 +43,6 @@ in
   sys.services.arrExporter.bazarr = {
     enable = true;
     openFirewall = true;
+    arrPort = reg.port;
   };
 }

--- a/vms/bazarr.nix
+++ b/vms/bazarr.nix
@@ -39,4 +39,6 @@ in
     dataDir = "/var/lib/bazarr";
     reverseProxy.enable = false;
   };
+
+  sys.services.arrExporter.bazarr.enable = true;
 }

--- a/vms/bazarr.nix
+++ b/vms/bazarr.nix
@@ -40,5 +40,8 @@ in
     reverseProxy.enable = false;
   };
 
-  sys.services.arrExporter.bazarr.enable = true;
+  sys.services.arrExporter.bazarr = {
+    enable = true;
+    openFirewall = true;
+  };
 }

--- a/vms/lidarr.nix
+++ b/vms/lidarr.nix
@@ -40,5 +40,8 @@ in
     reverseProxy.enable = false;
   };
 
-  sys.services.arrExporter.lidarr.enable = true;
+  sys.services.arrExporter.lidarr = {
+    enable = true;
+    openFirewall = true;
+  };
 }

--- a/vms/lidarr.nix
+++ b/vms/lidarr.nix
@@ -39,4 +39,6 @@ in
     dataDir = "/var/lib/lidarr";
     reverseProxy.enable = false;
   };
+
+  sys.services.arrExporter.lidarr.enable = true;
 }

--- a/vms/lidarr.nix
+++ b/vms/lidarr.nix
@@ -43,5 +43,6 @@ in
   sys.services.arrExporter.lidarr = {
     enable = true;
     openFirewall = true;
+    arrPort = reg.port;
   };
 }

--- a/vms/prowlarr.nix
+++ b/vms/prowlarr.nix
@@ -46,5 +46,6 @@ in
   sys.services.arrExporter.prowlarr = {
     enable = true;
     openFirewall = true;
+    arrPort = reg.port;
   };
 }

--- a/vms/prowlarr.nix
+++ b/vms/prowlarr.nix
@@ -43,5 +43,8 @@ in
     port = flaresolverrPort;
   };
 
-  sys.services.arrExporter.prowlarr.enable = true;
+  sys.services.arrExporter.prowlarr = {
+    enable = true;
+    openFirewall = true;
+  };
 }

--- a/vms/prowlarr.nix
+++ b/vms/prowlarr.nix
@@ -42,4 +42,6 @@ in
     enable = true;
     port = flaresolverrPort;
   };
+
+  sys.services.arrExporter.prowlarr.enable = true;
 }

--- a/vms/radarr.nix
+++ b/vms/radarr.nix
@@ -40,5 +40,8 @@ in
     reverseProxy.enable = false;
   };
 
-  sys.services.arrExporter.radarr.enable = true;
+  sys.services.arrExporter.radarr = {
+    enable = true;
+    openFirewall = true;
+  };
 }

--- a/vms/radarr.nix
+++ b/vms/radarr.nix
@@ -39,4 +39,6 @@ in
     dataDir = "/var/lib/radarr";
     reverseProxy.enable = false;
   };
+
+  sys.services.arrExporter.radarr.enable = true;
 }

--- a/vms/radarr.nix
+++ b/vms/radarr.nix
@@ -43,5 +43,6 @@ in
   sys.services.arrExporter.radarr = {
     enable = true;
     openFirewall = true;
+    arrPort = reg.port;
   };
 }

--- a/vms/readarr.nix
+++ b/vms/readarr.nix
@@ -40,5 +40,8 @@ in
     reverseProxy.enable = false;
   };
 
-  sys.services.arrExporter.readarr.enable = true;
+  sys.services.arrExporter.readarr = {
+    enable = true;
+    openFirewall = true;
+  };
 }

--- a/vms/readarr.nix
+++ b/vms/readarr.nix
@@ -43,5 +43,6 @@ in
   sys.services.arrExporter.readarr = {
     enable = true;
     openFirewall = true;
+    arrPort = reg.port;
   };
 }

--- a/vms/readarr.nix
+++ b/vms/readarr.nix
@@ -39,4 +39,6 @@ in
     dataDir = "/var/lib/readarr";
     reverseProxy.enable = false;
   };
+
+  sys.services.arrExporter.readarr.enable = true;
 }

--- a/vms/sonarr.nix
+++ b/vms/sonarr.nix
@@ -43,5 +43,6 @@ in
   sys.services.arrExporter.sonarr = {
     enable = true;
     openFirewall = true;
+    arrPort = reg.port;
   };
 }

--- a/vms/sonarr.nix
+++ b/vms/sonarr.nix
@@ -40,5 +40,8 @@ in
     reverseProxy.enable = false;
   };
 
-  sys.services.arrExporter.sonarr.enable = true;
+  sys.services.arrExporter.sonarr = {
+    enable = true;
+    openFirewall = true;
+  };
 }

--- a/vms/sonarr.nix
+++ b/vms/sonarr.nix
@@ -39,4 +39,6 @@ in
     dataDir = "/var/lib/sonarr";
     reverseProxy.enable = false;
   };
+
+  sys.services.arrExporter.sonarr.enable = true;
 }


### PR DESCRIPTION
This pull request introduces a new NixOS module for managing Prometheus exporters for the *arr suite of media automation services (Sonarr, Radarr, Lidarr, Readarr, Bazarr, and Prowlarr), automates their deployment across relevant VMs, and integrates their monitoring into Prometheus and Grafana. The changes add secure API key handling, configuration options, and dashboard support for these exporters.

**New arr-exporter NixOS module and service integration:**

- Adds a reusable NixOS module (`modules/services/arr-exporter.nix`) that manages Prometheus exporters for each *arr service, including secure extraction and handling of API keys, per-service configuration, and firewall management.
- Enables the `arrExporter` service for Sonarr, Radarr, Lidarr, Readarr, Bazarr, and Prowlarr in their respective VM configuration files, ensuring the exporters are deployed and running. [[1]](diffhunk://#diff-a9f6a9c47c9da89a0d37050f834d96c74f657491c3502b00c7961a04c47ff0f6R42-R43) [[2]](diffhunk://#diff-276e2d97bd3b3e346f5304a3da89fad237ad0672ab5d5b14ee99544d4cdd2c82R42-R43) [[3]](diffhunk://#diff-2c1ccd75c1a2db92699ce78ca1ae956bfe21bb6ca520242dcb7d126471e3deddR42-R43) [[4]](diffhunk://#diff-f98378e1bb23dc397a22d28b92a5c5670de1095a866747603c9eb64b8dddb566R42-R43) [[5]](diffhunk://#diff-186d40373f02db29a81e369e5944840ea5e9598ded61ee2549b892feb5cba20aR42-R43) [[6]](diffhunk://#diff-8f7f7ee9c6a15953c393f3e65127b6ce43c670f407b9311b4ba341b11f535386R45-R46)

**Monitoring and observability integration:**

- Updates the Prometheus configuration to scrape all *arr exporters, assigning appropriate labels and static targets for each service.
- Adds a custom Grafana dashboard for *arr services to the dashboard registry and includes it in the Grafana provisioning for visibility into *arr metrics. [[1]](diffhunk://#diff-c74eb7930f48689309b60005f55c4b4f1628e82c6cacb144eed535c998a3d3f0R34) [[2]](diffhunk://#diff-f7bc3d49a6180d73ec1254059847c5d0129ace0cdb3c45ed470f5287809a4005R20)