### PR TITLE
docs: fix microvm.nix upstream links to microvm-nix org

### DIFF
--- a/vms/README.md
+++ b/vms/README.md
@@ -1,6 +1,6 @@
 ## MicroVM Configurations
 
-Isolated service VMs using [microvm.nix](https://github.com/astro/microvm.nix)
+Isolated service VMs using [microvm.nix](https://github.com/microvm-nix/microvm.nix)
 for lightweight virtualization. The flake currently defines 23 MicroVM
 configurations for the `blizzard` host on a `10.100.0.0/24` tap bridge.
 
@@ -184,7 +184,7 @@ ______________________________________________________________________
 
 ### Related documentation
 
-- [microvm.nix upstream](https://github.com/astro/microvm.nix)
+- [microvm.nix upstream](https://github.com/microvm-nix/microvm.nix)
 - [modules/services/README.md](../modules/services/README.md) — Service module catalog
 - [Blizzard host config](../hosts/blizzard/blizzard.nix) — VM host example
 - [vm-registry.nix](vm-registry.nix) — Single source of truth for all VM parameters


### PR DESCRIPTION
Fix two broken links in `vms/README.md` that pointed to the old `astro/microvm.nix` GitHub organisation. The flake input (`flake.nix`) pins `github:microvm-nix/microvm.nix`, so the docs should reference the same upstream.

**Changes:**
- Line 3: intro link `astro/microvm.nix` → `microvm-nix/microvm.nix`
- Line 187: "microvm.nix upstream" link `astro/microvm.nix` → `microvm-nix/microvm.nix`

Caught by Copilot reviewer on PR #5818 after that PR had already been auto-merged.