### PR TITLE
Deprecate openweather-refined extension

### DIFF
--- a/home/desktop/gnome.nix
+++ b/home/desktop/gnome.nix
@@ -98,7 +98,7 @@ in
       pkgs.gnomeExtensions.coverflow-alt-tab
       pkgs.gnomeExtensions.clipboard-indicator
       pkgs.gnomeExtensions.gsconnect
-      pkgs.gnomeExtensions.openweather-refined
+      # pkgs.gnomeExtensions.openweather-refined # deprecated
       pkgs.gnomeExtensions.proton-vpn-button
       pkgs.gnomeExtensions.status-area-horizontal-spacing
       pkgs.gnomeExtensions.tailscale-status


### PR DESCRIPTION
Comment out deprecated openweather-refined extension.