### PR TITLE
Fix inter-container networking and ClickHouse migration issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Commands
 
+> **Note:** `nixos-rebuild`, `nix build`, and `nix flake check` all pull the
+> private `nix-secrets` flake via SSH (`git+ssh://git@github.com/telometto/nix-secrets`).
+> They will fail with a publickey error without the corresponding SSH key.
+> CI is the source of truth for build validation.
+
 ```bash
 # Apply configuration to current host
 sudo nixos-rebuild switch --flake .#<hostname>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Hosts: `snowfall` (desktop/KDE), `blizzard` (server), `avalanche` (desktop/GNOME
 
 ### Auto-loading
 
-The repo uses two loaders that eliminate manual imports:
+The repo uses three loaders that eliminate manual imports:
 
 - **`system-loader.nix`** — recursively imports every `.nix` file under `modules/`. Any new file there is immediately available.
 - **`hm-loader.nix`** — recursively imports every `.nix` file under `home/`, excluding `overrides/host/` and `overrides/user/` (those are opt-in).

--- a/docs/troubleshooting-trigger-vm.md
+++ b/docs/troubleshooting-trigger-vm.md
@@ -1,0 +1,201 @@
+# Trigger VM — Troubleshooting Log
+
+**Date:** 2026-05-08  
+**VM:** `trigger-vm` (`admin@10.100.0.80`)  
+**Reported issue:** `trigger-ch-migrate-fixup.service` fails → `trigger-compose.service` never starts.
+
+---
+
+## Symptom
+
+```
+× trigger-ch-migrate-fixup.service - Repair trigger.dev ClickHouse goose migration state before stack startup
+     Active: failed (Result: exit-code)
+    Process: ExecStart=…trigger-ch-migrate-fixup-start (code=exited, status=81)
+
+May 08 08:28:20 trigger-vm trigger-ch-migrate-fixup-start[2334]:
+  Code: 81. DB::Exception: Database trigger_dev does not exist. (UNKNOWN_DATABASE)
+```
+
+`trigger-compose.service` is `inactive (dead)` because its `Requires=` on the fixup service was not satisfied.
+
+---
+
+## Initial Code Analysis (from nix-config)
+
+The relevant service is defined in `modules/services/trigger.nix`.
+
+The `trigger-ch-migrate-fixup` script:
+
+1. Starts only the ClickHouse container (`docker compose up -d clickhouse`).
+2. Waits up to 60 s for it to become healthy.
+3. Extracts `CLICKHOUSE_PASSWORD` from `/run/trigger/compose.env`.
+4. Defines a helper `ch()` that runs `clickhouse-client --database trigger_dev`.
+5. Uses `ch()` for the **very first check** — a query against `system.tables`:
+   ```bash
+   GOOSE_TABLE=$(ch "SELECT count() FROM system.tables WHERE database='trigger_dev' AND name='goose_db_version'")
+   [ "$GOOSE_TABLE" = "0" ] && exit 0
+   ```
+
+**Root-cause hypothesis (pre-SSH):** The `ch()` helper passes `--database trigger_dev` to every invocation of `clickhouse-client`. On a fresh install (or after a data-volume wipe) the `trigger_dev` database does not yet exist. The intent is to detect this case (`GOOSE_TABLE = 0`) and bail early, but the `--database` flag forces ClickHouse to switch to `trigger_dev` *before* running the query, producing exit code 81 (`UNKNOWN_DATABASE`) before the result can be returned. The early-exit guard never fires.
+
+---
+
+## SSH Investigation
+
+### Step 1 — Service status (already known from user report)
+
+```
+trigger-setup.service   → active (exited) — SUCCESS
+trigger-ch-migrate-fixup.service → failed (exit-code 81)
+trigger-compose.service → inactive (dead, dependency failed)
+```
+
+### Step 2 — Confirmed root cause of fixup failure
+
+SSH'd into `blizzard` via Tailscale, then `ssh admin@10.100.0.80`.
+
+```
+# SHOW DATABASES inside ClickHouse → trigger_dev does not exist (fresh install)
+# Confirms hypothesis: ch() passes --database trigger_dev before the DB exists
+# → ClickHouse throws UNKNOWN_DATABASE (exit 81) before the query runs
+```
+
+**Fix applied** in `modules/services/trigger.nix`: added a prior check using
+`system.databases` (no `--database` flag) before calling `ch()`. Skips the
+entire script when the database does not yet exist.
+
+### Step 3 — Manually started the stack, discovered networking failure
+
+Bypassed the fixup service and ran `docker compose up -d` manually. All 9
+containers started, but `trigger-webapp-1` immediately crash-looped with:
+
+```
+Error: P1001: Can't reach database server at `postgres:5432`
+```
+
+Prisma migration cannot connect to postgres. Tested with upstream
+trigger.dev compose files in `/tmp/trigger-test/` — identical failure,
+confirming this is an environmental issue, not specific to our Nix config.
+
+### Step 4 — Network diagnostics
+
+| Test | Result |
+|---|---|
+| `nslookup postgres` from webapp network | Resolves to `172.19.0.3` ✓ |
+| `nc -w3 -zv postgres 5432` | **Hangs** (no SYN-ACK) |
+| `nc -w3 -zv 172.19.0.3 5432` (by IP) | **Hangs** |
+| `ping 172.19.0.3` from same network | **No reply** |
+| `postgres listen_addresses` | `'*'` (all interfaces) |
+| `ip_forward` | `1` (enabled) |
+| `iptables -L FORWARD` | `policy ACCEPT`, DOCKER-FORWARD chain present |
+| `bridge link show` | **Empty** — no ports attached to ANY bridge |
+| `/sys/class/net/br-960e0a746dc5/brif/` | **Empty** — confirmed at sysfs |
+
+Docker had created bridge interfaces (`br-*`) and veth pairs, but **never
+attached the veths as bridge slaves**. This is the structural reason no
+inter-container traffic could flow — even ICMP was blocked.
+
+### Step 5 — Root cause identified: systemd-networkd matching Docker veths
+
+The routing table revealed the cause:
+
+```
+default via 10.100.0.1 dev vethcca6681 proto static   ← wrong!
+default via 10.100.0.1 dev veth84d50bc proto static   ← wrong!
+10.100.0.0/24 dev vethcca6681 src 10.100.0.80         ← wrong!
+...
+```
+
+`systemd-networkd` was matching every Docker veth interface because
+`/etc/systemd/network/20-lan.network` uses `matchConfig.Type = "ether"`,
+which also matches veth link-type interfaces. This caused two problems:
+
+1. **networkd "claimed" each veth**, preventing Docker from running
+   `ip link set vethXXX master br-YYY` — hence `brif/` always empty.
+2. **Route table pollution** — the VM's static LAN routes were injected into
+   every new veth, breaking Docker's own routing.
+
+Secondary blocker also found: `base.nix` sets `rp_filter = 1` (strict), which
+would additionally drop inter-container packets even if the bridge were
+attached, because return packets arrive on the bridge but the routing table
+routes the source subnet via the veth.
+
+---
+
+## Fix
+
+### Fix 1 — `trigger-ch-migrate-fixup` (code complete, needs rebuild)
+
+File: `modules/services/trigger.nix`
+
+Added a prior check against `system.databases` (no `--database` flag) before
+calling `ch()`. This correctly handles a fresh install where `trigger_dev` does
+not yet exist.
+
+### Fix 2 — systemd-networkd veth match (code complete, needs rebuild)
+
+File: `vms/mkMicrovmConfig.nix`
+
+Changed `matchConfig.Type = "ether"` to also exclude Docker interface names:
+
+```nix
+matchConfig = {
+  Type = "ether";
+  Name = "!veth* !br-* !docker*";
+};
+```
+
+Added a `"99-docker-ignore"` network unit that marks `veth*`, `br-*`, and
+`docker*` interfaces as `Unmanaged = true`.
+
+### Fix 3 — rp_filter (code complete, needs rebuild)
+
+File: `vms/base.nix`
+
+Changed `net.ipv4.conf.all.rp_filter` from `1` (strict) to `2` (loose).
+Loose mode still validates that a route exists for the source IP, but does not
+require the reverse path to use the same interface — which is the normal
+behaviour for Docker bridge networking.
+
+### Live workaround (applied on the VM, not persistent across rebuild)
+
+```bash
+# 1. Create a networkd ignore file with higher priority (sorts before 20-lan)
+#    and correct permissions
+sudo bash -c 'cat > /etc/systemd/network/10-docker-ignore.network << EOF
+[Match]
+Name=veth* br-* docker*
+
+[Link]
+Unmanaged=yes
+EOF'
+sudo chmod 644 /etc/systemd/network/10-docker-ignore.network
+sudo networkctl reload
+
+# 2. Lower rp_filter to loose mode
+sudo sysctl -w net.ipv4.conf.all.rp_filter=2 net.ipv4.conf.default.rp_filter=2
+
+# 3. Restart Docker so new veths use the corrected networkd rules
+sudo systemctl restart docker
+```
+
+After applying: `bridge link show` shows all veth slaves in `forwarding`
+state, and `nc -w3 -zv postgres 5432` returns `open` from within the webapp
+network.
+
+> **NOTE:** The live workaround file `/etc/systemd/network/10-docker-ignore.network`
+> and the `sysctl` changes are NOT persistent across a reboot or NixOS rebuild.
+> The proper fix is in the Nix config (see fixes 2 and 3 above) and must be
+> deployed via a NixOS rebuild on Blizzard once CI validates it.
+
+---
+
+## Remaining work
+
+- [ ] Deploy all three fixes via NixOS rebuild on Blizzard (requires SSH to
+  Blizzard with rebuild permissions, or push to `main` and let CI build).
+- [ ] After rebuild, wipe `/tmp/trigger-test/` and re-run the native
+  `trigger-compose.service` (not the upstream test) to confirm end-to-end.
+- [ ] Monitor that `trigger-ch-migrate-fixup.service` succeeds on the first
+  boot after the rebuild (fresh `trigger_dev` database).

--- a/docs/troubleshooting-trigger-vm.md
+++ b/docs/troubleshooting-trigger-vm.md
@@ -1,10 +1,10 @@
 # Trigger VM — Troubleshooting Log
 
-**Date:** 2026-05-08  
-**VM:** `trigger-vm` (`admin@10.100.0.80`)  
+**Date:** 2026-05-08\
+**VM:** `trigger-vm` (`admin@10.100.0.80`)\
 **Reported issue:** `trigger-ch-migrate-fixup.service` fails → `trigger-compose.service` never starts.
 
----
+______________________________________________________________________
 
 ## Symptom
 
@@ -19,7 +19,7 @@ May 08 08:28:20 trigger-vm trigger-ch-migrate-fixup-start[2334]:
 
 `trigger-compose.service` is `inactive (dead)` because its `Requires=` on the fixup service was not satisfied.
 
----
+______________________________________________________________________
 
 ## Initial Code Analysis (from nix-config)
 
@@ -28,10 +28,10 @@ The relevant service is defined in `modules/services/trigger.nix`.
 The `trigger-ch-migrate-fixup` script:
 
 1. Starts only the ClickHouse container (`docker compose up -d clickhouse`).
-2. Waits up to 60 s for it to become healthy.
-3. Extracts `CLICKHOUSE_PASSWORD` from `/run/trigger/compose.env`.
-4. Defines a helper `ch()` that runs `clickhouse-client --database trigger_dev`.
-5. Uses `ch()` for the **very first check** — a query against `system.tables`:
+1. Waits up to 60 s for it to become healthy.
+1. Extracts `CLICKHOUSE_PASSWORD` from `/run/trigger/compose.env`.
+1. Defines a helper `ch()` that runs `clickhouse-client --database trigger_dev`.
+1. Uses `ch()` for the **very first check** — a query against `system.tables`:
    ```bash
    GOOSE_TABLE=$(ch "SELECT count() FROM system.tables WHERE database='trigger_dev' AND name='goose_db_version'")
    [ "$GOOSE_TABLE" = "0" ] && exit 0
@@ -39,7 +39,7 @@ The `trigger-ch-migrate-fixup` script:
 
 **Root-cause hypothesis (pre-SSH):** The `ch()` helper passes `--database trigger_dev` to every invocation of `clickhouse-client`. On a fresh install (or after a data-volume wipe) the `trigger_dev` database does not yet exist. The intent is to detect this case (`GOOSE_TABLE = 0`) and bail early, but the `--database` flag forces ClickHouse to switch to `trigger_dev` *before* running the query, producing exit code 81 (`UNKNOWN_DATABASE`) before the result can be returned. The early-exit guard never fires.
 
----
+______________________________________________________________________
 
 ## SSH Investigation
 
@@ -113,7 +113,7 @@ which also matches veth link-type interfaces. This caused two problems:
 
 1. **networkd "claimed" each veth**, preventing Docker from running
    `ip link set vethXXX master br-YYY` — hence `brif/` always empty.
-2. **Route table pollution** — the VM's static LAN routes were injected into
+1. **Route table pollution** — the VM's static LAN routes were injected into
    every new veth, breaking Docker's own routing.
 
 Secondary blocker also found: `base.nix` sets `rp_filter = 1` (strict), which
@@ -121,7 +121,7 @@ would additionally drop inter-container packets even if the bridge were
 attached, because return packets arrive on the bridge but the routing table
 routes the source subnet via the veth.
 
----
+______________________________________________________________________
 
 ## Fix
 
@@ -189,7 +189,7 @@ network.
 > The proper fix is in the Nix config (see fixes 2 and 3 above) and must be
 > deployed via a NixOS rebuild on Blizzard once CI validates it.
 
----
+______________________________________________________________________
 
 ## Remaining work
 

--- a/docs/troubleshooting-trigger-vm.md
+++ b/docs/troubleshooting-trigger-vm.md
@@ -151,12 +151,14 @@ Added a `"99-docker-ignore"` network unit that marks `veth*`, `br-*`, and
 
 ### Fix 3 — rp_filter (code complete, needs rebuild)
 
-File: `vms/base.nix`
+File: `modules/services/trigger.nix`
 
-Changed `net.ipv4.conf.all.rp_filter` from `1` (strict) to `2` (loose).
-Loose mode still validates that a route exists for the source IP, but does not
-require the reverse path to use the same interface — which is the normal
-behaviour for Docker bridge networking.
+Added a `sys.services.trigger.looseRpFilter` option (defaults to `true`).
+When enabled, it sets `net.ipv4.conf.all.rp_filter = 2` (loose) scoped only
+to the system that enables the trigger service. `vms/base.nix` keeps the
+strict default (`rp_filter = 1`) for all other VMs — only trigger-vm gets
+loose mode, because Docker bridge networking creates asymmetric routing that
+strict mode drops.
 
 ### Live workaround (applied on the VM, not persistent across rebuild)
 

--- a/docs/troubleshooting-trigger-vm.md
+++ b/docs/troubleshooting-trigger-vm.md
@@ -137,17 +137,15 @@ not yet exist.
 
 File: `vms/mkMicrovmConfig.nix`
 
-Changed `matchConfig.Type = "ether"` to also exclude Docker interface names:
+Replaced the broad `Type = "ether"` match with a precise MAC-address match so
+only the VM's virtio NIC receives the static LAN config:
 
 ```nix
-matchConfig = {
-  Type = "ether";
-  Name = "!veth* !br-* !docker*";
-};
+matchConfig.MACAddress = mac;
 ```
 
 Added a `"99-docker-ignore"` network unit that marks `veth*`, `br-*`, and
-`docker*` interfaces as `Unmanaged = true`.
+`docker*` interfaces as `Unmanaged = true` for defense in depth.
 
 ### Fix 3 — rp_filter (code complete, needs rebuild)
 

--- a/hosts/blizzard/virtualisation/microvms.nix
+++ b/hosts/blizzard/virtualisation/microvms.nix
@@ -301,6 +301,7 @@ let
 
     trigger = {
       enable = true;
+      ingressHosts = [ "triggers" ];
       reverseProxy = {
         subdomain = "triggers";
         url = vmUrl "trigger";

--- a/modules/services/trigger.nix
+++ b/modules/services/trigger.nix
@@ -365,6 +365,18 @@ in
       description = "Docker image tag for tecnativa/docker-socket-proxy.";
     };
 
+    looseRpFilter = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Set rp_filter to 2 (loose) on this host. Required when Docker bridge
+        networking is in use: bridge return paths are asymmetric and strict mode
+        (1) drops inter-container packets. Defaults to true because the trigger
+        service always requires Docker. Set to false only if a custom routing
+        configuration eliminates the asymmetry and you need strict anti-spoofing.
+      '';
+    };
+
     smtp = {
       enable = lib.mkEnableOption "SMTP transport for magic-link emails" // {
         default = false;
@@ -462,13 +474,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    # rp_filter=1 (strict) drops inter-container packets on Docker bridge networks
-    # because the return route for a container source IP goes out the bridge
-    # interface, not the veth the packet arrived on.  Loose mode (2) accepts
-    # packets as long as the source IP is routable by any route, which is
-    # sufficient for the isolated VM threat model while still dropping
-    # completely unroutable (spoofed) source addresses.
-    boot.kernel.sysctl = {
+    boot.kernel.sysctl = lib.mkIf cfg.looseRpFilter {
       "net.ipv4.conf.all.rp_filter" = lib.mkForce 2;
       "net.ipv4.conf.default.rp_filter" = lib.mkForce 2;
     };

--- a/modules/services/trigger.nix
+++ b/modules/services/trigger.nix
@@ -462,6 +462,17 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # rp_filter=1 (strict) drops inter-container packets on Docker bridge networks
+    # because the return route for a container source IP goes out the bridge
+    # interface, not the veth the packet arrived on.  Loose mode (2) accepts
+    # packets as long as the source IP is routable by any route, which is
+    # sufficient for the isolated VM threat model while still dropping
+    # completely unroutable (spoofed) source addresses.
+    boot.kernel.sysctl = {
+      "net.ipv4.conf.all.rp_filter" = lib.mkForce 2;
+      "net.ipv4.conf.default.rp_filter" = lib.mkForce 2;
+    };
+
     assertions = [
       {
         assertion = !cfg.smtp.enable || cfg.smtp.passwordFile != "";
@@ -609,7 +620,15 @@ in
                 --database trigger_dev --query "$1"
             }
 
-            # Skip all checks on a first-ever install (goose_db_version does not exist yet).
+            # Skip all checks on a first-ever install: trigger_dev database does not exist yet.
+            # NOTE: do NOT use ch() here — it passes --database trigger_dev, which makes
+            # ClickHouse throw UNKNOWN_DATABASE (exit 81) before the query can run.
+            DB_EXISTS=$(${pkgs.docker}/bin/docker exec trigger-clickhouse-1 \
+              clickhouse-client --user default --password "$CHPASS" \
+              --query "SELECT count() FROM system.databases WHERE name='trigger_dev'")
+            [ "$DB_EXISTS" = "0" ] && exit 0
+
+            # trigger_dev exists — skip if goose_db_version table has not been created yet.
             GOOSE_TABLE=$(ch "SELECT count() FROM system.tables WHERE database='trigger_dev' AND name='goose_db_version'")
             [ "$GOOSE_TABLE" = "0" ] && exit 0
 

--- a/vms/README.md
+++ b/vms/README.md
@@ -98,7 +98,7 @@ ______________________________________________________________________
 - **Standard kernel** (`pkgs.linuxPackages`) — intentionally not the hardened
   variant; chosen for broad driver compatibility. The comment at line 19 of
   `base.nix` makes this explicit.
-- **sysctl hardening** — rp_filter=1, no ICMP redirects/broadcasts, no source
+- **sysctl hardening** — rp_filter=1 (strict; trigger-vm overrides to 2 via `trigger.nix`), no ICMP redirects/broadcasts, no source
   routing, kptr_restrict=2, dmesg_restrict=1, core dumps disabled
   (`kernel.core_pattern = "|/bin/false"`)
 - **Kernel module blacklist** — bluetooth, btusb, uvcvideo

--- a/vms/README.md
+++ b/vms/README.md
@@ -98,7 +98,7 @@ ______________________________________________________________________
 - **Standard kernel** (`pkgs.linuxPackages`) — intentionally not the hardened
   variant; chosen for broad driver compatibility. The comment at line 19 of
   `base.nix` makes this explicit.
-- **sysctl hardening** — rp_filter=1 (strict; trigger-vm overrides to 2 via `trigger.nix`), no ICMP redirects/broadcasts, no source
+- **sysctl hardening** — rp_filter=1 (strict; trigger-vm overrides to 2 via `sys.services.trigger.looseRpFilter` in `modules/services/trigger.nix`), no ICMP redirects/broadcasts, no source
   routing, kptr_restrict=2, dmesg_restrict=1, core dumps disabled
   (`kernel.core_pattern = "|/bin/false"`)
 - **Kernel module blacklist** — bluetooth, btusb, uvcvideo

--- a/vms/base.nix
+++ b/vms/base.nix
@@ -26,7 +26,12 @@
     ];
 
     kernel.sysctl = {
-      # Network security: enable reverse path filtering to prevent IP spoofing
+      # Strict reverse-path filtering: drop packets whose source IP's best
+      # return route does not use the same interface the packet arrived on.
+      # This is the correct default for all VMs.  Services that run Docker
+      # (trigger-vm) override this to 2 (loose) in their own config because
+      # Docker bridge networking creates asymmetric routing that strict mode
+      # would otherwise drop.
       "net.ipv4.conf.all.rp_filter" = 1;
       "net.ipv4.conf.default.rp_filter" = 1;
 

--- a/vms/mkMicrovmConfig.nix
+++ b/vms/mkMicrovmConfig.nix
@@ -68,7 +68,15 @@
   };
 
   systemd.network.networks."20-lan" = {
-    matchConfig.Type = "ether";
+    # Match only the VM's physical NIC (virtio); explicitly exclude Docker
+    # veth pairs and bridge interfaces so systemd-networkd does not claim them.
+    # Without this, networkd matches every new veth Docker creates (Type=ether)
+    # and applies the VM's static routes to it, which both pollutes the routing
+    # table and prevents Docker from attaching the veth to a bridge.
+    matchConfig = {
+      Type = "ether";
+      Name = "!veth* !br-* !docker*";
+    };
     networkConfig = {
       Address = [ "${ip}/24" ];
       Gateway = gateway;
@@ -77,4 +85,11 @@
     };
   }
   // lib.optionalAttrs (extraRoutes != [ ]) { routes = extraRoutes; };
+
+  # Explicitly tell systemd-networkd to leave Docker veth and bridge
+  # interfaces unmanaged so Docker can configure them freely.
+  systemd.network.networks."99-docker-ignore" = {
+    matchConfig.Name = "veth* br-* docker*";
+    linkConfig.Unmanaged = true;
+  };
 }

--- a/vms/mkMicrovmConfig.nix
+++ b/vms/mkMicrovmConfig.nix
@@ -68,15 +68,10 @@
   };
 
   systemd.network.networks."20-lan" = {
-    # Match only the VM's physical NIC (virtio); explicitly exclude Docker
-    # veth pairs and bridge interfaces so systemd-networkd does not claim them.
-    # Without this, networkd matches every new veth Docker creates (Type=ether)
-    # and applies the VM's static routes to it, which both pollutes the routing
-    # table and prevents Docker from attaching the veth to a bridge.
-    matchConfig = {
-      Type = "ether";
-      Name = "!veth* !br-* !docker*";
-    };
+    # Match the VM's primary NIC by its fixed MAC address so only the virtio
+    # interface gets the static LAN config; no other interface (Docker veth,
+    # future ether device, etc.) can accidentally match this unit.
+    matchConfig.MACAddress = mac;
     networkConfig = {
       Address = [ "${ip}/24" ];
       Gateway = gateway;


### PR DESCRIPTION
This pull request addresses several networking and service initialization issues with the `trigger-vm` (running Docker) and improves documentation and configuration for better reliability and maintainability. The main themes are: fixing Docker bridge networking, improving service startup checks, and making sysctl (rp_filter) handling more robust and explicit.

**Key changes:**

**Docker networking and systemd-networkd integration:**
* Updated `vms/mkMicrovmConfig.nix` to match the VM's primary NIC by MAC address instead of `Type = "ether"`, preventing systemd-networkd from claiming Docker veth interfaces and breaking container networking. Also added a `"99-docker-ignore"` network unit to mark `veth*`, `br-*`, and `docker*` interfaces as unmanaged, ensuring Docker can manage its own network devices. [[1]](diffhunk://#diff-47385c63a97900da14adad34251e5a64f3ca0c8356b56c540889c4992754f1d2L71-R74) [[2]](diffhunk://#diff-47385c63a97900da14adad34251e5a64f3ca0c8356b56c540889c4992754f1d2R83-R89)
* Improved documentation in `vms/base.nix` and `vms/README.md` to clarify the default strict `rp_filter` setting and the override for Docker hosts. [[1]](diffhunk://#diff-fcace3e7166e9c1aabaf2167b5e71adab70088853ed2d5da16984f969c137fccL29-R34) [[2]](diffhunk://#diff-6b86bbe7bc4b460194ad6422f48e0e4cf0198c907a66e27aeb697fba049b5c4bL101-R101)

**Service startup and troubleshooting:**
* Enhanced the `trigger-ch-migrate-fixup` service in `modules/services/trigger.nix` to check for the existence of the `trigger_dev` database before attempting to query it, preventing failures on fresh installs where the database does not exist yet.
* Added a new troubleshooting guide, `docs/troubleshooting-trigger-vm.md`, detailing the root causes and fixes for the ClickHouse migration and Docker networking failures, and documenting live workarounds and permanent solutions.

**Sysctl/rp_filter configuration:**
* Introduced a `looseRpFilter` option in `modules/services/trigger.nix` (default `true`), which sets `net.ipv4.conf.all.rp_filter` and `net.ipv4.conf.default.rp_filter` to `2` (loose mode) only on hosts running the trigger service, to accommodate Docker's asymmetric routing. [[1]](diffhunk://#diff-e463bb4ec370fc096eaa06395e99ef4ba04e6be9934defe78d308dc77d7dcdadR368-R379) [[2]](diffhunk://#diff-e463bb4ec370fc096eaa06395e99ef4ba04e6be9934defe78d308dc77d7dcdadR477-R481)

**Minor documentation and config improvements:**
* Updated `CLAUDE.md` with additional notes on SSH requirements for Nix commands and clarified that three auto-loaders are used. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R7-R11) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L27-R32)
* Added `ingressHosts = [ "triggers" ];` to the `trigger` VM definition in `hosts/blizzard/virtualisation/microvms.nix` for improved ingress configuration.