### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778921576,
-        "narHash": "sha256-jgIbBcGgKTtkp+lBas29hNFUU1t5O/2+GFvUjbiG0vM=",
+        "lastModified": 1778937626,
+        "narHash": "sha256-OzLAT0G96WlT/WWaNdkTvQ7E9ohq9h0xQTdL1oe3gm0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "32b42d71b4b22c4465963285bb6e462d7c93d45e",
+        "rev": "d5ece85b6d3d6b5ab5a514b2785fb952b629bfea",
         "type": "github"
       },
       "original": {
@@ -654,11 +654,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1778443072,
-        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778928309,
-        "narHash": "sha256-Ip1aeJq+v5B/UZCumsDP/uRadZkL/znNdiK3UNayYBQ=",
+        "lastModified": 1778944455,
+        "narHash": "sha256-1kb+w2fGIsefw2yeae73xQdjek0sxuyR0BKihFFWMfU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "65c51877443a1b3d63daabe7a696e6601df89caa",
+        "rev": "f8f41aee00744ec8b3a1b631ca5e479656017063",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/32b42d7' (2026-05-16)
  → 'github:nix-community/home-manager/d5ece85' (2026-05-16)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/da5ad66' (2026-05-10)
  → 'github:NixOS/nixpkgs/d233902' (2026-05-15)
• Updated input 'nur':
    'github:nix-community/NUR/65c5187' (2026-05-16)
  → 'github:nix-community/NUR/f8f41ae' (2026-05-16)
```