### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -234,11 +234,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1780058324,
-        "narHash": "sha256-+t97F7PpZWjMcXFOH9oPGNsG424azqCDTcBRL1gMkoE=",
+        "lastModified": 1780133317,
+        "narHash": "sha256-5YmxDPnBx7DxyyIhMNzwdbAh7WtRW6hfEmM+kU1cMjE=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "cbcddf2848fcdd9d2490df786c92003bcd763fac",
+        "rev": "e43b163f7917f4f2bfa16f8474096badd5170f39",
         "type": "github"
       },
       "original": {
@@ -692,11 +692,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780122683,
-        "narHash": "sha256-5Ob7sZTJPHyJ09dYzsGKuTfckQQi6cKbYZjFp11a4Kw=",
+        "lastModified": 1780133727,
+        "narHash": "sha256-hwwhJjgDvdVP4tFICnZe3yWSezI7qnQ5l5A6BxVgQ+w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "346b019336388f237d5686584d833e024edf96ff",
+        "rev": "10ae770b7190e60ff39955a4d0fa19b644501ce8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hyprland':
    'github:hyprwm/Hyprland/cbcddf2' (2026-05-29)
  → 'github:hyprwm/Hyprland/e43b163' (2026-05-30)
• Updated input 'nur':
    'github:nix-community/NUR/346b019' (2026-05-30)
  → 'github:nix-community/NUR/10ae770' (2026-05-30)
```