### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1778250672,
-        "narHash": "sha256-1ZiBsqEpVSNjG3HqpmXxGXr/GrSqt9+XNh4YRgYjGFU=",
+        "lastModified": 1778255143,
+        "narHash": "sha256-XLenzzQ7f9kC1od8pwkbVRNR7XGjhbeWiNXVL+E4wME=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "ac75bcab713490eb000e4fa48f7e7316c3535854",
+        "rev": "bd7f695363898826d5bd04fe830f19581ac4c5b2",
         "type": "github"
       },
       "original": {
@@ -544,11 +544,11 @@
     },
     "nix-secrets": {
       "locked": {
-        "lastModified": 1778190022,
-        "narHash": "sha256-Sr2qivViULqEdYV+PPKzFZs2GqNXETTbBk75F09BeSg=",
+        "lastModified": 1778264374,
+        "narHash": "sha256-0oE8bll7D+j/l93EgeqDNaw4+F5dDqomHdXbN4UTul8=",
         "ref": "refs/heads/master",
-        "rev": "8d3c004b2fdb9071c99a19de342c049a0739577d",
-        "revCount": 115,
+        "rev": "acb2397413ae2304abdabd411e2fca44b39a07df",
+        "revCount": 119,
         "type": "git",
         "url": "ssh://git@github.com/telometto/nix-secrets.git"
       },
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778247803,
-        "narHash": "sha256-Q3Xc4rXZAO6xmpQTVCwmWVVXUstD++tNGlY1ERWO9xY=",
+        "lastModified": 1778261723,
+        "narHash": "sha256-vDa6Dc9yNzV1LYGGkGcst8gyb7nDIKLXUTy490EkkjY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eb31e7d6ea71a4dc38688af19b1c02331b645a18",
+        "rev": "f034b3ef2841340b1440a052e6d0bb2cf7916030",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hyprland':
    'github:hyprwm/Hyprland/ac75bca' (2026-05-08)
  → 'github:hyprwm/Hyprland/bd7f695' (2026-05-08)
• Updated input 'nix-secrets':
    'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=8d3c004b2fdb9071c99a19de342c049a0739577d' (2026-05-07)
  → 'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=acb2397413ae2304abdabd411e2fca44b39a07df' (2026-05-08)
• Updated input 'nur':
    'github:nix-community/NUR/eb31e7d' (2026-05-08)
  → 'github:nix-community/NUR/f034b3e' (2026-05-08)
```