### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1777830947,
-        "narHash": "sha256-+wHLBmwtt/75aQxqlDCOUzvOE9OzGSIazb+aeuzLLlU=",
+        "lastModified": 1777840661,
+        "narHash": "sha256-m0Ix9S1fnx1dZS2Jc2hwtmH1zQlsDE68S63lerNbWd8=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "6a7abd00379b4f37b468bc2d0e717d4ba293efe1",
+        "rev": "6d4bcaf075dec8f6de003cb8403df8c788e7079e",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777829211,
-        "narHash": "sha256-lj86cNCSvr3u+Hxpv3Gi22o9Sd3DRa328bSkc7WUQwI=",
+        "lastModified": 1777842400,
+        "narHash": "sha256-0+EyicmPj8CJni1rwBArmSx+U6P3MU5xp7lz63q+qf4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d177168211d22d25d8c8383a9b99dc5f48db9699",
+        "rev": "e298aa41ce07bbe9df46488267c44b45753729ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hyprland':
    'github:hyprwm/Hyprland/6a7abd0' (2026-05-03)
  → 'github:hyprwm/Hyprland/6d4bcaf' (2026-05-03)
• Updated input 'nur':
    'github:nix-community/NUR/d177168' (2026-05-03)
  → 'github:nix-community/NUR/e298aa4' (2026-05-03)
```