### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780805800,
-        "narHash": "sha256-lMqZCF0k0ZbMp4pUgwQuBr1v1AcSN97ea7f2ZEcVqb4=",
+        "lastModified": 1780816466,
+        "narHash": "sha256-u7O3EK3UQkpQFOmPzziF8yhSK94tXPd9qZpJg6nyXWg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9574d514d0a7c07aad4fce6ea230fd7f5a6af84d",
+        "rev": "d2fd0b3251897ef0ce2f0f1bede8b4e94fc298d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/9574d51' (2026-06-07)
  → 'github:nix-community/NUR/d2fd0b3' (2026-06-07)
```