### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777951278,
-        "narHash": "sha256-4YiuaQFSxD51W3gtumdL7IdFA45dp15L5609D2Ecn1M=",
+        "lastModified": 1777962000,
+        "narHash": "sha256-Nrr5s5BZM6NSSdTjXY9x0qpFoOX19FFtlbNF+Mf9pRE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b63d7da8c15abc45d7afc9aa739cabd57aca33ce",
+        "rev": "2fcf045936bc226a0f006b2e92cd697478e8df31",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/b63d7da' (2026-05-05)
  → 'github:nix-community/NUR/2fcf045' (2026-05-05)
```