### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779726696,
-        "narHash": "sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA=",
+        "lastModified": 1779963803,
+        "narHash": "sha256-FyaT9NIl8TkydPKwjyJTsi9YZc62lWxSa2sdiyyQbXk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1a95e2efb477959b70b4a14c51035975c0481df6",
+        "rev": "d17712ec7a9f8682919b4659a3975018e8ed9dcb",
         "type": "github"
       },
       "original": {
@@ -638,11 +638,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1779912294,
-        "narHash": "sha256-Ek1wwdQHlM06lnnuCrZqQD4wo8iTnCgMt+VRN+xyH2g=",
+        "lastModified": 1779955849,
+        "narHash": "sha256-31mhzm2HpzRr/rupWAFfWBmt9SUjzwr5+giv5Nmb/rA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9be0b880a6dbb749060aca82f60bede62f318e69",
+        "rev": "a2c6938835fca96e4a10c8561d461efd2f91d04f",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779951790,
-        "narHash": "sha256-4DHEbDXzNwEC/mif/zpHsDn5vnIFG5JipDVVWWZ2EzA=",
+        "lastModified": 1779962957,
+        "narHash": "sha256-/WChCACMER1A1PMpxe0UBXXzjT5fnj4sr02sHPvEK1w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "566c3f6bdb8a2c46e146a55be21e3b8de6fe8a96",
+        "rev": "0766e59b683c56088e40114d9406a31251dc5133",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/1a95e2e' (2026-05-25)
  → 'github:nix-community/home-manager/d17712e' (2026-05-28)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/9be0b88' (2026-05-27)
  → 'github:NixOS/nixpkgs/a2c6938' (2026-05-28)
• Updated input 'nur':
    'github:nix-community/NUR/566c3f6' (2026-05-28)
  → 'github:nix-community/NUR/0766e59' (2026-05-28)
```