### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781237817,
-        "narHash": "sha256-4xCWS0rA4CVCXArHDOMwzgpnsley1kcDREA0kL2jHjU=",
+        "lastModified": 1781249153,
+        "narHash": "sha256-dsgF2aJkN4K8sEloUWYTcl/SbI6CfvLeoPiKIIgwKR8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1453c61070d4e3e958bce87b950091289506ccd7",
+        "rev": "4f7ea5e4c22462c30cad1bc0c5416beb348024aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/1453c61' (2026-06-12)
  → 'github:nix-community/NUR/4f7ea5e' (2026-06-12)
```