### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1780046192,
-        "narHash": "sha256-Jg9jOzfCN/oPNlWJK2ahMovSKgK5XzD1cygCAIwc4G4=",
+        "lastModified": 1780058324,
+        "narHash": "sha256-+t97F7PpZWjMcXFOH9oPGNsG424azqCDTcBRL1gMkoE=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "558936e2382ec14b8dda6a9156522f65f6b07d15",
+        "rev": "cbcddf2848fcdd9d2490df786c92003bcd763fac",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780047425,
-        "narHash": "sha256-pIm+REWTwlUtFgAchErwQyBfm8hEv2Tv0nfA0DEPVqg=",
+        "lastModified": 1780057162,
+        "narHash": "sha256-7UwTPs0ZfN6amjg7fnrbQhskslE30ll5NmhO5/+xYEo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "94702d415c9ba700b57609fd052ac97ea773c0dd",
+        "rev": "3d4e8370533d85da786ba16410316d77791c680a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hyprland':
    'github:hyprwm/Hyprland/558936e' (2026-05-29)
  → 'github:hyprwm/Hyprland/cbcddf2' (2026-05-29)
• Updated input 'nur':
    'github:nix-community/NUR/94702d4' (2026-05-29)
  → 'github:nix-community/NUR/3d4e837' (2026-05-29)
```