### PR TITLE
Dev gitea

### DIFF
--- a/modules/services/cloudflare-access-ip-updater.nix
+++ b/modules/services/cloudflare-access-ip-updater.nix
@@ -74,7 +74,7 @@ let
     echo "Policy: $POLICY_NAME (decision: $POLICY_DECISION, precedence: $POLICY_PRECEDENCE)"
 
     # Determine correct CIDR notation: /32 for IPv4, /128 for IPv6
-    if echo "$CURRENT_IP" | grep -qF ':'; then
+    if [[ "$CURRENT_IP" == *:* ]]; then
       IP_CIDR="$CURRENT_IP/128"
     else
       IP_CIDR="$CURRENT_IP/32"

--- a/modules/services/cloudflare-access-ip-updater.nix
+++ b/modules/services/cloudflare-access-ip-updater.nix
@@ -73,13 +73,20 @@ let
 
     echo "Policy: $POLICY_NAME (decision: $POLICY_DECISION, precedence: $POLICY_PRECEDENCE)"
 
+    # Determine correct CIDR notation: /32 for IPv4, /128 for IPv6
+    if echo "$CURRENT_IP" | grep -qF ':'; then
+      IP_CIDR="$CURRENT_IP/128"
+    else
+      IP_CIDR="$CURRENT_IP/32"
+    fi
+
     # Build the updated policy JSON
     # This creates a policy with the IP rule for bypass
     UPDATE_PAYLOAD=$(${pkgs.jq}/bin/jq -n \
       --arg name "$POLICY_NAME" \
       --arg decision "$POLICY_DECISION" \
       --argjson precedence "$POLICY_PRECEDENCE" \
-      --arg ip "$CURRENT_IP/32" \
+      --arg ip "$IP_CIDR" \
       '{
         name: $name,
         decision: $decision,

--- a/modules/services/gitea.nix
+++ b/modules/services/gitea.nix
@@ -192,7 +192,6 @@ in
             HTTP_PORT = cfg.port;
 
             LFS_START_SERVER = lib.mkIf cfg.lfs.enable true;
-            LFS_ALLOW_PURE_SSH = lib.mkIf cfg.lfs.enable true;
           };
 
           repository = {
@@ -202,7 +201,7 @@ in
 
           service.DISABLE_REGISTRATION = cfg.disableRegistration;
 
-          session.COOKIE_SECURE = lib.mkIf cfg.reverseProxy.enable true;
+          session.COOKIE_SECURE = lib.mkDefault true;
         }
         (lib.mkIf (cfg.lfs.enable && cfg.lfs.s3Backend.enable) {
           lfs = {

--- a/vms/gitea.nix
+++ b/vms/gitea.nix
@@ -11,22 +11,6 @@
 let
   reg = (import ./vm-registry.nix).gitea;
 
-  # TEMP: pin gitea to the nixpkgs commit that bumped it to 1.26.0, so we get
-  # chunked LFS upload responses (go-gitea/gitea#36380, shipped in v1.26.0).
-  # No new flake input; fetchTarball pins an exact rev in-tree.
-  # DELETE this block (and the assertion below) once `nix flake update nixpkgs`
-  # locks a commit at-or-past 836f421fca0b8e112393a929852cd39d6073a723:
-  #   gh api repos/NixOS/nixpkgs/compare/836f421fca0b8e112393a929852cd39d6073a723...<new-rev> --jq '.status'
-  #   -> want "ahead" or "identical"
-  giteaPinRev = "836f421fca0b8e112393a929852cd39d6073a723";
-  giteaPinnedNixpkgs = builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/${giteaPinRev}.tar.gz";
-    sha256 = "0sw830n4n2cx1hn6aqr9yxdyp34s67raxap6s5ir9v5bkzjd3d7y";
-  };
-  giteaPinnedPkgs = import giteaPinnedNixpkgs {
-    inherit system;
-    inherit (config.nixpkgs) config;
-  };
 in
 {
   imports = [
@@ -52,12 +36,10 @@ in
     ))
   ];
 
-  nixpkgs.overlays = [ (_: _: { inherit (giteaPinnedPkgs) gitea; }) ];
-
   assertions = [
     {
       assertion = lib.versionAtLeast pkgs.gitea.version "1.26.0";
-      message = "gitea-pin: expected >= 1.26.0 from nixpkgs@${giteaPinRev}, got ${pkgs.gitea.version}. Delete the overlay when unstable catches up.";
+      message = "gitea: chunked LFS upload support requires >= 1.26.0 (go-gitea/gitea#36380); got ${pkgs.gitea.version}.";
     }
   ];
 


### PR DESCRIPTION
This pull request includes several improvements and cleanups related to the Gitea service configuration and Cloudflare Access IP updater. The most significant changes are the removal of temporary Gitea pinning logic now that the required version is available upstream, and enhancements to IP handling in the Cloudflare updater script. There are also some configuration adjustments for Gitea to improve default security and simplify LFS settings.

**Gitea Pinning Cleanup:**
- Removed the temporary code that pinned Gitea to a specific nixpkgs commit for chunked LFS upload support, since the required version (>= 1.26.0) is now available in upstream nixpkgs. This includes deleting the overlay and related assertion logic in `vms/gitea.nix`. [[1]](diffhunk://#diff-7e8de5d54ba02db95f5bea8fb287036f6d8f4f96b4e36b41e8a869a5d89a966aL14-L29) [[2]](diffhunk://#diff-7e8de5d54ba02db95f5bea8fb287036f6d8f4f96b4e36b41e8a869a5d89a966aL55-R42)

**Cloudflare Access IP Updater Improvements:**
- Updated the script to correctly handle both IPv4 and IPv6 addresses by applying the appropriate CIDR notation (`/32` for IPv4, `/128` for IPv6) when updating the policy JSON.

**Gitea Configuration Adjustments:**
- Changed the default for `session.COOKIE_SECURE` to always be `true`, improving default security for session cookies regardless of reverse proxy settings.
- Removed the redundant or unnecessary setting of `LFS_ALLOW_PURE_SSH` in the LFS configuration, simplifying the setup.