### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779941221,
-        "narHash": "sha256-3id5avGwINZRTvGGnYM2+TuidEkcp9QDdKPtyY5ur+w=",
+        "lastModified": 1779951790,
+        "narHash": "sha256-4DHEbDXzNwEC/mif/zpHsDn5vnIFG5JipDVVWWZ2EzA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "635015086a68c7912081912a2ab2e72311a5925d",
+        "rev": "566c3f6bdb8a2c46e146a55be21e3b8de6fe8a96",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/6350150' (2026-05-28)
  → 'github:nix-community/NUR/566c3f6' (2026-05-28)
```