### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778482206,
-        "narHash": "sha256-xJJmDrBhf8ng8uy2wXDHi3BJgE6nMh7akb4ujdhzkbs=",
+        "lastModified": 1778491870,
+        "narHash": "sha256-8pBUC6Zr+9xUwgg+seXBR/Qk1Ahccdkrprmkz+BjJ6M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8382bc9a9a4b63fef00c67adae9a06a2efb6254d",
+        "rev": "61c8204435edf29e8db049ffbf2e8d10d3b5f766",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/8382bc9' (2026-05-11)
  → 'github:nix-community/NUR/61c8204' (2026-05-11)
```