### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778628724,
-        "narHash": "sha256-VNG6hJ146VEenXcDrB3t6MVnrMx+gtyCWTCDkzOp9Qs=",
+        "lastModified": 1778681890,
+        "narHash": "sha256-RK4sTgei29wBzLu+e4ljeixKutWhbMygFsdxdFKpZOU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6a0bbd6b4720da1c9ce7ebf35ff5c41a82db367a",
+        "rev": "7654d90b94bab7eba3a52fd6f73b3f5a4c544fa2",
         "type": "github"
       },
       "original": {
@@ -234,11 +234,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1778673255,
-        "narHash": "sha256-bG5+6/rZAR54UljPRpr5+nB0AzrMeyX5Als0l+M2uY0=",
+        "lastModified": 1778683849,
+        "narHash": "sha256-fKMHYZexPtUUVVvGRake8HE0qXxSdKCtUGdNYqRFNec=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "9099ac311812ccf1befe9f8435ba1f52b30a4bd0",
+        "rev": "998d3af07f57603710674e7cb337b0814d925caf",
         "type": "github"
       },
       "original": {
@@ -638,11 +638,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1778586796,
-        "narHash": "sha256-/WuJBhnL6LLlXto4Pa2w5FGcmwIVZIN0PA7tY/RLEU8=",
+        "lastModified": 1778672786,
+        "narHash": "sha256-Blg88K1jwG+P0Mr27+rKMFCufdrWkV3wWh9AdYtz0FQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b25e938b89759b5f9466fc53c4a970244f84dc39",
+        "rev": "eef00dfd8a712b34af845f9350bac681b1228bd1",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778675535,
-        "narHash": "sha256-h7qUkm+u+IvuATyB4iGRO3Eu7Q5cKjUMPFQjoBFxHF4=",
+        "lastModified": 1778683893,
+        "narHash": "sha256-ne3l9Y4QTU40g4Yl3HAFGbf+UC59sjZTFlf+cDlo5Og=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "160e1b9bff7012a462172bef427a6165c86d0ad3",
+        "rev": "eac968451bd5e184c24142a5919d6f04b263756e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/6a0bbd6' (2026-05-12)
  → 'github:nix-community/home-manager/7654d90' (2026-05-13)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/9099ac3' (2026-05-13)
  → 'github:hyprwm/Hyprland/998d3af' (2026-05-13)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/b25e938' (2026-05-12)
  → 'github:NixOS/nixpkgs/eef00df' (2026-05-13)
• Updated input 'nur':
    'github:nix-community/NUR/160e1b9' (2026-05-13)
  → 'github:nix-community/NUR/eac9684' (2026-05-13)
```