### PR TITLE
Update documentation for MicroVM outputs and verification dates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -103,7 +103,7 @@ hosts/<hostname>/             # Per-host config
   packages.nix (optional)
   containers.nix (optional)
 
-vms/                          # MicroVM definitions (23 VMs), merged into nixosConfigurations
+vms/                          # MicroVM definitions (25 wired VM outputs), merged into nixosConfigurations
 containers/                   # Rootless Podman containers (Home Manager modules)
 lib/                          # Shared helpers (constants, traefik, grafana)
 dashboards/                   # Grafana dashboard JSON (shared/ + host/blizzard/)
@@ -277,7 +277,7 @@ maintainer instead of guessing lock hashes.
 - `paperless-ngx` has a build workaround in `vms/flake-microvms.nix`
   (`doCheck = false; doInstallCheck = false;`). Preserve it unless you
   are deliberately re-testing upstream.
-- Documentation was last audited and verified against the codebase on 2026-04-27.
+- Documentation was last audited and verified against the codebase on 2026-06-01.
   When in doubt, prefer verifying against the source files over trusting a doc claim.
 
 ## 9. Where to look first

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Hosts: `snowfall` (desktop/KDE), `blizzard` (server), `avalanche` (desktop/GNOME
 
 ### Channel posture
 
-`nixpkgs` tracks `nixos-26.05` (stable). Use `sys.overlays.fromInputs.nixpkgs-small = [ "pkg" ]` to pull individual packages from `nixos-unstable-small`; use `nixpkgs-unstable = [ "pkg" ]` to back-pin to `nixos-24.11`. See `modules/core/overlays.nix` for the full option.
+`nixpkgs` and `nixpkgs-beta` track `nixos-26.05` (stable). Use `sys.overlays.fromInputs.nixpkgs-small = [ "pkg" ]` to pull individual packages from `nixos-unstable-small`; use `nixpkgs-unstable = [ "pkg" ]` for `nixos-unstable`. See `modules/core/overlays.nix` for the full option.
 
 ### Auto-loading
 
@@ -95,9 +95,11 @@ Enable in a host file: `sys.role.desktop.enable = true;`
 
 ### MicroVMs
 
+- `vms/flake-microvms.nix` — wires the 25 current `*-vm` outputs into `nixosConfigurations`.
 - `vms/vm-registry.nix` — single source of truth for CID, MAC, IP, memory, vCPU per VM.
 - `vms/mkMicrovmConfig.nix` — helper that generates common network/storage config from a registry entry.
 - `vms/base.nix` — shared hardened base (SSH keys, admin user, firewall).
+- `flaresolverr` currently has a standalone registry/file scaffold, but the active service runs inside `prowlarr-vm`; see `docs/architecture-risks-and-improvements.md`.
 
 ### Lib helpers
 

--- a/docs/Project_Architecture_Blueprint.md
+++ b/docs/Project_Architecture_Blueprint.md
@@ -1,6 +1,6 @@
 # Project Architecture Blueprint
 
-> **Last verified: 2026-04-27**
+> **Last verified: 2026-06-01**
 >
 > **Project Type:** NixOS Flake Configuration
 >
@@ -10,7 +10,7 @@ ______________________________________________________________________
 
 ## 1. Executive Summary
 
-This repository implements a modular NixOS flake configuration for 4 physical hosts and 23 MicroVMs.
+This repository implements a modular NixOS flake configuration for 4 physical hosts and 25 wired MicroVM outputs.
 The design centres on three auto-loading mechanisms that eliminate manual `imports` lists, a
 two-namespace option system (`sys.*` / `hm.*`), role files that bundle machine-class defaults,
 and a layered Home Manager precedence stack that allows fine-grained per-user overrides without
@@ -27,7 +27,7 @@ flowchart TD
     SL -->|"imports every .nix"| MOD["modules/**"]
     HL -->|"imports every .nix"| HOST["hosts/<hostname>/**"]
     HML -->|"imports every .nix\nexcluding overrides/"| HOME["home/**"]
-    F -->|merged from vms/flake-microvms.nix| VMS["nixosConfigurations.*-vm\n(23 MicroVMs)"]
+    F -->|merged from vms/flake-microvms.nix| VMS["nixosConfigurations.*-vm\n(25 wired VM outputs)"]
     F --> HOSTS["nixosConfigurations\nsnowfall · blizzard · avalanche · kaizer"]
 ```
 
@@ -39,7 +39,7 @@ ______________________________________________________________________
 
 | Output | Value |
 |--------|-------|
-| `nixosConfigurations` | 4 named hosts + 23 `-vm` entries (merged from `vms/flake-microvms.nix`) |
+| `nixosConfigurations` | 4 named hosts + 25 `-vm` entries (merged from `vms/flake-microvms.nix`) |
 | `formatter.x86_64-linux` | treefmt wrapper (nixfmt, shfmt, yamlfmt, mdformat, jsonfmt, ruff) |
 | `checks.x86_64-linux.formatting` | treefmt formatting check |
 | `devShells.x86_64-linux.default` | nil, nixfmt, deadnix, statix, sops, ssh-to-age |
@@ -55,7 +55,7 @@ There are no `homeConfigurations`, `packages`, `apps`, or `templates` outputs.
 | `./system-loader.nix` | repo |
 | `./host-loader.nix` | repo |
 | `inputs.disko.nixosModules.disko` | disko input (included; not actively used — see §13) |
-| `inputs.home-manager.nixosModules.home-manager` | home-manager |
+| `inputs.hm-stable.nixosModules.home-manager` | Home Manager release module |
 | `inputs.sops-nix.nixosModules.sops` | sops-nix |
 | `inputs.lanzaboote.nixosModules.lanzaboote` | lanzaboote |
 | `inputs.microvm.nixosModules.host` | microvm |
@@ -68,14 +68,15 @@ There are no `homeConfigurations`, `packages`, `apps`, or `templates` outputs.
 ```mermaid
 flowchart LR
     subgraph Core
-        NP[nixpkgs unstable]
-        NPS[nixpkgs-stable-latest 25.11]
-        NPS2[nixpkgs-stable 24.11]
-        NPU[nixpkgs-unstable-small]
+        NP[nixpkgs nixos-26.05]
+        NPB[nixpkgs-beta nixos-26.05]
+        NPU[nixpkgs-unstable]
+        NPS[nixpkgs-small unstable-small]
         NHW[nixos-hardware]
     end
     subgraph Build
-        HM[home-manager]
+        HM[hm-stable release-26.05]
+        HMM[hm-master]
         SOPS[sops-nix]
         LB[lanzaboote]
         MVM[microvm]
@@ -97,7 +98,7 @@ flowchart LR
     Build --> F
     Secrets --> F
     Dev --> F
-    F --> OUT1[nixosConfigurations\n4 hosts + 23 VMs]
+    F --> OUT1[nixosConfigurations\n4 hosts + 25 VM outputs]
     F --> OUT2[formatter / checks / devShells]
 ```
 
@@ -361,7 +362,7 @@ flowchart TD
     MK["vms/mkMicrovmConfig.nix\nTransforms registry attrs into NixOS module:\nmicrovm.hypervisor = cloud-hypervisor\nmicrovm.vsock.cid\nmicrovm.mem / vcpu\nmicrovm.interfaces / volumes\nnetworking + systemd.network\nAuto-appends /persist volume\nand /nix/store virtiofs share"]
     SVC["vms/<name>.nix\nPer-VM service module\n(actual application config)"]
     FM["vms/flake-microvms.nix\nmkMicrovm helper\nwraps each VM"]
-    OUT["nixosConfigurations.*-vm\n(23 entries merged into flake outputs)"]
+    OUT["nixosConfigurations.*-vm\n(25 entries merged into flake outputs)"]
 
     REG --> MK
     BASE --> FM
@@ -399,7 +400,16 @@ and therefore do not inherit host-only modules.
 | paperless | 10.100.0.61 | 11061 | 8 GB | 4 | Document management |
 | firefly | 10.100.0.62 | 11062 | 2 GB | 2 | Personal finance |
 | firefly-importer | 10.100.0.63 | 11063 | 512 MB | 1 | Firefly data import |
+| flaresolverr | 10.100.0.13 | 11013 | 512 MB | 1 | Embedded in `prowlarr-vm`; standalone scaffold exists |
 | immich | 10.100.0.70 | 11070 | 8 GB | 4 | Photo library |
+| mealie | 10.100.0.71 | 11071 | 1 GB | 1 | Recipe manager |
+| trigger | 10.100.0.80 | 11080 | 12 GB | 6 | Trigger.dev v4 background jobs |
+
+`vms/flake-microvms.nix` exposes 25 VM outputs. `vms/vm-registry.nix` also
+contains a standalone `flaresolverr` allocation and `vms/flaresolverr.nix`
+exists, but FlareSolverr currently runs inside `prowlarr-vm` instead of as a
+separate `flaresolverr-vm` output. See
+[`architecture-risks-and-improvements.md`](architecture-risks-and-improvements.md#microvm-count-and-flaresolverr).
 
 ______________________________________________________________________
 
@@ -413,7 +423,7 @@ flowchart TD
     HOST["blizzard host\n192.168.2.x / 10.100.0.1 bridge"]
     ADG["adguard-vm\n10.100.0.10\nDNS sinkhole"]
     WG["wireguard-vm\n10.100.0.11\nVPN gateway"]
-    REST["Other VMs\n10.100.0.12–70\ndefault gateway = 10.100.0.1"]
+    REST["Other VMs\n10.100.0.12–80\ndefault gateway = 10.100.0.1"]
 
     HOST --> ADG
     HOST --> WG
@@ -544,6 +554,11 @@ ______________________________________________________________________
 
 Hosts: `snowfall`, `blizzard`, `avalanche`, `kaizer`.
 
+Full flake evaluation, host builds, and `nixos-rebuild` require access to the
+private `nix-secrets` SSH input. In sandboxes without that deploy key, prefer
+syntax-only checks such as `nix-instantiate --parse <file>.nix` and rely on CI
+for full evaluation.
+
 ### Formatter chain (`nix fmt`)
 
 treefmt-nix orchestrates the following formatters in one pass:
@@ -611,4 +626,4 @@ ______________________________________________________________________
 
 ______________________________________________________________________
 
-*Last verified against source: 2026-04-27*
+*Last verified against source: 2026-06-01*

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,8 @@ flowchart LR
     subgraph Reference["Information-Oriented"]
         RA["Reference: Architecture\nreference-architecture.md"]
         RC["Reference: CI\nreference-ci.md"]
+      SOPS["SOPS Setup Guide\nsops-setup-guide.md"]
+      RISKS["Architecture Risks\narchitecture-risks-and-improvements.md"]
         BP["Architecture Blueprint\nProject_Architecture_Blueprint.md"]
     end
     subgraph Understanding["Understanding-Oriented"]
@@ -50,6 +52,9 @@ flowchart LR
   Quick reference for options and patterns
 - [reference-ci.md](reference-ci.md) —
   CI workflows, checks, and automation
+- [sops-setup-guide.md](sops-setup-guide.md) — Host recipient setup and secret flow
+- [architecture-risks-and-improvements.md](architecture-risks-and-improvements.md) —
+  Source-guided risks and improvement opportunities
 - [Project_Architecture_Blueprint.md](Project_Architecture_Blueprint.md) —
   Comprehensive architecture documentation
 
@@ -65,6 +70,8 @@ flowchart LR
 | Add a new user | [How-To: Add Hosts and Users](how-to-add-host-and-users.md) |
 | Understand the architecture | [Architecture Blueprint](Project_Architecture_Blueprint.md) |
 | Find option namespaces | [Reference: Architecture](reference-architecture.md) |
+| Configure host secrets | [SOPS Setup Guide](sops-setup-guide.md) |
+| Review risks and improvements | [Architecture Risks and Improvements](architecture-risks-and-improvements.md) |
 | Learn why things work this way | [Explanation: Design](explanation-design.md) |
 
 ### Directory READMEs

--- a/docs/reference-architecture.md
+++ b/docs/reference-architecture.md
@@ -11,7 +11,7 @@ Information reference for this repo's moving parts, options, and commands.
 | Output | Description |
 |--------|-------------|
 | `nixosConfigurations.{snowfall,blizzard,avalanche,kaizer}` | The four physical hosts |
-| `nixosConfigurations.<vm-name>` (×23) | MicroVM guests defined in `vms/` |
+| `nixosConfigurations.<vm-name>` (×25) | Wired MicroVM guests defined in `vms/flake-microvms.nix` |
 | `formatter.x86_64-linux` | treefmt wrapper (`nix fmt`) |
 | `checks.x86_64-linux.formatting` | Formatting check (`nix flake check`) |
 | `devShells.x86_64-linux.default` | Dev shell with nil, nixfmt, deadnix, statix, sops, ssh-to-age |
@@ -93,21 +93,25 @@ ______________________________________________________________________
 
 ## HM Override System
 
-Home Manager config is assembled in layers. Lower layers supply defaults; higher layers win.
+Home Manager config is assembled from imports and attrsets in
+`modules/core/home-users.nix`. Lower layers usually supply defaults; higher
+layers are where host/user-specific choices live. Normal Nix module priorities
+still apply, so `lib.mkForce` wins from any layer.
 
 | Layer | File / mechanism | Scope |
 |-------|-----------------|-------|
-| 1. Module defaults | Individual `home/*.nix` option defaults | All users, all hosts |
-| 2. HM loader modules | All files under `home/` (via hm-loader) | All users, all hosts |
-| 3. Host-wide extra modules | `sys.home.extraModules` in host file | All users on that host |
-| 4. Base template | `sys.home.template` in host file | All users on that host |
-| 5. Auto desktop | `hm.desktop.<flavor>.enable = true` from `sys.desktop.flavor` (via `lib.mkDefault`) | All users on hosts with a desktop flavor |
-| 6. Host override | `home/overrides/host/<hostname>.nix` | All users on that specific host |
-| 7. User@host override | `home/overrides/user/<username>-<hostname>.nix` | Specific user on specific host |
-| 8. User extra modules | `sys.home.users.<username>.extraModules` in host file | Specific user on that host |
-| 9. `extraConfig` | `sys.home.users.<username>.extraConfig` in host file | Specific user on that host |
+| 1. HM loader modules | All files under `home/` via `hm-loader.nix` | All users, all hosts |
+| 2. Host-wide extra modules | `sys.home.extraModules` in host config | All users on that host |
+| 3. Template imports | `sys.home.template.imports` | All users on that host |
+| 4. Host override | `home/overrides/host/<hostname>.nix`, if it exists | All users on that host |
+| 5. User@host override | `home/overrides/user/<username>-<hostname>.nix`, if it exists | Specific user on that host |
+| 6. User extra modules/imports | `sys.home.users.<username>.extraModules` and `extraConfig.imports` | Specific user on that host |
+| 7. Template attrs | `sys.home.template` without `imports` | All users on that host |
+| 8. User extra config attrs | `sys.home.users.<username>.extraConfig` without `imports` | Specific user on that host |
+| 9. Auto desktop defaults | `hm.desktop.<flavor>.enable = lib.mkDefault true` for KDE/GNOME/Hyprland | Desktop hosts |
 
-`lib.mkForce` in any override file always wins regardless of layer.
+`home.username` and `home.homeDirectory` are also filled with `lib.mkDefault`
+from the enabled system user data.
 
 ### The `ssh-common.nix` exception
 
@@ -175,7 +179,9 @@ The bridge between SOPS and service modules is the `sys.secrets.*` option namesp
 
 The `whenEnabled` pattern ties secret definitions to service enablement. A secret is only declared in `sops.secrets` when its corresponding service module is enabled (`lib.mkIf cfg.enable { sops.secrets.X = ...; }`). Disabling a service automatically removes its secret definition, preventing dangling decryption rules that would fail on hosts where that service is not running.
 
-See also: [Architecture Blueprint — Section 8: Secrets Architecture](Project_Architecture_Blueprint.md#section-8---secrets-architecture) for a full diagram.
+See also: [SOPS Setup Guide](sops-setup-guide.md) for host-recipient setup and
+[Architecture Blueprint — Section 8: Secrets Architecture](Project_Architecture_Blueprint.md#section-8---secrets-architecture)
+for a full diagram.
 
 ______________________________________________________________________
 
@@ -188,6 +194,11 @@ VMs do **not** use `system-loader.nix`. They are built with a minimal module set
 - [`vms/base.nix`](../vms/base.nix): Shared hardened base config for all VMs. Includes SSH host keys, admin user, firewall, and stateVersion.
 
 See [`vms/README.md`](../vms/README.md) for the full VM list and per-VM details.
+
+`vms/vm-registry.nix` currently contains one extra standalone allocation for
+`flaresolverr`. FlareSolverr is wired inside `prowlarr-vm` today, while the
+standalone `vms/flaresolverr.nix` scaffold is not a `nixosConfigurations`
+output. See [Architecture Risks and Improvements](architecture-risks-and-improvements.md#microvm-count-and-flaresolverr).
 
 ______________________________________________________________________
 
@@ -259,6 +270,8 @@ ______________________________________________________________________
 ## See Also
 
 - [Architecture Blueprint](Project_Architecture_Blueprint.md) — comprehensive diagrams and detailed explanations
+- [SOPS Setup Guide](sops-setup-guide.md) — host recipient setup and secret troubleshooting
+- [Architecture Risks and Improvements](architecture-risks-and-improvements.md) — source-guided risks and future improvements
 - [Explanation: Design](explanation-design.md) — rationale behind key decisions
 - [How-To: Add Hosts and Users](how-to-add-host-and-users.md) — step-by-step task guide
 - [vms/README.md](../vms/README.md) — VM list and configuration details

--- a/docs/reference-ci.md
+++ b/docs/reference-ci.md
@@ -31,6 +31,21 @@ SSH authentication error.
 
 ______________________________________________________________________
 
+### Local validation matrix
+
+| Check | Local without `nix-secrets` SSH? | Notes |
+|-------|:-------------------------------:|-------|
+| Read and edit files | yes | Always safe |
+| `nix-instantiate --parse <file>.nix` | yes | Syntax-only; does not evaluate the flake |
+| `deadnix .` / `statix check .` | yes, if installed | Static analysis only |
+| `nix fmt` | usually | Formats through `treefmt`; if input fetching fails locally, rely on `auto-format.yml` |
+| `nix flake check --no-build` | no | Evaluates the flake and needs the private input |
+| `nix eval .#nixosConfigurations.<host>...` | no | Requires `nix-secrets` and full host evaluation |
+| `nix build .#nixosConfigurations.<host>...` | no | Same private input requirement; may also be expensive |
+| `nixos-rebuild` | no in sandboxes | Requires full evaluation and a real NixOS/root context |
+
+______________________________________________________________________
+
 ### Auto-Merge Chain
 
 The primary lock-file automation (`update-nix-lock.yml`) opens a PR, then
@@ -56,6 +71,11 @@ flowchart TD
     K[update-nix-lock-recreate.yml\ncron 1st of month] -->|opens separate PR| L[manual review\nor auto-merge]
 ```
 
+`copilot-auto-merge.yml` is separate from lock-file automation. It arms GitHub
+auto-merge only when the latest Copilot review on the current head SHA has no
+inline comments. The final merge is still subject to repository branch
+protection, required status checks, and unresolved conversation settings.
+
 ______________________________________________________________________
 
 ### Full Workflow Reference
@@ -63,7 +83,7 @@ ______________________________________________________________________
 | Workflow | Trigger | Purpose | Auto-commits? |
 |----------|---------|---------|--------------|
 | `auto-format.yml` | PR / push to main / manual | Runs `nix fmt`, commits formatted changes back to the branch, comments on PR, enables auto-merge | Yes — formats in-place |
-| `flake-check.yml` | PR / push to main / manual (paths: `**.nix`, `flake.lock`, `treefmt.nix`) | Runs `nix flake check --no-build`, redacts secrets in failure output | No |
+| `flake-check.yml` | PR / push to main / manual (PR paths include `**.nix`, `flake.lock`, `treefmt.nix`; push paths include `**.nix`, `flake.lock`) | Runs `nix flake check --no-build`, redacts secrets in failure output | No |
 | `validate-config.yml` | PR / push to main / manual | Discovers hosts via `mkHost` grep, evaluates each host's `config.system.build.toplevel` with `nix eval` in a matrix, and evaluates the Home Manager users attrset | No |
 | `change-impact-analysis.yml` | PR | Diffs changed files under `hosts/`, `modules/`, `home/`, `vms/`, `lib/`, `flake.*`, posts impact report as a PR comment | No |
 | `compliance-check.yml` | PR / push / cron Mon 09:00 | Runs `deadnix` and other Nix linters, comments results | No |

--- a/home/README.md
+++ b/home/README.md
@@ -101,7 +101,10 @@ in
 
 ### Configuration Precedence
 
-Layers are applied from lowest priority (bottom) to highest (top):
+The canonical implementation is
+[`modules/core/home-users.nix`](../modules/core/home-users.nix). Layers are
+applied from lowest priority to highest priority, with `autoDesktopConfig`
+merged separately via `lib.mkDefault`.
 
 ```mermaid
 flowchart TD
@@ -127,6 +130,9 @@ As a numbered list (low → high):
 `autoDesktopConfig` (`hm.desktop.<flavor>.enable = lib.mkDefault true`) is merged separately — it uses `lib.mkDefault` so any explicit `hm.desktop.*.enable` setting in any layer takes precedence.
 
 `lib.mkForce` overrides everything regardless of layer.
+
+See [Reference: Architecture — HM Override System](../docs/reference-architecture.md#hm-override-system)
+for the canonical table and source-level notes.
 
 ### Related Documentation
 

--- a/vms/README.md
+++ b/vms/README.md
@@ -1,8 +1,8 @@
 ## MicroVM Configurations
 
 Isolated service VMs using [microvm.nix](https://github.com/microvm-nix/microvm.nix)
-for lightweight virtualization. The flake currently defines 25 MicroVM
-configurations for the `blizzard` host on a `10.100.0.0/24` tap bridge.
+for lightweight virtualization. The flake currently wires 25 MicroVM outputs
+for the `blizzard` host on a `10.100.0.0/24` tap bridge.
 
 ______________________________________________________________________
 
@@ -69,6 +69,7 @@ ______________________________________________________________________
 | brave | 10.100.0.54 | 11054 | 4 GB | 4 | Via WG | Containerized Brave browser |
 | firefly | 10.100.0.62 | 11062 | 2 GB | 2 | Direct | Firefly III finance |
 | firefly-importer | 10.100.0.63 | 11063 | 512 MB | 1 | Direct | Firefly data importer |
+| flaresolverr | 10.100.0.13 | 11013 | 512 MB | 1 | Embedded | Runs inside `prowlarr-vm`; standalone registry/file scaffold exists |
 | firefox | 10.100.0.52 | 11052 | 4 GB | 4 | Via WG | Containerized Firefox browser |
 | gitea | 10.100.0.50 | 11050 | 2 GB | 2 | Direct | Self-hosted git forge |
 | immich | 10.100.0.70 | 11070 | 8 GB | 4 | Direct | Photo library |
@@ -149,6 +150,12 @@ sys.virtualisation.microvm.instances.<name> = {
 
 Each instance toggle is independent, so a VM can remain active while
 selectively disabling its Cloudflare Tunnel or Traefik routing.
+
+> **FlareSolverr note:** `vm-registry.nix` and `vms/flaresolverr.nix` contain
+> standalone FlareSolverr scaffolding, but `flake-microvms.nix` does not expose
+> `flaresolverr-vm`. The active service is currently started inside
+> `prowlarr-vm`; see
+> [Architecture Risks and Improvements](../docs/architecture-risks-and-improvements.md#microvm-count-and-flaresolverr).
 
 ______________________________________________________________________
 


### PR DESCRIPTION
Revise documentation to reflect the current state of MicroVM outputs and update the last verification date to June 1, 2026. Enhance clarity on configuration precedence and related resources.