### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1778966108,
-        "narHash": "sha256-nq8lNb/YRIH6Re3AKtlJDjbx2RhhQYm1sCQVCf5moeY=",
+        "lastModified": 1779037148,
+        "narHash": "sha256-1xFi+dLOySAtI76dC0bG/+yA8rnZAH1Xl0s8mpP+PGE=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "24c5c13c2cef2b4324478f2fb8c2ecc386dd42d3",
+        "rev": "93b83c19f3e4e71fb36ed61a47277e141c09b3f7",
         "type": "github"
       },
       "original": {
@@ -559,11 +559,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1778945272,
-        "narHash": "sha256-Aipz0UiBhE2a1FYJrNc2y+5vKWo5QVkhmaIJk3/ls+g=",
+        "lastModified": 1779034340,
+        "narHash": "sha256-zhMjgfsnNPcZtMhhWoeyaUV7JVEJ4rm5YJ0whwTfo8M=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "379c1f274f0fa354d012f0600806de54e79f29b5",
+        "rev": "88e6bd5c2db9e0b098d8ccb081f35fe33f0f3186",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779030773,
-        "narHash": "sha256-nXuB6kCzjSCjkmtVG4JI0FPsuW8rUiR4p+RuZ0OwCD0=",
+        "lastModified": 1779041511,
+        "narHash": "sha256-yHKOKS4c3N9LZI9N8gevboU4xHswtfLaSFUFEiZ6ubA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "449b40632cbd295c7a3978ff9dd1cb1dd983eeae",
+        "rev": "4cc9a64b7243b7c1bd6e17558052f795f659e91d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hyprland':
    'github:hyprwm/Hyprland/24c5c13' (2026-05-16)
  → 'github:hyprwm/Hyprland/93b83c1' (2026-05-17)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/379c1f2' (2026-05-16)
  → 'github:NixOS/nixos-hardware/88e6bd5' (2026-05-17)
• Updated input 'nur':
    'github:nix-community/NUR/449b406' (2026-05-17)
  → 'github:nix-community/NUR/4cc9a64' (2026-05-17)
```