### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -255,11 +255,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1781462409,
-        "narHash": "sha256-YJ7lWxGXD789bZFzOhwYk8bcwaiYgyq68OWs/HUuzjA=",
+        "lastModified": 1781528515,
+        "narHash": "sha256-li6yUpi0cY3gkQqpQpvLskhpGZzp9Ji4MkzSc3t0CYk=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "e5c721f29ae035881aef1620b2d714da97067883",
+        "rev": "61d6ec78c6b5e0d80308867e8a3edd1b7e130cbb",
         "type": "github"
       },
       "original": {
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781520149,
-        "narHash": "sha256-Xu1A3ZHgQc4agyi3sNHmPR/tBdPaqVmkNjsWBIND2H0=",
+        "lastModified": 1781531558,
+        "narHash": "sha256-CbX/Qz3OOuNcd/bfzD+p31CjBC1nqKe1LfBIl/pZo1U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "74c0f5ec6667328c594bbeba63405c57e4b2b439",
+        "rev": "2f94c03e23afdafc52f0d5163dfc238121b6d69b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hyprland':
    'github:hyprwm/Hyprland/e5c721f' (2026-06-14)
  → 'github:hyprwm/Hyprland/61d6ec7' (2026-06-15)
• Updated input 'nur':
    'github:nix-community/NUR/74c0f5e' (2026-06-15)
  → 'github:nix-community/NUR/2f94c03' (2026-06-15)
```