### PR TITLE
Dev gitea

### DIFF
--- a/home/overrides/user/zeno-avalanche.nix
+++ b/home/overrides/user/zeno-avalanche.nix
@@ -68,12 +68,6 @@
             SetEnv = "TERM=xterm-256color";
           };
 
-          "ssh-git.*" = {
-            User = "gitea";
-            IdentityFile = "${config.home.homeDirectory}/.ssh/github-key";
-            IdentitiesOnly = "yes";
-            ProxyCommand = "${pkgs.cloudflared.out}/bin/cloudflared access ssh --hostname %h";
-          };
         };
 
         allowedSigners = [

--- a/home/overrides/user/zeno-blizzard.nix
+++ b/home/overrides/user/zeno-blizzard.nix
@@ -72,12 +72,6 @@
             IdentityFile = "${config.home.homeDirectory}/.ssh/zeno-blizzard";
           };
 
-          "ssh-git.*" = {
-            User = "gitea";
-            IdentityFile = "${config.home.homeDirectory}/.ssh/github-key";
-            IdentitiesOnly = "yes";
-            ProxyCommand = "${pkgs.cloudflared.out}/bin/cloudflared access ssh --hostname %h";
-          };
         };
       };
     };

--- a/home/overrides/user/zeno-snowfall.nix
+++ b/home/overrides/user/zeno-snowfall.nix
@@ -75,12 +75,6 @@
             SetEnv = "TERM=xterm-256color";
           };
 
-          "ssh-git.*" = {
-            User = "gitea";
-            IdentityFile = "${config.home.homeDirectory}/.ssh/github-key";
-            IdentitiesOnly = "yes";
-            ProxyCommand = "${pkgs.cloudflared.out}/bin/cloudflared access ssh --hostname %h";
-          };
         };
 
         allowedSigners = [

--- a/hosts/blizzard/virtualisation/microvms.nix
+++ b/hosts/blizzard/virtualisation/microvms.nix
@@ -109,9 +109,6 @@ let
     gitea = {
       enable = true;
       ingressHosts = [ "git" ];
-      extraIngress = {
-        "ssh-git.${VARS.domains.public}" = "ssh://${reg.gitea.ip}:2222";
-      };
       reverseProxy = {
         subdomain = "git";
         url = vmUrl "gitea";

--- a/modules/services/gitea.nix
+++ b/modules/services/gitea.nix
@@ -157,6 +157,29 @@ in
       default = true;
     };
 
+    ssh = {
+      enable = lib.mkEnableOption "Gitea built-in SSH server";
+
+      domain = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "Public SSH hostname advertised to clients (SSH_DOMAIN). Defaults to the HTTP domain when null.";
+        example = "ssh-git.example.com";
+      };
+
+      listenHost = lib.mkOption {
+        type = lib.types.str;
+        default = "0.0.0.0";
+        description = "Address the built-in SSH server binds to (SSH_LISTEN_HOST).";
+      };
+
+      listenPort = lib.mkOption {
+        type = lib.types.port;
+        default = 2222;
+        description = "Port the built-in SSH server listens on (SSH_LISTEN_PORT).";
+      };
+    };
+
     reverseProxy = traefikLib.mkReverseProxyOptions {
       name = "gitea";
       defaults.enable = false;
@@ -192,6 +215,11 @@ in
             HTTP_PORT = cfg.port;
 
             LFS_START_SERVER = lib.mkIf cfg.lfs.enable true;
+
+            START_SSH_SERVER = lib.mkIf cfg.ssh.enable true;
+            SSH_LISTEN_HOST = lib.mkIf cfg.ssh.enable cfg.ssh.listenHost;
+            SSH_LISTEN_PORT = lib.mkIf cfg.ssh.enable cfg.ssh.listenPort;
+            SSH_DOMAIN = lib.mkIf (cfg.ssh.enable && cfg.ssh.domain != null) cfg.ssh.domain;
           };
 
           repository = {
@@ -228,7 +256,7 @@ in
     };
 
     networking.firewall = lib.mkIf cfg.openFirewall {
-      allowedTCPPorts = [ cfg.port ];
+      allowedTCPPorts = [ cfg.port ] ++ lib.optional cfg.ssh.enable cfg.ssh.listenPort;
     };
 
     services.traefik.dynamic.files.gitea = traefikLib.mkTraefikDynamicConfig {

--- a/modules/services/gitea.nix
+++ b/modules/services/gitea.nix
@@ -215,6 +215,7 @@ in
             HTTP_PORT = cfg.port;
 
             LFS_START_SERVER = lib.mkIf cfg.lfs.enable true;
+            DISABLE_SSH = lib.mkIf (!cfg.ssh.enable) true;
 
             START_SSH_SERVER = lib.mkIf cfg.ssh.enable true;
             SSH_LISTEN_HOST = lib.mkIf cfg.ssh.enable cfg.ssh.listenHost;

--- a/modules/services/gitea.nix
+++ b/modules/services/gitea.nix
@@ -215,7 +215,6 @@ in
             HTTP_PORT = cfg.port;
 
             LFS_START_SERVER = lib.mkIf cfg.lfs.enable true;
-            DISABLE_SSH = lib.mkIf (!cfg.ssh.enable) true;
 
             START_SSH_SERVER = lib.mkIf cfg.ssh.enable true;
             SSH_LISTEN_HOST = lib.mkIf cfg.ssh.enable cfg.ssh.listenHost;

--- a/vms/gitea.nix
+++ b/vms/gitea.nix
@@ -62,11 +62,6 @@ in
     };
   };
 
-  networking.firewall.allowedTCPPorts = [
-    reg.port
-    2222
-  ];
-
   systemd.tmpfiles.rules = [
     "d /var/lib/gitea 0700 gitea gitea -"
     "d /var/lib/postgresql 0700 postgres postgres -"
@@ -106,18 +101,12 @@ in
 
       reverseProxy.enable = false;
 
-      settings = {
-        server = {
-          ROOT_URL = "https://git.${VARS.domains.public}/";
-          START_SSH_SERVER = true;
-
-          SSH_DOMAIN = "ssh-git.${VARS.domains.public}";
-          SSH_LISTEN_HOST = "0.0.0.0";
-          SSH_LISTEN_PORT = 2222;
-        };
-
-        session.COOKIE_SECURE = true;
+      ssh = {
+        enable = false;
+        domain = "ssh-git.${VARS.domains.public}";
       };
+
+      settings.server.ROOT_URL = "https://git.${VARS.domains.public}/";
     };
   };
 }

--- a/vms/gitea.nix
+++ b/vms/gitea.nix
@@ -106,7 +106,10 @@ in
         domain = "ssh-git.${VARS.domains.public}";
       };
 
-      settings.server.ROOT_URL = "https://git.${VARS.domains.public}/";
+      settings.server = {
+        ROOT_URL = "https://git.${VARS.domains.public}/";
+        DISABLE_SSH = true;
+      };
     };
   };
 }


### PR DESCRIPTION
This pull request introduces a new, structured configuration option for managing the Gitea built-in SSH server in the NixOS module, and updates related VM and firewall settings to use this new approach. The main changes are the addition of the `ssh` attribute set, improved option handling, and simplification of the VM configuration.

**Gitea SSH server configuration improvements:**

* Added a new `ssh` attribute set to `modules/services/gitea.nix` for configuring the built-in SSH server, including options for enabling the server, setting the advertised domain, listen host, and port.
* Updated the Gitea service environment variables to use the new `ssh` options, ensuring values are only set if SSH is enabled.

**Firewall and networking adjustments:**

* Modified the firewall rules to automatically open the SSH port if the built-in SSH server is enabled, rather than hardcoding the port.
* Removed the hardcoded SSH port from the VM firewall configuration, relying on the new module logic instead.

**VM configuration simplification:**

* Updated the Gitea VM configuration to use the new `ssh` attribute set, disabling the built-in SSH server by default and setting the advertised domain, while removing redundant or now-unnecessary settings.