### PR TITLE
Improve SSH key handling and user enablement settings

### DIFF
--- a/home/desktop/kde.nix
+++ b/home/desktop/kde.nix
@@ -39,11 +39,27 @@ let
       timeout=$((timeout - 1))
     done
 
-    # Auto-discover SSH keys: for every .pub file, import the private counterpart
-    sshDir="${config.home.homeDirectory}/.ssh"
+    if [ -z "''${HOME:-}" ]; then
+      echo "HOME is not set; cannot locate this user's SSH keys" >&2
+      exit 1
+    fi
+
+    currentUid="$(${pkgs.coreutils}/bin/id -u)"
+    sshDir="$HOME/.ssh"
+    [ -d "$sshDir" ] || exit 0
+
+    realSshDir="$(${pkgs.coreutils}/bin/readlink -f "$sshDir")"
+    sshDirUid="$(${pkgs.coreutils}/bin/stat -c %u "$realSshDir" 2>/dev/null || true)"
+    if [ "$sshDirUid" != "$currentUid" ]; then
+      echo "Skipping SSH key import because $realSshDir is not owned by the current user" >&2
+      exit 0
+    fi
+
+    # Auto-discover SSH keys from this session user's ~/.ssh only:
+    # for every .pub file, import the private counterpart.
     for pubKey in "$sshDir"/*.pub; do
       [ -e "$pubKey" ] || continue
-      keyName="$(basename "$pubKey" .pub)"
+      keyName="$(${pkgs.coreutils}/bin/basename "$pubKey" .pub)"
       privKey="$sshDir/$keyName"
       ${lib.optionalString (cfg.excludeKeys != [ ]) ''
         skip=0
@@ -53,6 +69,22 @@ let
         [ "$skip" = "1" ] && continue
       ''}
       [ -f "$privKey" ] || continue
+
+      realPrivKey="$(${pkgs.coreutils}/bin/readlink -f "$privKey")"
+      case "$realPrivKey" in
+        "$realSshDir"/*) ;;
+        *)
+          echo "Skipping key outside this user's ~/.ssh: $privKey"
+          continue
+          ;;
+      esac
+
+      keyUid="$(${pkgs.coreutils}/bin/stat -c %u "$realPrivKey" 2>/dev/null || true)"
+      if [ "$keyUid" != "$currentUid" ]; then
+        echo "Skipping key not owned by the current user: $privKey"
+        continue
+      fi
+
       if ${pkgs.openssh}/bin/ssh-keygen -l -f "$privKey" > /dev/null 2>&1; then
         echo "Adding key: $privKey"
         ${pkgs.openssh}/bin/ssh-add "$privKey" </dev/null || true

--- a/home/desktop/kde.nix
+++ b/home/desktop/kde.nix
@@ -48,7 +48,11 @@ let
     sshDir="$HOME/.ssh"
     [ -d "$sshDir" ] || exit 0
 
-    realSshDir="$(${pkgs.coreutils}/bin/readlink -f "$sshDir")"
+    if ! realSshDir="$(${pkgs.coreutils}/bin/readlink -f "$sshDir" 2>/dev/null)"; then
+      echo "Skipping SSH key import because $sshDir could not be resolved" >&2
+      exit 0
+    fi
+
     sshDirUid="$(${pkgs.coreutils}/bin/stat -c %u "$realSshDir" 2>/dev/null || true)"
     if [ "$sshDirUid" != "$currentUid" ]; then
       echo "Skipping SSH key import because $realSshDir is not owned by the current user" >&2
@@ -70,7 +74,11 @@ let
       ''}
       [ -f "$privKey" ] || continue
 
-      realPrivKey="$(${pkgs.coreutils}/bin/readlink -f "$privKey")"
+      if ! realPrivKey="$(${pkgs.coreutils}/bin/readlink -f "$privKey" 2>/dev/null)"; then
+        echo "Skipping key that could not be resolved: $privKey"
+        continue
+      fi
+
       case "$realPrivKey" in
         "$realSshDir"/*) ;;
         *)

--- a/home/desktop/kde.nix
+++ b/home/desktop/kde.nix
@@ -40,8 +40,8 @@ let
     done
 
     if [ -z "''${HOME:-}" ]; then
-      echo "HOME is not set; cannot locate this user's SSH keys" >&2
-      exit 1
+      export HOME=${lib.escapeShellArg config.home.homeDirectory}
+      echo "HOME is not set; falling back to configured home directory: $HOME" >&2
     fi
 
     currentUid="$(${pkgs.coreutils}/bin/id -u)"

--- a/home/files/files.nix
+++ b/home/files/files.nix
@@ -31,7 +31,7 @@ in
         example = {
           "*" = {
             ForwardAgent = "yes";
-            AddKeysToAgent = "yes";
+            AddKeysToAgent = "no";
             Compression = "yes";
           };
           "github-personal" = {

--- a/home/overrides/role/ssh-common.nix
+++ b/home/overrides/role/ssh-common.nix
@@ -5,7 +5,7 @@
 
     settings = {
       "*" = {
-        AddKeysToAgent = "yes";
+        AddKeysToAgent = "no";
         Compression = false;
         ServerAliveInterval = 0;
         ServerAliveCountMax = 3;

--- a/home/overrides/user/zeno-avalanche.nix
+++ b/home/overrides/user/zeno-avalanche.nix
@@ -44,7 +44,7 @@
         hosts = {
           "*" = {
             ForwardAgent = "yes";
-            AddKeysToAgent = "yes";
+            AddKeysToAgent = "no";
             Compression = "yes";
           };
 

--- a/home/overrides/user/zeno-blizzard.nix
+++ b/home/overrides/user/zeno-blizzard.nix
@@ -63,7 +63,7 @@
         hosts = {
           "*" = {
             ForwardAgent = "yes";
-            AddKeysToAgent = "yes";
+            AddKeysToAgent = "no";
             Compression = "yes";
           };
 

--- a/home/overrides/user/zeno-snowfall.nix
+++ b/home/overrides/user/zeno-snowfall.nix
@@ -54,7 +54,7 @@
         hosts = {
           "*" = {
             ForwardAgent = "yes";
-            AddKeysToAgent = "yes";
+            AddKeysToAgent = "no";
             Compression = "yes";
           };
 

--- a/modules/core/home-users.nix
+++ b/modules/core/home-users.nix
@@ -20,7 +20,7 @@ let
   # Filter to only normal users that are enabled on this host
   systemUsers = lib.filterAttrs (
     username: userData:
-    (userData.isNormalUser or false) && (config.sys.users.${username}.enable or true)
+    (userData.isNormalUser or false) && (config.sys.users.${username}.enable or false)
   ) varsUsersByUsername;
 
   # Auto-enable desktop flavor based on system config

--- a/modules/core/users.nix
+++ b/modules/core/users.nix
@@ -8,7 +8,7 @@
 let
   # Filter users based on per-host enablement (sys.users.<username>.enable)
   enabledUsers = lib.filterAttrs (
-    _roleName: userData: config.sys.users.${userData.user}.enable or true
+    _roleName: userData: config.sys.users.${userData.user}.enable or false
   ) VARS.users;
 in
 {


### PR DESCRIPTION
This pull request makes several security and configuration improvements related to SSH key handling and user filtering. The most important changes are enhanced validation and ownership checks when importing SSH keys, and disabling automatic addition of SSH keys to the SSH agent by default. Additionally, the logic for enabling users has been corrected to be more restrictive.

**SSH Key Handling Improvements:**

* The SSH key import logic in `home/desktop/kde.nix` now checks that `HOME` is set, verifies that the `.ssh` directory and private keys are owned by the current user, and ensures that only keys inside the user's own `.ssh` directory are imported. These changes improve security and prevent accidental or malicious key imports. [[1]](diffhunk://#diff-49a833e75ca48f4cdd4efd591a879c63cc8bb3b37d00f89842263fdacc205c1dL42-R62) [[2]](diffhunk://#diff-49a833e75ca48f4cdd4efd591a879c63cc8bb3b37d00f89842263fdacc205c1dR72-R87)

**SSH Agent Behavior Changes:**

* The default SSH configuration in multiple locations (`home/files/files.nix`, `home/overrides/role/ssh-common.nix`, and several user override files) now sets `AddKeysToAgent` to `"no"` instead of `"yes"`, preventing SSH from automatically adding keys to the agent unless explicitly configured. [[1]](diffhunk://#diff-9bab6f930fc2bf3f09dc722557955d0a9c607553377751a4bbe827dc8ff3c45dL34-R34) [[2]](diffhunk://#diff-48b8598498b2250726206b24ed4cfc793ca5f556144ac58a4aa51cee83ff3540L8-R8) [[3]](diffhunk://#diff-bebcf111ceee6f2c87a6518687e5e6b8d94725496a1ceffacda50a1bdad4666cL47-R47) [[4]](diffhunk://#diff-7d06a8130756e51aaa70ed93957c1503856c6dd1df480d4a61e92527263d2731L66-R66) [[5]](diffhunk://#diff-6a1c6b6d75b1e5131663ec9f55310782117a5a59075b3338863bcf113da4f504L57-R57)

**User Enablement Logic:**

* The logic for determining enabled users in `modules/core/home-users.nix` and `modules/core/users.nix` has been fixed to default to `false` (disabled) when `enable` is not set, making user enablement more explicit and secure. [[1]](diffhunk://#diff-77e50927ea3fddf0edd56ed2a04d821b55be81a680eec978a967412ff5382c68L23-R23) [[2]](diffhunk://#diff-9c248c6784bd756e0a1d67fdfe67ea206128688e42a2a01d35b733ffd3709417L11-R11)