### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780978555,
-        "narHash": "sha256-ypDqbmORvm35z0F/pJnFy+t9txtUS19YMazu3uAsAPA=",
+        "lastModified": 1780988397,
+        "narHash": "sha256-ZvdtKDyncHH75TX51OJqmPtm83wIZHvSArgUfpHRlPU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ee6e2017506a665f28316cb04419b8f201e216d",
+        "rev": "2209902238ec3c9ece6a98936008263548c544c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/4ee6e20' (2026-06-09)
  → 'github:nix-community/NUR/2209902' (2026-06-09)
```