### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781533608,
-        "narHash": "sha256-Mgsu/x5cs8EqlhIQ7bMBo14LpkAYtgzDbG/S/eattJA=",
+        "lastModified": 1781557312,
+        "narHash": "sha256-QOIRYSUFSq7L5mY3dZymaVhcnne3tPgoR9riB0WocjA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8aec76cc1e045f37b55d82ca3cee4910ae04d3db",
+        "rev": "c03e4752899e55705dfa63979abd885c582a5c48",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1781528515,
-        "narHash": "sha256-li6yUpi0cY3gkQqpQpvLskhpGZzp9Ji4MkzSc3t0CYk=",
+        "lastModified": 1781551294,
+        "narHash": "sha256-6cHkPGrQmd8RI/YdEgHmY3ebnPHHq07DxOxST70jYhI=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "61d6ec78c6b5e0d80308867e8a3edd1b7e130cbb",
+        "rev": "88262e1f860adc56f528ef68b2909ee33a27186b",
         "type": "github"
       },
       "original": {
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781550632,
-        "narHash": "sha256-UrmWD0W5XiHRR5jEYebZRYtxEysNKpFyMs3w5tkR3L4=",
+        "lastModified": 1781559960,
+        "narHash": "sha256-TCYVEho6muilvbA9le1iN/eodq23tQNVSgDE5HyBA64=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "69b68496b6d186cf1268015821125353fc5d19e3",
+        "rev": "276e2799459b5a1ff5738acc7a30f289f275e25e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hm-master':
    'github:nix-community/home-manager/8aec76c' (2026-06-15)
  → 'github:nix-community/home-manager/c03e475' (2026-06-15)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/61d6ec7' (2026-06-15)
  → 'github:hyprwm/Hyprland/88262e1' (2026-06-15)
• Updated input 'nur':
    'github:nix-community/NUR/69b6849' (2026-06-15)
  → 'github:nix-community/NUR/276e279' (2026-06-15)
```