### PR TITLE
Update SSH configuration and enable auto-discovery of keys

### DIFF
--- a/home/desktop/kde.nix
+++ b/home/desktop/kde.nix
@@ -28,25 +28,31 @@ let
       if [ $timeout -le 0 ]; then
         echo "KWallet not available yet, skipping automatic SSH key import"
         echo "Keys can be added manually with: ssh-add"
-        exit 0  # Exit gracefully instead of failing
+        exit 0
       fi
       sleep 1
       timeout=$((timeout - 1))
     done
 
-    # Import only explicitly listed SSH keys (no greedy auto-discovery)
+    # Auto-discover SSH keys: for every .pub file, import the private counterpart
     sshDir="${config.home.homeDirectory}/.ssh"
-    for keyName in ${lib.escapeShellArgs cfg.sshKeys}; do
-      key="$sshDir/$keyName"
-      if [ -f "$key" ]; then
-        if ${pkgs.openssh}/bin/ssh-keygen -l -f "$key" > /dev/null 2>&1; then
-          echo "Adding key: $key"
-          ${pkgs.openssh}/bin/ssh-add "$key" </dev/null || true
-        else
-          echo "Skipping invalid key: $key"
-        fi
+    for pubKey in "$sshDir"/*.pub; do
+      [ -e "$pubKey" ] || continue
+      keyName="$(basename "$pubKey" .pub)"
+      privKey="$sshDir/$keyName"
+      ${lib.optionalString (cfg.excludeKeys != [ ]) ''
+        skip=0
+        for excl in ${lib.escapeShellArgs cfg.excludeKeys}; do
+          [ "$keyName" = "$excl" ] && skip=1 && break
+        done
+        [ "$skip" = "1" ] && continue
+      ''}
+      [ -f "$privKey" ] || continue
+      if ${pkgs.openssh}/bin/ssh-keygen -l -f "$privKey" > /dev/null 2>&1; then
+        echo "Adding key: $privKey"
+        ${pkgs.openssh}/bin/ssh-add "$privKey" </dev/null || true
       else
-        echo "Warning: SSH key not found: $key"
+        echo "Skipping invalid key: $privKey"
       fi
     done
   '';
@@ -67,10 +73,10 @@ in
       description = "Additional KDE configuration";
     };
 
-    sshKeys = lib.mkOption {
+    excludeKeys = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ ];
-      description = "List of SSH key filenames in ~/.ssh to auto-import via KWallet on login. Empty list disables auto-import.";
+      description = "SSH key filenames in ~/.ssh to skip during auto-import (base name without .pub extension).";
       example = [
         "id_ed25519"
         "work_rsa"
@@ -118,8 +124,8 @@ in
       SSH_ASKPASS_REQUIRE = "prefer";
     };
 
-    # Automatic SSH key import using KWallet
-    systemd.user.services."ssh-add-keys" = lib.mkIf (cfg.sshKeys != [ ]) {
+    # Automatic SSH key import: auto-discovers private keys by .pub counterpart
+    systemd.user.services."ssh-add-keys" = {
       Unit = {
         Description = "Load SSH keys into the agent using KWallet";
 

--- a/home/overrides/host/ssh-common.nix
+++ b/home/overrides/host/ssh-common.nix
@@ -1,31 +1,29 @@
-# Shared SSH matchBlocks configuration.
-# Imported explicitly by host overrides that need it.
 { config, ... }:
 {
   programs.ssh = {
     enableDefaultConfig = false;
-    matchBlocks = {
+    settings = {
       "*" = {
-        addKeysToAgent = "yes";
-        compression = false;
-        serverAliveInterval = 0;
-        serverAliveCountMax = 3;
-        hashKnownHosts = false;
-        userKnownHostsFile = "~/.ssh/known_hosts";
-        controlMaster = "no";
-        controlPath = "~/.ssh/master-%r@%n:%p";
-        controlPersist = "no";
+        AddKeysToAgent = "yes";
+        Compression = false;
+        ServerAliveInterval = 0;
+        ServerAliveCountMax = 3;
+        HashKnownHosts = false;
+        UserKnownHostsFile = "~/.ssh/known_hosts";
+        ControlMaster = "no";
+        ControlPath = "~/.ssh/master-%r@%n:%p";
+        ControlPersist = "no";
       };
       "github.com" = {
-        hostname = "ssh.github.com";
-        port = 443;
-        user = "git";
-        identitiesOnly = true;
-        identityFile = "${config.home.homeDirectory}/.ssh/github-key";
+        HostName = "ssh.github.com";
+        Port = 443;
+        User = "git";
+        IdentitiesOnly = true;
+        IdentityFile = "${config.home.homeDirectory}/.ssh/github-key";
       };
       "192.168.*" = {
-        identityFile = "${config.home.homeDirectory}/.ssh/id_ed25519";
-        identitiesOnly = true;
+        IdentityFile = "${config.home.homeDirectory}/.ssh/id_ed25519";
+        IdentitiesOnly = true;
       };
     };
   };


### PR DESCRIPTION
This pull request updates the SSH key import logic and SSH client configuration to simplify management and improve compatibility. The main changes are: auto-discovery of SSH keys for import (with an exclusion list), and a migration from `matchBlocks` to `settings` in the SSH configuration for improved option casing and consistency.

**SSH key import improvements:**

* Changed the SSH key import mechanism in `home/desktop/kde.nix` to auto-discover all private keys that have a `.pub` file in `~/.ssh`, instead of requiring an explicit list. A new `excludeKeys` option allows users to skip specific keys by base name. [[1]](diffhunk://#diff-49a833e75ca48f4cdd4efd591a879c63cc8bb3b37d00f89842263fdacc205c1dL31-R55) [[2]](diffhunk://#diff-49a833e75ca48f4cdd4efd591a879c63cc8bb3b37d00f89842263fdacc205c1dL70-R79) [[3]](diffhunk://#diff-49a833e75ca48f4cdd4efd591a879c63cc8bb3b37d00f89842263fdacc205c1dL121-R128)

**SSH configuration migration and improvements:**

* Migrated from `matchBlocks` to `settings` in `home/overrides/host/ssh-common.nix`, updating all SSH options to use the correct casing (e.g., `AddKeysToAgent` instead of `addKeysToAgent`) and ensuring compatibility with the latest Nix Home Manager conventions.