### PR TITLE
Add Nominatim service configuration and ingress route

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -69,6 +69,19 @@ Spawns four containers together: `lingarr` (subtitle manager), `libretranslate`
 The two options (`services.lingarr.enable` and `services.subgen.enable`) control
 whether to include the stack.
 
+**`nominatim.nix`** — OpenStreetMap geocoding API backed by PostgreSQL 16. Runs
+the `mediagis/nominatim` image as a standalone container. The initial start
+downloads and imports the configured PBF file (Norway by default, ~1.5 GB
+download / ~50 GB on-disk); this can take several hours — `TimeoutStartSec` is
+set to `infinity` to accommodate this. Incremental OSM updates via replication
+are enabled by default. The image uses default rootless Podman userns (no
+`keep-id`) because its entrypoint runs as container-root to create the
+`nominatim` system user and initialize the PostgreSQL cluster before dropping
+privileges — this is safe; container-root maps to the host user with zero host
+privilege. **Version upgrades** (e.g. 5.3 → 5.4) require running
+`nominatim admin --migrate` inside the container before the new image can serve
+requests; skipping this step will cause startup failures.
+
 ______________________________________________________________________
 
 ### Architecture
@@ -98,6 +111,9 @@ as rootless Podman Quadlet systemd user services.
          │
          ├── subgen-container (services.subgen-container.enable)
          │   └── subgen (:11027)
+         │
+         ├── nominatim-container (services.nominatim-container.enable)
+         │   └── nominatim-standalone (:11080)
          │
          └── subtitle-stack
              ├── lingarr        (:11025)  ← services.lingarr.enable

--- a/containers/README.md
+++ b/containers/README.md
@@ -54,6 +54,7 @@ ______________________________________________________________________
 | `services.subgen-container.enable` | [subgen.nix](subgen.nix) | 11027 | Whisper-based subtitle generator (CPU or AMD GPU) |
 | `services.lingarr.enable` | [subtitle-stack.nix](subtitle-stack.nix) | 11025 | Full subtitle translation pipeline (lingarr + libretranslate + ollama + subgen as a pod) |
 | `services.subgen.enable` | [subtitle-stack.nix](subtitle-stack.nix) | 11027 | Subgen as part of the subtitle-stack pod |
+| `services.nominatim-container.enable` | [nominatim.nix](nominatim.nix) | 11080 | OpenStreetMap geocoding API (mediagis/nominatim) |
 
 **`ollama.nix`** — Standalone LLM inference server. Supports ROCm (AMD GPU) or
 CPU-only image selection. Usable on any host that has Podman. Enable via

--- a/containers/nominatim.nix
+++ b/containers/nominatim.nix
@@ -16,7 +16,7 @@ in
 
     image = lib.mkOption {
       type = lib.types.str;
-      default = "mediagis/nominatim:5.3";
+      default = "docker.io/mediagis/nominatim:5.3";
       description = "Container image to use.";
     };
 
@@ -65,7 +65,7 @@ in
     virtualisation.quadlet.containers.nominatim-standalone = {
       autoStart = true;
       containerConfig = {
-        image = cfg.image;
+        inherit (cfg) image;
         publishPorts = [ "${toString cfg.port}:8080" ];
         volumes = [ "${cfg.dataDir}:/var/lib/postgresql/16/main" ];
         environments = {
@@ -77,8 +77,7 @@ in
           FREEZE = "false";
         }
         // cfg.extraEnvironments;
-        shmSize = cfg.shmSize;
-        userns = "keep-id";
+        inherit (cfg) shmSize;
       };
       serviceConfig = {
         Restart = "on-failure";

--- a/containers/nominatim.nix
+++ b/containers/nominatim.nix
@@ -62,7 +62,7 @@ in
       "d ${cfg.dataDir} 0755 - - -"
     ];
 
-    virtualisation.quadlet.containers.nominatim = {
+    virtualisation.quadlet.containers.nominatim-standalone = {
       autoStart = true;
       containerConfig = {
         image = cfg.image;

--- a/containers/nominatim.nix
+++ b/containers/nominatim.nix
@@ -3,7 +3,6 @@
 { lib, config, ... }:
 let
   cfg = config.services.nominatim-container;
-  inherit (config.virtualisation.quadlet) volumes;
 in
 {
   options.services.nominatim-container = {
@@ -19,6 +18,12 @@ in
       type = lib.types.str;
       default = "mediagis/nominatim:5.3";
       description = "Container image to use.";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/rpool/unenc/apps/docker/nominatim";
+      description = "Path for persistent Nominatim/Postgres data storage.";
     };
 
     pbfUrl = lib.mkOption {
@@ -53,14 +58,16 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    virtualisation.quadlet.volumes.nominatim-data = { };
+    systemd.user.tmpfiles.rules = [
+      "d ${cfg.dataDir} 0755 - - -"
+    ];
 
     virtualisation.quadlet.containers.nominatim = {
       autoStart = true;
       containerConfig = {
         image = cfg.image;
         publishPorts = [ "${toString cfg.port}:8080" ];
-        volumes = [ "${volumes.nominatim-data.ref}:/var/lib/postgresql/14/main" ];
+        volumes = [ "${cfg.dataDir}:/var/lib/postgresql/16/main" ];
         environments = {
           PBF_URL = cfg.pbfUrl;
           THREADS = toString cfg.threads;

--- a/containers/nominatim.nix
+++ b/containers/nominatim.nix
@@ -1,0 +1,82 @@
+# Nominatim OpenStreetMap geocoding API container
+# Home Manager module - runs rootless via quadlet-nix
+{ lib, config, ... }:
+let
+  cfg = config.services.nominatim-container;
+  inherit (config.virtualisation.quadlet) volumes;
+in
+{
+  options.services.nominatim-container = {
+    enable = lib.mkEnableOption "Nominatim OpenStreetMap geocoding container";
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 11080;
+      description = "Host port to expose the Nominatim API on.";
+    };
+
+    image = lib.mkOption {
+      type = lib.types.str;
+      default = "mediagis/nominatim:5.3";
+      description = "Container image to use.";
+    };
+
+    pbfUrl = lib.mkOption {
+      type = lib.types.str;
+      default = "https://download.geofabrik.de/europe/norway-latest.osm.pbf";
+      description = "URL of the OpenStreetMap PBF file to import on first run.";
+    };
+
+    replicationUrl = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = "https://download.geofabrik.de/europe/norway-updates/";
+      description = "Replication base URL for incremental OSM updates. Set null to disable.";
+    };
+
+    threads = lib.mkOption {
+      type = lib.types.int;
+      default = 4;
+      description = "Number of CPU threads for the initial PBF import.";
+    };
+
+    shmSize = lib.mkOption {
+      type = lib.types.str;
+      default = "1g";
+      description = "Shared memory size for Postgres inside the container.";
+    };
+
+    extraEnvironments = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      description = "Additional environment variables for the Nominatim container.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    virtualisation.quadlet.volumes.nominatim-data = { };
+
+    virtualisation.quadlet.containers.nominatim = {
+      autoStart = true;
+      containerConfig = {
+        image = cfg.image;
+        publishPorts = [ "${toString cfg.port}:8080" ];
+        volumes = [ "${volumes.nominatim-data.ref}:/var/lib/postgresql/14/main" ];
+        environments = {
+          PBF_URL = cfg.pbfUrl;
+          THREADS = toString cfg.threads;
+        }
+        // lib.optionalAttrs (cfg.replicationUrl != null) {
+          REPLICATION_URL = cfg.replicationUrl;
+          FREEZE = "false";
+        }
+        // cfg.extraEnvironments;
+        shmSize = cfg.shmSize;
+        userns = "keep-id";
+      };
+      serviceConfig = {
+        Restart = "on-failure";
+        TimeoutStartSec = "infinity";
+      };
+    };
+  };
+}

--- a/containers/nominatim.nix
+++ b/containers/nominatim.nix
@@ -34,8 +34,8 @@ in
 
     replicationUrl = lib.mkOption {
       type = lib.types.nullOr lib.types.str;
-      default = "https://download.geofabrik.de/europe/norway-updates/";
-      description = "Replication base URL for incremental OSM updates. Set null to disable.";
+      default = null;
+      description = "Replication base URL for incremental OSM updates. Must match the region of pbfUrl. Set null to disable (default).";
     };
 
     threads = lib.mkOption {

--- a/containers/ollama.nix
+++ b/containers/ollama.nix
@@ -23,7 +23,7 @@ in
     image = lib.mkOption {
       type = lib.types.nullOr lib.types.str;
       default = null;
-      description = "Container image to use. Defaults to ollama/ollama:rocm when gpu.enable is true, ollama/ollama:latest otherwise.";
+      description = "Container image to use. Defaults to docker.io/ollama/ollama:rocm when gpu.enable is true, docker.io/ollama/ollama:latest otherwise.";
     };
 
     extraEnvironments = lib.mkOption {

--- a/containers/ollama.nix
+++ b/containers/ollama.nix
@@ -53,9 +53,9 @@ in
           if cfg.image != null then
             cfg.image
           else if cfg.gpu.enable then
-            "ollama/ollama:rocm"
+            "docker.io/ollama/ollama:rocm"
           else
-            "ollama/ollama:latest";
+            "docker.io/ollama/ollama:latest";
         publishPorts = [
           "${toString cfg.port}:11434"
         ];

--- a/containers/subgen.nix
+++ b/containers/subgen.nix
@@ -1,6 +1,6 @@
 # Standalone Subgen container - can run on any host independently
 # Home Manager module - runs rootless via quadlet-nix
-# Uses mccloud/subgen:cpu by default, mccloud/subgen:amd when gpu.enable is true
+# Uses docker.io/mccloud/subgen:cpu by default, docker.io/mccloud/subgen:amd when gpu.enable is true
 { lib, config, ... }:
 let
   cfg = config.services.subgen-container;
@@ -32,7 +32,7 @@ in
     image = lib.mkOption {
       type = lib.types.nullOr lib.types.str;
       default = null;
-      description = "Container image to use. Defaults to mccloud/subgen:amd when gpu.enable is true, mccloud/subgen:cpu otherwise.";
+      description = "Container image to use. Defaults to docker.io/mccloud/subgen:amd when gpu.enable is true, docker.io/mccloud/subgen:cpu otherwise.";
     };
 
     whisperModel = lib.mkOption {

--- a/containers/subgen.nix
+++ b/containers/subgen.nix
@@ -138,9 +138,9 @@ in
           if cfg.image != null then
             cfg.image
           else if cfg.gpu.enable then
-            "mccloud/subgen:amd"
+            "docker.io/mccloud/subgen:amd"
           else
-            "mccloud/subgen:cpu";
+            "docker.io/mccloud/subgen:cpu";
         publishPorts = [
           "${toString cfg.port}:9000"
         ];

--- a/containers/subtitle-stack.nix
+++ b/containers/subtitle-stack.nix
@@ -204,7 +204,7 @@ in
           subgen = {
             autoStart = true;
             containerConfig = {
-              image = "mccloud/subgen";
+              image = "docker.io/mccloud/subgen";
               environments = {
                 WHISPER_MODEL = cfgSubgen.whisperModel;
                 WHISPER_THREADS = "6";

--- a/containers/subtitle-stack.nix
+++ b/containers/subtitle-stack.nix
@@ -147,7 +147,7 @@ in
           lingarr = {
             autoStart = true;
             containerConfig = {
-              image = "lingarr/lingarr:latest";
+              image = "docker.io/lingarr/lingarr:latest";
               environments = {
                 ASPNETCORE_URLS = "http://+:9876";
                 MAX_CONCURRENT_JOBS = "1";
@@ -175,7 +175,7 @@ in
           libretranslate = {
             autoStart = true;
             containerConfig = {
-              image = "libretranslate/libretranslate:latest";
+              image = "docker.io/libretranslate/libretranslate:latest";
               environments = {
                 LT_LOAD_ONLY = "en,it,nb";
               };
@@ -191,7 +191,7 @@ in
           ollama = {
             autoStart = true;
             containerConfig = {
-              image = "ollama/ollama:latest";
+              image = "docker.io/ollama/ollama:latest";
               volumes = [
                 "${cfgLingarr.dataDir}/ollama:/root/.ollama"
               ];

--- a/hosts/blizzard/security/traefik.nix
+++ b/hosts/blizzard/security/traefik.nix
@@ -36,6 +36,10 @@ let
         "crowdsec"
       ];
     };
+    nominatim = {
+      subdomain = "nominatim";
+      url = "http://127.0.0.1:11080";
+    };
   };
   generated = traefikLib.mkRoutes { domain = VARS.domains.public; } (generatedVmRoutes // hostRoutes);
   matrixSynapseEnabled = vmInstances."matrix-synapse".enable or false;

--- a/hosts/blizzard/services/cloudflared.nix
+++ b/hosts/blizzard/services/cloudflared.nix
@@ -12,6 +12,7 @@
       "dashboard.${VARS.domains.public}" = "http://localhost:80";
       "metrics.${VARS.domains.public}" = "http://localhost:80";
       "lingarr.${VARS.domains.public}" = "http://localhost:80";
+      "nominatim.${VARS.domains.public}" = "http://localhost:80";
     };
   };
 }

--- a/hosts/blizzard/virtualisation/containers.nix
+++ b/hosts/blizzard/virtualisation/containers.nix
@@ -21,7 +21,10 @@ in
         ollama.enable = false;
       };
 
-      nominatim-container.enable = true;
+      nominatim-container = {
+        enable = true;
+        replicationUrl = "https://download.geofabrik.de/europe/norway-updates/";
+      };
 
       subgen = {
         enable = false;

--- a/hosts/blizzard/virtualisation/containers.nix
+++ b/hosts/blizzard/virtualisation/containers.nix
@@ -12,6 +12,7 @@ in
   home-manager.users.${username} = {
     imports = [
       ../../../containers/subtitle-stack.nix
+      ../../../containers/nominatim.nix
     ];
 
     services = {
@@ -19,6 +20,8 @@ in
         enable = true;
         ollama.enable = false;
       };
+
+      nominatim-container.enable = true;
 
       subgen = {
         enable = false;


### PR DESCRIPTION
This pull request introduces a new Nominatim OpenStreetMap geocoding API container to the system, making it available as a managed service. It includes configuration options, integrates the service into the Blizzard host, and exposes it via Traefik and Cloudflared for public access. The most important changes are summarized below:

**Nominatim container service addition and configuration:**

* Added a new Home Manager module `nominatim.nix` to define a `services.nominatim-container` option, allowing users to enable a rootless Nominatim container with configurable image, port, import data, replication, and resource settings.
* Updated the service documentation in `containers/README.md` to document the new `services.nominatim-container.enable` option and its purpose.

**Host integration and exposure:**

* Enabled the Nominatim container service in the Blizzard host configuration by importing `nominatim.nix` and setting `nominatim-container.enable = true` in `hosts/blizzard/virtualisation/containers.nix`. [[1]](diffhunk://#diff-a3cac066bed20dfb933bb86bb35036a06de94580604ab5c3761434b29861e178R15) [[2]](diffhunk://#diff-a3cac066bed20dfb933bb86bb35036a06de94580604ab5c3761434b29861e178R24-R25)
* Added a Traefik route for `nominatim` to expose the service internally at `http://127.0.0.1:11080` via the `nominatim` subdomain.
* Configured Cloudflared to expose `nominatim.${VARS.domains.public}` externally, routing it to the local service.