### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782041031,
-        "narHash": "sha256-W0oyXVoZh0AYc0AOxBpAwxOxlT8zRKIC7mLBTK0xZiM=",
+        "lastModified": 1782048205,
+        "narHash": "sha256-s19zu3+F0gtZ2q0a5u21xpYRsZSPhUBLo+qV5OLwFOY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4bd743f95915ff458c9d6d96c1822fc5ac3e5ea5",
+        "rev": "4dd97c99d2d3112b3f3451013e28ec1c6ac8383e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/4bd743f' (2026-06-21)
  → 'github:nix-community/NUR/4dd97c9' (2026-06-21)
```