### PR TITLE
Add gitleaks allowlist for historical false positives

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,18 @@
+title = "gitleaks nix-config"
+
+# Suppress false positives from the generic-api-key rule across git history.
+# Each allowlist is narrowly scoped to a specific pattern or commit.
+
+[[allowlists]]
+description = "GPG signing key IDs (format: 0x<16 hex chars>) are public identifiers, not secrets"
+regexes = ['''(?i)^(?:0x)?[0-9a-f]{16}$''']
+regexTarget = "secret"
+
+[[allowlists]]
+description = "kubectl --for=condition=<value> argument misidentified as generic-api-key"
+regexes = ['''(?i)^condition=\w+$''']
+regexTarget = "secret"
+
+[[allowlists]]
+description = "CrowdSec firewall-bouncer key — draft comment in commit 4fe0533f (2024-10-30), bouncer deleted"
+commits = ["4fe0533f359ee95399872cd0bcd8861a7409f8bc"]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,5 +1,8 @@
 title = "gitleaks nix-config"
 
+[extend]
+useDefault = true
+
 # Suppress false positives from the generic-api-key rule across git history.
 # Each allowlist is narrowly scoped to a specific pattern or commit.
 
@@ -15,4 +18,4 @@ regexTarget = "secret"
 
 [[allowlists]]
 description = "CrowdSec firewall-bouncer key — draft comment in commit 4fe0533f (2024-10-30), bouncer deleted"
-commits = ["4fe0533f359ee95399872cd0bcd8861a7409f8bc"]
+stopwords = ["a2aCfCdapZ3NdhlXfXhWB5KAwTs52q5r4EadFfPt"]


### PR DESCRIPTION
This pull request adds a new `.gitleaks.toml` configuration file to the repository. The file customizes secret scanning by suppressing specific false positives, ensuring that legitimate public identifiers and known non-secret patterns are not flagged as secrets.

Secret scanning configuration improvements:

* Added `.gitleaks.toml` to define allowlists for secret scanning, including:
  - Allowing GPG signing key IDs (which are public) to avoid false positives.
  - Allowing `kubectl --for=condition=<value>` arguments, which are sometimes misidentified as secrets.
  - Suppressing a specific known non-secret (CrowdSec firewall-bouncer key) from a draft commit.