### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780342707,
-        "narHash": "sha256-wQ56uDoEMaZ9XPHCtSUEGn6beBO7Egy6sCT0N/NM4Fo=",
+        "lastModified": 1780347968,
+        "narHash": "sha256-I8ibSDQx+E8cgw6k3UxX6Bm7awmGoKSTXc8Gt1Zbpp4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5a608a621b001922dd708ca51a6260d5bef9e29b",
+        "rev": "d0af9b8bf3b4a1d449be7034bebc9f8f9fd6ee99",
         "type": "github"
       },
       "original": {
@@ -662,11 +662,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780341031,
-        "narHash": "sha256-yFPrwRy7Px0VxQGnuAN9/Ztpddth5+85aK29tKnDtuw=",
+        "lastModified": 1780350612,
+        "narHash": "sha256-iKyK9m+/VuP6xyBFc27cyxSz/I+/g4NWq9kVsRGTDWI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "53765a67ae85b37e9c241f4d1087a8a081fb1016",
+        "rev": "2fb995cfb96a460fe4684a66c993bd353aea2afa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hm-master':
    'github:nix-community/home-manager/5a608a6' (2026-06-01)
  → 'github:nix-community/home-manager/d0af9b8' (2026-06-01)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/64c08a7' (2026-05-23)
  → 'github:NixOS/nixpkgs/331800d' (2026-05-31)
• Updated input 'nur':
    'github:nix-community/NUR/53765a6' (2026-06-01)
  → 'github:nix-community/NUR/2fb995c' (2026-06-01)
```