### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780898635,
-        "narHash": "sha256-cS0BUd+f4VWcR8jL519fdSH6RazJIkaX5KZxd2PNT/U=",
+        "lastModified": 1780914410,
+        "narHash": "sha256-H9Koxj+LAPHYSdm2XDeaJvzGRiGzFqPnR5JjJ0VKVmM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a2ef82fa86713e70708495e45f509b63a44c2aa7",
+        "rev": "90e2663764873cdd4d643f2159b738b6158693d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/a2ef82f' (2026-06-08)
  → 'github:nix-community/NUR/90e2663' (2026-06-08)
```