### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778386059,
-        "narHash": "sha256-/I1GXcNiDHw5TUmeNAT6w3rvsMO7occMDSAQ/aw9Nmk=",
+        "lastModified": 1778394406,
+        "narHash": "sha256-ClABzj2hOM0g15xP15PgZf5n0bSE8JeZ4gUhQd5on2o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1f69698ef66af4707accb7004c36e193d4032da4",
+        "rev": "c6fcfd668de2bc5a940e0442579b8ddfbb2526ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/1f69698' (2026-05-10)
  → 'github:nix-community/NUR/c6fcfd6' (2026-05-10)
```