### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781043330,
-        "narHash": "sha256-eApJsGv0lSn8OKqcBQJDFZI6Jg8coS7M8urNo3cVl9U=",
+        "lastModified": 1781064232,
+        "narHash": "sha256-+7cIaqM6ucKf5fDyMnkwehxG8tBdaU51TZOMtxacXmI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bd4277722d215970366a405d280301a796a364fc",
+        "rev": "1ffdc28076a1809ee7c0cf08f06af18f31c480cd",
         "type": "github"
       },
       "original": {
@@ -166,11 +166,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780883961,
-        "narHash": "sha256-WU6SUrESuPiEXEUvX4D51AgWrXRJty+sLJBwBaDBGqE=",
+        "lastModified": 1781063120,
+        "narHash": "sha256-1UIF/mDJluwJQjmmcZ2j1L2+mjYsefe82QCLj0TYSOg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4eb4fec41674d5b059aa2eedf0f98453890546fa",
+        "rev": "baa46aeb6d02e0ba13de67cd35e3d57aedfacf01",
         "type": "github"
       },
       "original": {
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781048613,
-        "narHash": "sha256-67cToQwGO+cTwwnIOoOMWRnbXQdGAbQlOD+7oGule0k=",
+        "lastModified": 1781065290,
+        "narHash": "sha256-Kqqga9WBtFNob2YudnKuVXzHXZnmTc8GQsISAjc3+1Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "14e772d3834142374ca72cee57147bba99c1f931",
+        "rev": "2a9a026882797bb0a64c90a07b0ced7868d9f3c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hm-master':
    'github:nix-community/home-manager/bd42777' (2026-06-09)
  → 'github:nix-community/home-manager/1ffdc28' (2026-06-10)
• Updated input 'hm-stable':
    'github:nix-community/home-manager/4eb4fec' (2026-06-08)
  → 'github:nix-community/home-manager/baa46ae' (2026-06-10)
• Updated input 'nur':
    'github:nix-community/NUR/14e772d' (2026-06-09)
  → 'github:nix-community/NUR/2a9a026' (2026-06-10)
```