### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780748195,
-        "narHash": "sha256-UgIAGTmhoLKIuKvijQtGOpjD3uQbUiBEK8aZSDYe80A=",
+        "lastModified": 1780758083,
+        "narHash": "sha256-zSCPcKfMGoFwN2xnyTXPtW7EXKzeC93Hjzwxs17l8KE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "68708dd94f396de9e791b2779979684c9ba36550",
+        "rev": "d47d99d3354792c5151813b74d46ff0a8beebf01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/68708dd' (2026-06-06)
  → 'github:nix-community/NUR/d47d99d' (2026-06-06)
```