### PR TITLE
Dev vm mealie

### DIFF
--- a/hosts/blizzard/virtualisation/microvms.nix
+++ b/hosts/blizzard/virtualisation/microvms.nix
@@ -286,7 +286,7 @@ let
     };
 
     mealie = {
-      enable = false;
+      enable = true;
       portForwards = [ (mkPortForward "tcp" 11071 null) ];
       ingressHosts = [ "recipes" ];
       reverseProxy = {

--- a/vms/mealie.nix
+++ b/vms/mealie.nix
@@ -51,7 +51,9 @@ in
   users = {
     users.mealie = {
       isSystemUser = true;
+      description = "Mealie service user";
       group = "mealie";
+      home = "/var/lib/mealie";
     };
     groups.mealie = { };
   };

--- a/vms/mealie.nix
+++ b/vms/mealie.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   config,
   inputs,
   VARS,
@@ -47,6 +48,14 @@ in
     };
   };
 
+  users = {
+    users.mealie = {
+      isSystemUser = true;
+      group = "mealie";
+    };
+    groups.mealie = { };
+  };
+
   networking.firewall.allowedTCPPorts = [ reg.port ];
 
   systemd = {
@@ -58,6 +67,7 @@ in
     services.mealie = {
       after = [ "sops-install-secrets.service" ];
       requires = [ "sops-install-secrets.service" ];
+      serviceConfig.DynamicUser = lib.mkForce false;
     };
   };
 


### PR DESCRIPTION
This pull request enables and configures the Mealie service in the virtual machine setup. The main changes involve activating Mealie, setting up its user and group, and ensuring proper systemd service configuration.

**Mealie Service Activation and Configuration:**

* Enabled the Mealie service by setting `enable = true` in `microvms.nix`, allowing the service to start on the VM.
* Added explicit user and group configuration for Mealie in `mealie.nix`, creating a dedicated system user and group for the service.
* Forced `DynamicUser` to `false` in the Mealie systemd service configuration to ensure it runs under the created static user.

**Codebase Maintenance:**

* Added `lib` to the module arguments in `mealie.nix` to support the new configuration.