### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780718842,
-        "narHash": "sha256-sv7GsnlGIBmgNmPZxq4EWzLQh2ttPJ4++EpCRyv2VUo=",
+        "lastModified": 1780728338,
+        "narHash": "sha256-pFaD/oFhJztQeNIgZ1xjPBd7WaNUqREL57ayOq7cnrw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "77d4bc7c93550216a3e01ed285d130225a43c0be",
+        "rev": "c5c494af86020217e95607a5693f2c4ab0126910",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/77d4bc7' (2026-06-06)
  → 'github:nix-community/NUR/c5c494a' (2026-06-06)
```