### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -255,11 +255,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1782055684,
-        "narHash": "sha256-PICDK3hQBrRNIc42/KgrAkPqnc7khbJV6/7f6MCu0HA=",
+        "lastModified": 1782059327,
+        "narHash": "sha256-DkXzKpyckIEOAdPjNnceCSsb6i9pWPShcX+igU1D03s=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "cbfc3044d410db54bd1bc6ffd006b1c2fdb29cc6",
+        "rev": "8f91ba920f3d791e1e2eddb817d7da7ce8b1872a",
         "type": "github"
       },
       "original": {
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782058037,
-        "narHash": "sha256-ZI7zkflAZDIP/kZRNe4XTyVU/LWDD5L+P9ev8dBrOpE=",
+        "lastModified": 1782068731,
+        "narHash": "sha256-IbCmcOnYn0p1oRmFbLH64ZI40X6GnRF9bFrs2h0GQ6s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "587b03b184a0ed1f780b3911b4b37b3f58efaaa2",
+        "rev": "caa08b92f94bfc1c17987d079e2640c1f8fca756",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hyprland':
    'github:hyprwm/Hyprland/cbfc304' (2026-06-21)
  → 'github:hyprwm/Hyprland/8f91ba9' (2026-06-21)
• Updated input 'nur':
    'github:nix-community/NUR/587b03b' (2026-06-21)
  → 'github:nix-community/NUR/caa08b9' (2026-06-21)
```