### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781751568,
-        "narHash": "sha256-hZAbXoNA4nCSaIJJLGl/EdErFtlnAS06jEp4oO7Qp6s=",
+        "lastModified": 1781804281,
+        "narHash": "sha256-kWlKRTBtrMLjIROlr0GICTy1WqHLvWtefm/IbmH+Adw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5bcff43156c0eebe68759338b7879c8e1b2e2bd0",
+        "rev": "9f9b23ae218b8484ef183d47ddf588e2def0f7c2",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1781729184,
-        "narHash": "sha256-S5Lq1/5RgsLZSFMrjnO5jzpV3/3q3Zt4Nsrz2TnVQzQ=",
+        "lastModified": 1781803280,
+        "narHash": "sha256-LvjQLSOAdnJAh1ShfljgZDJE49xhvyDlcIDrhh0Wzk8=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "2b81ad3bdf95d866b2c51460e67474f3190e6a80",
+        "rev": "7a75ce5f209d8142c40dfe6dd8bb03749987e11d",
         "type": "github"
       },
       "original": {
@@ -646,11 +646,11 @@
     },
     "nixpkgs-small": {
       "locked": {
-        "lastModified": 1781736998,
-        "narHash": "sha256-tFjtdQkEO4WQZjF6o5fUqXcp/Vb+DUDCoQMYiTMNPbw=",
+        "lastModified": 1781773087,
+        "narHash": "sha256-ea0KwTPXGdFXcpuwfvAq+NyxtzOeen3vgrA5i3nQ7yQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "89ccddc4c5565410c9c5c81eef193c93e6eda92a",
+        "rev": "76e11c75b099ff27967d7a4330def9164b9aea32",
         "type": "github"
       },
       "original": {
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781783913,
-        "narHash": "sha256-lLboFvgXfMUpbi1KsLGisyRz8zq1eI5iWtlMp0eXY5s=",
+        "lastModified": 1781804766,
+        "narHash": "sha256-JgmbzuAwTwZgVrH9TNeBHNxw77R8woUZyCivwuRgs4w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "451ec56d915ccfaaf0f47b1bf70685123756260a",
+        "rev": "13b296a9dd806fd0b978f4bd17d5562f059552bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hm-master':
    'github:nix-community/home-manager/5bcff43' (2026-06-18)
  → 'github:nix-community/home-manager/9f9b23a' (2026-06-18)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/2b81ad3' (2026-06-17)
  → 'github:hyprwm/Hyprland/7a75ce5' (2026-06-18)
• Updated input 'nixpkgs-small':
    'github:NixOS/nixpkgs/89ccddc' (2026-06-17)
  → 'github:NixOS/nixpkgs/76e11c7' (2026-06-18)
• Updated input 'nur':
    'github:nix-community/NUR/451ec56' (2026-06-18)
  → 'github:nix-community/NUR/13b296a' (2026-06-18)
```