### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778991107,
-        "narHash": "sha256-Q/x+TiM4CmREXUh7Q7X7OIRr4kmWgMTYpID4QpGWJdE=",
+        "lastModified": 1779000169,
+        "narHash": "sha256-BHTE70uVmOH2Q5bwhP1hbyF575Es2GE6joZv0s+5Sxw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "41e6be42801d2cbcbb13c1eb0e5705ad3d5cd4c0",
+        "rev": "c39f81dacb4e66a46d825017cbadbe868618dcf8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/41e6be4' (2026-05-17)
  → 'github:nix-community/NUR/c39f81d' (2026-05-17)
```