### PR TITLE
Update documentation for Nixpkgs channel clarity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,12 @@ Hosts: `snowfall` (desktop/KDE), `blizzard` (server), `avalanche` (desktop/GNOME
 
 ### Channel posture
 
-`nixpkgs` tracks `nixos-26.05` (stable). Use `sys.overlays.fromInputs.nixpkgs-small = [ "pkg" ]` to pull individual packages from `nixos-unstable-small`; use `nixpkgs-unstable = [ "pkg" ]` to back-pin to `nixos-24.11`. See `modules/core/overlays.nix` for the full option.
+`nixpkgs` tracks `nixos-26.05` (stable), and `nixpkgs-beta` currently tracks
+the same channel as a symmetry/future-bump alias. Use
+`sys.overlays.fromInputs.nixpkgs-unstable = [ "pkg" ]` to pull individual
+packages from `nixos-unstable`, or
+`sys.overlays.fromInputs.nixpkgs-small = [ "pkg" ]` for
+`nixos-unstable-small`. See `modules/core/overlays.nix` for the full option.
 
 ### Auto-loading
 

--- a/flake.lock
+++ b/flake.lock
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780261350,
-        "narHash": "sha256-to/6FCT3gszW0DTDTbs7soa6I8ZKiSejPegUPsgfUiQ=",
+        "lastModified": 1780267018,
+        "narHash": "sha256-QlWbkxj6AAuwbW/wjMEIT+7f9xDS6/bcoJjBfDQWN9w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b6bb64ad535e640acf75d2707cb0c3d2b726dc7e",
+        "rev": "8bedf37e8b5c7648ae0fcae2cd08209ed9ad37b4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     # Latest stable alias (same target as nixpkgs; kept for symmetry and future bumps)
     nixpkgs-beta.url = "github:NixOS/nixpkgs/nixos-26.05";
-    # Older stable - back-pin escape hatch for packages that regressed in 25.11
+    # Unstable forward-pin: use sys.overlays.fromInputs for packages that need nixos-unstable
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     # Bleeding-edge forward-pin: use sys.overlays.fromInputs to pull individual packages from here
     nixpkgs-small.url = "github:NixOS/nixpkgs/nixos-unstable-small";


### PR DESCRIPTION
Clarify the Nixpkgs channel information in the documentation to improve understanding of stable and unstable package sources. Update the last modified timestamp and hash values for accuracy.