### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778503501,
-        "narHash": "sha256-08L/X4/do7nET4rzidJ76eV/1r+mB7DchVpdPypsghc=",
+        "lastModified": 1778534125,
+        "narHash": "sha256-NtERcpQEPjcal0WWC9ZuL5C52zU3L22Z2xkEUR1GoRs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "85ba629c79449badf4338117c27f0ee92b4b9f1a",
+        "rev": "bc63bedcab3454f11c79fcdbcf90301deb562b6c",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778522706,
-        "narHash": "sha256-Iuy0A0A5+VLeCU2BqxqZ4LWB+GV0L5wDH9rkV9wgNtc=",
+        "lastModified": 1778533032,
+        "narHash": "sha256-emPitPU+hYMX6Ir0MVUae+5Y3PHWWQ9eCgUDQV8a+gQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "962e88614e6be0002c6dd480e4948173e382e045",
+        "rev": "83359f93a6b9f75e488c503a2f5b31593b6ebf65",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/85ba629' (2026-05-11)
  → 'github:nix-community/home-manager/bc63bed' (2026-05-11)
• Updated input 'nur':
    'github:nix-community/NUR/962e886' (2026-05-11)
  → 'github:nix-community/NUR/83359f9' (2026-05-11)
```