### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779103424,
-        "narHash": "sha256-hBYJz5jnRDjACPrwdD064zwMW+s5bdNlG/lNQipLhgM=",
+        "lastModified": 1779118529,
+        "narHash": "sha256-+N//FFtb7YMg25HAhCejgQIkiqF5otLQtyrDrouRxlM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "dd71501fb7005264feb4de78444a2e1518cd4f66",
+        "rev": "7519f615df36804ef40bcb03d4114f5ec9216d40",
         "type": "github"
       },
       "original": {
@@ -234,11 +234,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1779061968,
-        "narHash": "sha256-kWlrGgqZJAdBbXlJMrZ2TKt+bsfEh6jPuAwV58kb6jg=",
+        "lastModified": 1779115357,
+        "narHash": "sha256-FOg5J51dsqKeXC0d2o7x3eMdLDVwRnyMqd1/kupVfwI=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "4e3955716619c58a8e9e2f81af5f8f2862e77a1b",
+        "rev": "01ab0474b4ae92db9c25dc0eef6515b99544698f",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779109178,
-        "narHash": "sha256-/SeZx1Yjp3s/yHytK5qWX1ZCxmJ61sfuJf/U77oeaPg=",
+        "lastModified": 1779120149,
+        "narHash": "sha256-sd+58T+CK1i2wwnisIfGW42BOS3xzJcUbz4LtYwpF+w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4445949c42fc870da6891e508d9b5d58bdb56c29",
+        "rev": "eec7c9af21e4617cca01d09d3b76329830bd6dee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/dd71501' (2026-05-18)
  → 'github:nix-community/home-manager/7519f61' (2026-05-18)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/4e39557' (2026-05-17)
  → 'github:hyprwm/Hyprland/01ab047' (2026-05-18)
• Updated input 'nur':
    'github:nix-community/NUR/4445949' (2026-05-18)
  → 'github:nix-community/NUR/eec7c9a' (2026-05-18)
```