### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -615,11 +615,11 @@
     },
     "nixpkgs-beta": {
       "locked": {
-        "lastModified": 1781808408,
-        "narHash": "sha256-0sOb6OIaD/K1zHxBhpmlKvkADfe0n8+l4Jj2e1Q0r3w=",
+        "lastModified": 1782116945,
+        "narHash": "sha256-G3tw/IXmaH6IQ2upZvhuN9sG8CkuX+BLuJDpE8hz0Ds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e8210c649915deed7080033cdbabcc19e40bb899",
+        "rev": "34268251cf5547d39063f2c5ea9a196246f7f3a6",
         "type": "github"
       },
       "original": {
@@ -691,11 +691,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1781808408,
-        "narHash": "sha256-0sOb6OIaD/K1zHxBhpmlKvkADfe0n8+l4Jj2e1Q0r3w=",
+        "lastModified": 1782116945,
+        "narHash": "sha256-G3tw/IXmaH6IQ2upZvhuN9sG8CkuX+BLuJDpE8hz0Ds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e8210c649915deed7080033cdbabcc19e40bb899",
+        "rev": "34268251cf5547d39063f2c5ea9a196246f7f3a6",
         "type": "github"
       },
       "original": {
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782196588,
-        "narHash": "sha256-JkYyeSJOcW+w+yhWgaYysATzIyhmjqiAsUoIlc1KMpM=",
+        "lastModified": 1782214517,
+        "narHash": "sha256-ef0LKBSMEPANkj7y04u8RzNhNVkSIVHInfMU5KFlJl4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3640c474a06826c7cc6551a91d22ac4809c47c33",
+        "rev": "6e32265c71b83a51911358b366c2c4cd07230d1d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/e8210c6' (2026-06-18)
  → 'github:NixOS/nixpkgs/3426825' (2026-06-22)
• Updated input 'nixpkgs-beta':
    'github:NixOS/nixpkgs/e8210c6' (2026-06-18)
  → 'github:NixOS/nixpkgs/3426825' (2026-06-22)
• Updated input 'nur':
    'github:nix-community/NUR/3640c47' (2026-06-23)
  → 'github:nix-community/NUR/6e32265' (2026-06-23)
```