### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -692,11 +692,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780099718,
-        "narHash": "sha256-dfzDr/3Hyur/z43oczMou5f4hNJJAU3uYKiWP9wREXQ=",
+        "lastModified": 1780114327,
+        "narHash": "sha256-oppaANHxj6aO9FigbGH/Wb5Mf4jDR0yl/o7clN2ely0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "402c4f0e205b2cc12c75380a1af830df7e1ddd6f",
+        "rev": "0d52ed663ce6f088f25d6026c198c5af371302cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/402c4f0' (2026-05-30)
  → 'github:nix-community/NUR/0d52ed6' (2026-05-30)
```