### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1777830388,
-        "narHash": "sha256-2uoQAqUk2H0ijQtGiWAyNeQYGYc6yfAcRRLlJAz4Gp8=",
+        "lastModified": 1778106249,
+        "narHash": "sha256-cM/AuKy5tMhwOOQIbha8ZRRMHVfNf7cv2aljIw+qoCg=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "d459c1350e96ce1a7e3859c513ef5e9869d67d6f",
+        "rev": "6d015ea29630b7ad2402841386da2cb617a470a7",
         "type": "github"
       },
       "original": {
@@ -488,11 +488,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1777882242,
-        "narHash": "sha256-9Ynx+ort1aSwReiCfkbgMS3Q6y+MPcekDoUWx9N3a7A=",
+        "lastModified": 1778697027,
+        "narHash": "sha256-ior9a10BqOyUH4hykv0qF4Mae3aqL5UjdFgIZiYzZMg=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "04723d4fd6bde2665fef3b25856aeebbd4013c16",
+        "rev": "2b568929cc954894be2a645c64f6ee2acdb17705",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778683893,
-        "narHash": "sha256-ne3l9Y4QTU40g4Yl3HAFGbf+UC59sjZTFlf+cDlo5Og=",
+        "lastModified": 1778695849,
+        "narHash": "sha256-0EO3WSLKutTLsCHiYlSBrYmdtG+b3qjt9hwk7im4Hog=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eac968451bd5e184c24142a5919d6f04b263756e",
+        "rev": "38b90b03da4aeb56bb58defc1b470415fbccf49b",
         "type": "github"
       },
       "original": {
@@ -788,11 +788,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777778183,
-        "narHash": "sha256-Lqv9MZO0XAGcMbXJU+ULBSMD41Pf391uJehylUQKe7Y=",
+        "lastModified": 1778383025,
+        "narHash": "sha256-UK7s2LJS1YwIMFL7PSaNJvLXT9pyRgm7X+HNPgMXiEE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "dbba5f888c82ef3ce594c451c33ac2474eb80847",
+        "rev": "4568a557ca325ff81fb354382d4a9968daa1001a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/04723d4' (2026-05-04)
  → 'github:nix-community/lanzaboote/2b56892' (2026-05-13)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/d459c13' (2026-05-03)
  → 'github:ipetkov/crane/6d015ea' (2026-05-06)
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/dbba5f8' (2026-05-03)
  → 'github:oxalica/rust-overlay/4568a55' (2026-05-10)
• Updated input 'nur':
    'github:nix-community/NUR/eac9684' (2026-05-13)
  → 'github:nix-community/NUR/38b90b0' (2026-05-13)
```