### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -662,11 +662,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "lastModified": 1782467914,
+        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782472998,
-        "narHash": "sha256-1AqA54c0tReTapfSCXlogy/YNcfOzlbRrtTSbiQAwsA=",
+        "lastModified": 1782482163,
+        "narHash": "sha256-8cPfKx5FBGMAdqFU2hRNTzg0hogz/bOOudo7+1fDCwY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7387da38fff4a997c6f9e8857782cac6ce8667b0",
+        "rev": "240f4ffde3000ed8f3bed9665691b9c9711c929e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/567a49d' (2026-06-16)
  → 'github:NixOS/nixpkgs/e73de5b' (2026-06-26)
• Updated input 'nur':
    'github:nix-community/NUR/7387da3' (2026-06-26)
  → 'github:nix-community/NUR/240f4ff' (2026-06-26)
```