### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -713,11 +713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782328561,
-        "narHash": "sha256-zhbsF/3zBGLwxpRMuBueY2tPxME/hVS37eu0mIz6/v0=",
+        "lastModified": 1782337423,
+        "narHash": "sha256-lqEa14pODl5tqXEQD2ehu/uzCya2I+27/m2Xw7YVtsI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ae5d62af029b0b4723bd80a6221167a84c7af855",
+        "rev": "5eff0b0f065b9ddddf7b869bcf6606a2f3c3e843",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/ae5d62a' (2026-06-24)
  → 'github:nix-community/NUR/5eff0b0' (2026-06-24)
```