### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778937626,
-        "narHash": "sha256-OzLAT0G96WlT/WWaNdkTvQ7E9ohq9h0xQTdL1oe3gm0=",
+        "lastModified": 1778954430,
+        "narHash": "sha256-oaNyOr05lblaQdtbkbN1wO0b2KLIL2O1LkmwDgdQp4I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d5ece85b6d3d6b5ab5a514b2785fb952b629bfea",
+        "rev": "26aaab785b0bab4af60a2c42b22760fa906ef22a",
         "type": "github"
       },
       "original": {
@@ -234,11 +234,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1778931952,
-        "narHash": "sha256-f/f0/RQ4aT2eeaiiydK/gZP5o1YWd2YrrJu0g/xQ7bk=",
+        "lastModified": 1778954996,
+        "narHash": "sha256-U/l8nAYLzMsQPriAIdiknypmVidrEqrt11AjbFnq3CI=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "d56a9444c3a22dcf4981fd8f54508a098bac3971",
+        "rev": "7d1e481bb8aaf0b56bd91eea24f2fd360eab1986",
         "type": "github"
       },
       "original": {
@@ -559,11 +559,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1778924461,
-        "narHash": "sha256-pDGhSCz+QxjHzP9gqYpK59k4Z1ZpVyYjzBgoXLFXh9s=",
+        "lastModified": 1778945272,
+        "narHash": "sha256-Aipz0UiBhE2a1FYJrNc2y+5vKWo5QVkhmaIJk3/ls+g=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "65a5c8f9c19d5f9d1b06d8942b04d790414ccfdd",
+        "rev": "379c1f274f0fa354d012f0600806de54e79f29b5",
         "type": "github"
       },
       "original": {
@@ -638,11 +638,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1778843877,
-        "narHash": "sha256-BxYhb8H0aVtiM1kGRt+S49NbsJMUMIHvOXxziE9u0nY=",
+        "lastModified": 1778930970,
+        "narHash": "sha256-FqqcYr0c5in/HRL5bkRWykAGp/Q10Vj/zUiSr1P8URE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "758b562bc257084aef30b8e3efbdd61d292806c3",
+        "rev": "5a51fe22e18a6ce886b3cffa4c255378c151323c",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778944455,
-        "narHash": "sha256-1kb+w2fGIsefw2yeae73xQdjek0sxuyR0BKihFFWMfU=",
+        "lastModified": 1778954777,
+        "narHash": "sha256-IHCuyDc/0i3uWkoyzXL9kfIqRVXMxTDytySG9rkwcIA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f8f41aee00744ec8b3a1b631ca5e479656017063",
+        "rev": "ad67825c68dff9de2ea7070b353bd7b83baa2ed9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/d5ece85' (2026-05-16)
  → 'github:nix-community/home-manager/26aaab7' (2026-05-16)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/d56a944' (2026-05-16)
  → 'github:hyprwm/Hyprland/7d1e481' (2026-05-16)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/65a5c8f' (2026-05-16)
  → 'github:NixOS/nixos-hardware/379c1f2' (2026-05-16)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/758b562' (2026-05-15)
  → 'github:NixOS/nixpkgs/5a51fe2' (2026-05-16)
• Updated input 'nur':
    'github:nix-community/NUR/f8f41ae' (2026-05-16)
  → 'github:nix-community/NUR/ad67825' (2026-05-16)
```