### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781822282,
-        "narHash": "sha256-QOhZhdvL4EM6w2Lw5/pjPztm8ZmEziT1h6f2yaM/9bU=",
+        "lastModified": 1781835727,
+        "narHash": "sha256-O3SXpwxwwYMR2v87Nq3T4ODwU/tSx9/g+fZyGBk8+t4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "63f5f30ea1dc5a82da9b3d10643be490b6c62cd1",
+        "rev": "584850b30bb888ea163b925be4dfe29058f158fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/63f5f30' (2026-06-18)
  → 'github:nix-community/NUR/584850b' (2026-06-19)
```