### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778630411,
-        "narHash": "sha256-Smu3BFqQSClR6xryZrhctY9lax58X712LWzNKN2OIW0=",
+        "lastModified": 1778645506,
+        "narHash": "sha256-7FokJ6hpBnJc/c3UsVhs2NiyeNZxLGGZY2qmY96v/78=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f1e9517dfcaaf8229e8f102932fc019fba76772c",
+        "rev": "7e7807470cc4b68c8d9e95dbaa0fce7adb5c782b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/f1e9517' (2026-05-13)
  → 'github:nix-community/NUR/7e78074' (2026-05-13)
```