### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781729244,
-        "narHash": "sha256-vT1hM3l+vH1h9BHhuxkAsJmAPl6Rld7cjLVEGtHGzOA=",
+        "lastModified": 1781741781,
+        "narHash": "sha256-wtC6GCj3OvUTLj6DbMm1unibc+mbFdMNRHySxoZoGa0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c51ac59e59f2a7362d71d1d01ab68b2c09d09347",
+        "rev": "c187002980e3e7dfa584ec1f32d58fc0805945f9",
         "type": "github"
       },
       "original": {
@@ -531,11 +531,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1781389237,
-        "narHash": "sha256-Ne1/E5XNUq0gleaQz0vW5R4xf/0h/uEZ+bOW1aNjeQk=",
+        "lastModified": 1781738058,
+        "narHash": "sha256-wgKY6pbZbFpBXae+8bjvJtW1Z9qekZergGly44n2qZw=",
         "owner": "microvm-nix",
         "repo": "microvm.nix",
-        "rev": "6ad601df0a07d9855c5e8f9b81135ecaf7c287eb",
+        "rev": "225b35c204e29efb5bbe9b55b1a38b07b3fca2af",
         "type": "github"
       },
       "original": {
@@ -646,11 +646,11 @@
     },
     "nixpkgs-small": {
       "locked": {
-        "lastModified": 1781655698,
-        "narHash": "sha256-KjVVyysvz3BJhwT2GBsgIXEOrKaxg/iBp2Xxpna4/F4=",
+        "lastModified": 1781687696,
+        "narHash": "sha256-9Eawq3bvi+OY50rdxuVDIvXL+UXFEtlOJABcqWMxr54=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8cf9f7fff1426b388a6421ca0b7bd5eb231d9d8c",
+        "rev": "171e47bc1ee0bf167678a39b4b36f4751f444592",
         "type": "github"
       },
       "original": {
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781734302,
-        "narHash": "sha256-p5KFCKnMsYZX/EhgF2kHRPv6+BcrNIvz6sm9AXS3zB8=",
+        "lastModified": 1781748888,
+        "narHash": "sha256-74EWK/ZRyg10R09jeozSVHnJPagXd2NhYd5HPaDkqY0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dd0422e46442119856d9d1e3c281c62f8cb9c1fe",
+        "rev": "15a790cb6639c3428e7e012116cfad4873e2b48e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hm-master':
    'github:nix-community/home-manager/c51ac59' (2026-06-17)
  → 'github:nix-community/home-manager/c187002' (2026-06-18)
• Updated input 'microvm':
    'github:microvm-nix/microvm.nix/6ad601d' (2026-06-13)
  → 'github:microvm-nix/microvm.nix/225b35c' (2026-06-17)
• Updated input 'nixpkgs-small':
    'github:NixOS/nixpkgs/8cf9f7f' (2026-06-17)
  → 'github:NixOS/nixpkgs/171e47b' (2026-06-17)
• Updated input 'nur':
    'github:nix-community/NUR/dd0422e' (2026-06-17)
  → 'github:nix-community/NUR/15a790c' (2026-06-18)
```