### PR TITLE
Enhance security audit and update related configurations

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -8,7 +8,7 @@ on:
     - cron: "0 2 * * 1"
 
 concurrency:
-  group: security-audit
+  group: security-audit-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,6 +1,9 @@
 name: Security Audit
 on:
   workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main]
   schedule:
     - cron: "0 2 * * 1"
 
@@ -10,11 +13,12 @@ concurrency:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   security-audit:
     runs-on: ubuntu-latest
+    outputs:
+      secrets_found: ${{ steps.gitleaks.outputs.secrets_found }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6.0.2
@@ -27,75 +31,96 @@ jobs:
       - name: Check secrets exposure
         id: gitleaks
         run: |
-          echo "## 🔍 Security Audit Results" >> $GITHUB_STEP_SUMMARY
-          echo "### Secrets Scanning" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## 🔍 Security Audit Results"
+            echo "### Secrets Scanning"
+          } >> "$GITHUB_STEP_SUMMARY"
 
           # Checkout uses fetch-depth: 0, so scan the full git history instead
           # of only the working tree.
           if nix run nixpkgs#gitleaks -- detect --source . --redact --verbose; then
-            echo "✅ Gitleaks: No secrets detected" >> $GITHUB_STEP_SUMMARY
-            echo "secrets_found=false" >> $GITHUB_OUTPUT
+            echo "✅ Gitleaks: No secrets detected" >> "$GITHUB_STEP_SUMMARY"
+            echo "secrets_found=false" >> "$GITHUB_OUTPUT"
           else
-            echo "🚨 Gitleaks: Potential secrets found" >> $GITHUB_STEP_SUMMARY
-            echo "secrets_found=true" >> $GITHUB_OUTPUT
+            echo "🚨 Gitleaks: Potential secrets found" >> "$GITHUB_STEP_SUMMARY"
+            echo "secrets_found=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Audit firewall configuration
         run: |
-          echo "### Firewall Configuration Audit" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "### Firewall Configuration Audit"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
 
           open_ports=$(find . -name "*.nix" -exec grep -l "openFirewall.*true" {} \; 2>/dev/null || true)
           if [ -n "$open_ports" ]; then
-            echo "**Files with opened firewall ports:**" >> $GITHUB_STEP_SUMMARY
-            echo "$open_ports" | while read file; do
-              echo "- \`$file\`" >> $GITHUB_STEP_SUMMARY
-            done
+            {
+              echo "**Files with opened firewall ports:**"
+              while IFS= read -r file; do
+                echo "- \`$file\`"
+              done <<< "$open_ports"
+            } >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "✅ No explicitly opened firewall ports found" >> $GITHUB_STEP_SUMMARY
+            echo "✅ No explicitly opened firewall ports found" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Audit SSH configuration
         run: |
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### SSH Security Audit" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          {
+            echo ""
+            echo "### SSH Security Audit"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
 
           if grep -Erq "services\.openssh\.settings\.PasswordAuthentication\s*=\s*true|PasswordAuthentication\s*=\s*true" --include="*.nix" . 2>/dev/null; then
-            echo "⚠️ Password authentication is enabled in some configurations" >> $GITHUB_STEP_SUMMARY
+            echo "⚠️ Password authentication is enabled in some configurations" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "✅ Password authentication not explicitly enabled" >> $GITHUB_STEP_SUMMARY
+            echo "✅ Password authentication not explicitly enabled" >> "$GITHUB_STEP_SUMMARY"
           fi
 
           if grep -Erq "services\.openssh\.settings\.PermitRootLogin\s*=\s*\"yes\"|PermitRootLogin\s*=\s*\"yes\"" --include="*.nix" . 2>/dev/null; then
-            echo "⚠️ Root login is permitted in some configurations" >> $GITHUB_STEP_SUMMARY
+            echo "⚠️ Root login is permitted in some configurations" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "✅ Root login not explicitly permitted" >> $GITHUB_STEP_SUMMARY
+            echo "✅ Root login not explicitly permitted" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Audit user permissions
         run: |
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### User Permissions Audit" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          {
+            echo ""
+            echo "### User Permissions Audit"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
 
           wheel_users=$(grep -r "extraGroups.*wheel" --include="*.nix" . 2>/dev/null || true)
           if [ -n "$wheel_users" ]; then
-            echo "**Users with sudo access (wheel group):**" >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-            echo "$wheel_users" >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            {
+              echo "**Users with sudo access (wheel group):**"
+              echo "\`\`\`"
+              echo "$wheel_users"
+              echo "\`\`\`"
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Generate security report
         run: |
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "## 📊 Security Summary" >> $GITHUB_STEP_SUMMARY
-          echo "Audit completed at: $(date)" >> $GITHUB_STEP_SUMMARY
-          echo "Repository: ${{ github.repository }}" >> $GITHUB_STEP_SUMMARY
+          {
+            echo ""
+            echo "## 📊 Security Summary"
+            echo "Audit completed at: $(date)"
+            echo "Repository: ${{ github.repository }}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
+  create-security-issue:
+    needs: security-audit
+    if: needs.security-audit.outputs.secrets_found == 'true' && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
       - name: Create issue if secrets found
-        if: steps.gitleaks.outputs.secrets_found == 'true'
         uses: actions/github-script@v8
         with:
           script: |

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@ flowchart LR
     subgraph Reference["Information-Oriented"]
         RA["Reference: Architecture\nreference-architecture.md"]
         RC["Reference: CI\nreference-ci.md"]
-        SA["Security Audit\nsecurity-audit-2026-05-13.md"]
+        SA["Security Audit\nsecurity-audit-2026-06-27.md"]
         BP["Architecture Blueprint\nProject_Architecture_Blueprint.md"]
     end
     subgraph Understanding["Understanding-Oriented"]
@@ -53,6 +53,8 @@ flowchart LR
   CI workflows, checks, and automation
 - [security-audit-2026-05-13.md](security-audit-2026-05-13.md) —
   Static security audit findings and remediation roadmap
+- [security-audit-2026-06-27.md](security-audit-2026-06-27.md) —
+  Local-first security audit and hardening pass
 - [Project_Architecture_Blueprint.md](Project_Architecture_Blueprint.md) —
   Comprehensive architecture documentation
 
@@ -75,7 +77,7 @@ flowchart LR
 | Add a new user | [How-To: Add Hosts and Users](how-to-add-host-and-users.md) |
 | Understand the architecture | [Architecture Blueprint](Project_Architecture_Blueprint.md) |
 | Find option namespaces | [Reference: Architecture](reference-architecture.md) |
-| Review security findings | [Security Audit](security-audit-2026-05-13.md) |
+| Review security findings | [Security Audit](security-audit-2026-06-27.md) |
 | Learn why things work this way | [Explanation: Design](explanation-design.md) |
 
 ### Directory READMEs

--- a/docs/security-audit-2026-06-27.md
+++ b/docs/security-audit-2026-06-27.md
@@ -1,0 +1,186 @@
+# Static Security Audit - 2026-06-27
+
+This report captures a local-first static security audit and hardening pass for
+the `telometto/nix-config` NixOS flake on `main`.
+
+The audit did not inspect private secret material, query GitHub security state,
+modify Cloudflare policy, or perform live service testing. Runtime validation
+for public routes and private `nix-secrets` backed full evaluation remains a
+CI or deployed-host responsibility.
+
+______________________________________________________________________
+
+## Executive summary
+
+No critical source-level vulnerabilities were confirmed in this pass. The
+changes focus on reducing configuration drift and making risky exceptions more
+explicit:
+
+1. Shared Traefik CSP defaults now deny inline/eval scripts.
+1. Known CSP compatibility exceptions remain named and route-scoped.
+1. Host role selection is now mutually exclusive.
+1. MicroVM registry allocations are checked for duplicate CID, MAC, IP, and
+   port values.
+1. Trigger.dev no longer permits open magic-link email access unless explicitly
+   opted in.
+1. The scheduled security workflow now also scans pull requests and pushes.
+
+______________________________________________________________________
+
+## Scope and validation
+
+### Reviewed areas
+
+- Traefik/CrowdSec route security headers and public route exceptions.
+- MicroVM registry allocation and Blizzard's enabled VM exposure map.
+- Trigger.dev authentication defaults, Docker socket proxy exposure, and secret
+  file handling.
+- Role defaults, OpenSSH hardening, SOPS secret path bridging, and workflow
+  secret scanning.
+- Prior 2026-06-01 audit findings that were still source-relevant.
+
+### Local checks
+
+| Check | Result |
+|------|--------|
+| Senior Security secret scanner | Passed; 0 high/critical findings |
+| Senior SecOps high-severity static scanner | Passed; 0 findings |
+| Standalone MicroVM registry duplicate check | Passed; no duplicate CID, MAC, IP, or port values |
+| Changed Nix file parse checks | Passed |
+| GitHub Actions lint for `security-audit.yml` | Passed |
+| Nix formatting | Passed; no changes after final run |
+| Full flake check | Passed with `nix flake check --no-build path:.` |
+
+### Limitations
+
+- Full host evaluation may require SSH access to the private `nix-secrets` flake
+  input.
+- CSP compatibility was reviewed statically only. Browser smoke tests are still
+  required for `search`, `git`, `triggers`, `matrix`, and Plex-adjacent routes.
+- Live Cloudflare Access policy, CrowdSec parser state, deployed service health,
+  Secure Boot, TPM2, and runtime AppArmor behavior were not validated.
+
+______________________________________________________________________
+
+## Findings
+
+### F-001 - Shared Traefik CSP allowed inline/eval scripts
+
+**Severity:** Important\
+**Category:** OWASP A02 Security Misconfiguration, A05 Injection/XSS\
+**Status:** Remediated in this change set\
+**Confidence:** High
+
+The shared Traefik header helper allowed `'unsafe-inline'` and `'unsafe-eval'`
+in the default CSP. That made the safest path for new routes weaker than
+necessary.
+
+Remediation:
+
+- `lib/traefik.nix` now uses a strict default CSP without inline/eval script
+  allowances.
+- `lib/traefik.nix` exports `compatibilityCsp` for routes that deliberately
+  need legacy browser allowances.
+- Blizzard's Plex-family, Lingarr, Matrix, Firefox, and Trigger exceptions
+  remain named and route-scoped.
+
+Follow-up:
+
+- Smoke test the public routes after deployment. If a route breaks, add or tune
+  a narrow compatibility middleware for that route rather than weakening the
+  shared default.
+
+### F-002 - Desktop/server role exclusivity was not enforced
+
+**Severity:** Suggestion\
+**Category:** OWASP A06 Insecure Design\
+**Status:** Remediated in this change set\
+**Confidence:** High
+
+The desktop and server roles were independent booleans. A host could
+accidentally enable both role bundles and merge conflicting network and service
+posture.
+
+Remediation:
+
+- `modules/core/roles.nix` now asserts that `sys.role.desktop.enable` and
+  `sys.role.server.enable` cannot both be true.
+
+### F-003 - MicroVM registry uniqueness was documented but not enforced
+
+**Severity:** Suggestion\
+**Category:** OWASP A06 Insecure Design, A02 Security Misconfiguration\
+**Status:** Remediated in this change set\
+**Confidence:** High
+
+The central registry documented CID, MAC, IP, and service port uniqueness, but
+evaluation did not enforce those invariants.
+
+Remediation:
+
+- `modules/virtualisation/microvm-base.nix` now asserts uniqueness for
+  registry CID, MAC, IP, and port values.
+- `vms/vm-registry.nix` now documents `flaresolverr` as a reserved allocation
+  for the service embedded in `prowlarr-vm`, not as a missing standalone VM
+  output.
+
+### F-004 - Trigger.dev email allowlist was open by default
+
+**Severity:** Important\
+**Category:** OWASP A01 Broken Access Control, A07 Identification and Authentication Failures\
+**Status:** Remediated in this change set\
+**Confidence:** Medium
+
+`sys.services.trigger.auth.whitelistedEmailsFile = null` caused the generated
+container environment to leave `WHITELISTED_EMAILS` empty, which Trigger.dev
+uses as open email access. That is risky for a public route even when the
+service is intended for a small trusted audience.
+
+Remediation:
+
+- `sys.services.trigger.auth.allowAllEmails` was added with default `false`.
+- Trigger now asserts that `auth.whitelistedEmailsFile` is set unless
+  `auth.allowAllEmails = true` is explicitly configured.
+
+### F-005 - Security audit workflow only ran on schedule/manual events
+
+**Severity:** Important\
+**Category:** OWASP A03 Software Supply Chain Failures\
+**Status:** Remediated in this change set\
+**Confidence:** High
+
+The security audit workflow scanned full git history, but only on the weekly
+schedule or manual dispatch. PRs and pushes could land without the same secret
+scan feedback.
+
+Remediation:
+
+- `.github/workflows/security-audit.yml` now runs on `pull_request` and pushes
+  to `main`.
+- Issue creation is split into a separate non-PR job that is the only job
+  requesting `issues: write`.
+
+______________________________________________________________________
+
+## Deferred live validation
+
+1. Verify response headers and login flows for enabled public routes after the
+   Traefik CSP change.
+1. Confirm the weekly/push/PR security workflow runs as expected in GitHub
+   Actions.
+1. Let CI perform full flake and host validation when local `nix-secrets` access
+   is unavailable.
+1. Review live Trigger.dev access behavior after deployment to ensure only the
+   intended email regex can authenticate.
+
+______________________________________________________________________
+
+## Files changed
+
+- `.github/workflows/security-audit.yml`
+- `hosts/blizzard/security/traefik.nix`
+- `lib/traefik.nix`
+- `modules/core/roles.nix`
+- `modules/services/trigger.nix`
+- `modules/virtualisation/microvm-base.nix`
+- `vms/vm-registry.nix`

--- a/hosts/blizzard/security/traefik.nix
+++ b/hosts/blizzard/security/traefik.nix
@@ -126,10 +126,10 @@ in
 
           security-headers = traefikLib.mkSecurityHeaders { };
 
-          # Lingarr currently needs inline script allowances and WebSocket
-          # connections; keep this exception route-scoped.
+          # Lingarr currently needs inline/eval script allowances and
+          # WebSocket connections; keep this exception route-scoped.
           lingarr-headers = traefikLib.mkSecurityHeaders {
-            csp = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;";
+            csp = traefikLib.compatibilityCsp;
           };
 
           gitea-xfp-https.headers.customRequestHeaders.X-Forwarded-Proto = "https";
@@ -150,11 +150,14 @@ in
           };
 
           firefox-headers = traefikLib.mkSecurityHeaders {
+            # Browser-in-browser UIs use nested frames and dynamic client code.
             xFrameOptions = null;
             csp = null;
           };
 
           trigger-headers = traefikLib.mkSecurityHeaders {
+            # Trigger.dev's app shell currently needs a service-specific CSP
+            # review; keep no-CSP scoped to the Trigger route only.
             csp = null;
           };
 

--- a/lib/traefik.nix
+++ b/lib/traefik.nix
@@ -2,7 +2,7 @@
 let
   defaultPermissionsPolicy = "geolocation=(), microphone=(), camera=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=(), fullscreen=(self), picture-in-picture=(self)";
   defaultCsp = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'self'; form-action 'self';";
-  compatibilityCsp = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https: ws: wss:;";
+  compatibilityCsp = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;";
 in
 {
   inherit defaultPermissionsPolicy defaultCsp compatibilityCsp;

--- a/lib/traefik.nix
+++ b/lib/traefik.nix
@@ -2,7 +2,7 @@
 let
   defaultPermissionsPolicy = "geolocation=(), microphone=(), camera=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=(), fullscreen=(self), picture-in-picture=(self)";
   defaultCsp = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'self'; form-action 'self';";
-  compatibilityCsp = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;";
+  compatibilityCsp = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; frame-ancestors 'self'; form-action 'self';";
 in
 {
   inherit defaultPermissionsPolicy defaultCsp compatibilityCsp;

--- a/lib/traefik.nix
+++ b/lib/traefik.nix
@@ -1,10 +1,11 @@
 { lib }:
 let
   defaultPermissionsPolicy = "geolocation=(), microphone=(), camera=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=(), fullscreen=(self), picture-in-picture=(self)";
-  defaultCsp = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self';";
+  defaultCsp = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'self'; form-action 'self';";
+  compatibilityCsp = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https: ws: wss:;";
 in
 {
-  inherit defaultPermissionsPolicy defaultCsp;
+  inherit defaultPermissionsPolicy defaultCsp compatibilityCsp;
 
   # Build a Traefik middleware attrset with security response headers.
   # Pass null to any parameter to omit that header entirely.

--- a/modules/core/roles.nix
+++ b/modules/core/roles.nix
@@ -1,7 +1,14 @@
-{ lib, ... }:
+{ lib, config, ... }:
 {
   options.sys.role = {
     desktop.enable = lib.mkEnableOption "Desktop role toggle";
     server.enable = lib.mkEnableOption "Server role toggle";
   };
+
+  config.assertions = [
+    {
+      assertion = !(config.sys.role.desktop.enable && config.sys.role.server.enable);
+      message = "sys.role.desktop.enable and sys.role.server.enable are mutually exclusive";
+    }
+  ];
 }

--- a/modules/services/traefik.nix
+++ b/modules/services/traefik.nix
@@ -1,6 +1,7 @@
 { lib, config, ... }:
 let
   cfg = config.sys.services.traefik;
+  traefikLib = import ../../lib/traefik.nix { inherit lib; };
 
   trustedIPs = [
     "127.0.0.1/32"
@@ -158,17 +159,7 @@ in
 
         dynamic.files.core.settings.http = {
           middlewares = lib.optionalAttrs cfg.securityHeaders {
-            security-headers.headers = {
-              customResponseHeaders = {
-                X-Content-Type-Options = "nosniff";
-                X-Frame-Options = "SAMEORIGIN";
-                X-XSS-Protection = "1; mode=block";
-                Referrer-Policy = "no-referrer";
-                Permissions-Policy = "geolocation=(), microphone=(), camera=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=(), fullscreen=(self), picture-in-picture=(self)";
-              };
-
-              contentSecurityPolicy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self';";
-            };
+            security-headers = traefikLib.mkSecurityHeaders { };
           };
 
           routers = lib.optionalAttrs cfg.dashboard.enable {

--- a/modules/services/trigger.nix
+++ b/modules/services/trigger.nix
@@ -499,6 +499,10 @@ in
         message = "sys.services.trigger: smtp.fromEmail must be set when smtp.enable = true";
       }
       {
+        assertion = cfg.auth.whitelistedEmailsFile != "";
+        message = "sys.services.trigger: auth.whitelistedEmailsFile must not be an empty string";
+      }
+      {
         assertion = cfg.auth.allowAllEmails || cfg.auth.whitelistedEmailsFile != null;
         message = "sys.services.trigger: auth.whitelistedEmailsFile must be set unless auth.allowAllEmails = true";
       }

--- a/modules/services/trigger.nix
+++ b/modules/services/trigger.nix
@@ -414,10 +414,16 @@ in
     };
 
     auth = {
+      allowAllEmails = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Allow any email address to request magic-link access when no whitelist file is configured.";
+      };
+
       whitelistedEmailsFile = lib.mkOption {
         type = lib.types.nullOr lib.types.str;
         default = null;
-        description = "Path to file containing a regex of permitted email addresses. Null allows all.";
+        description = "Path to file containing a regex of permitted email addresses. Null is rejected unless allowAllEmails is true.";
       };
 
       adminEmailsFile = lib.mkOption {
@@ -491,6 +497,10 @@ in
       {
         assertion = !cfg.smtp.enable || cfg.smtp.fromEmail != "";
         message = "sys.services.trigger: smtp.fromEmail must be set when smtp.enable = true";
+      }
+      {
+        assertion = cfg.auth.allowAllEmails || cfg.auth.whitelistedEmailsFile != null;
+        message = "sys.services.trigger: auth.whitelistedEmailsFile must be set unless auth.allowAllEmails = true";
       }
     ];
 

--- a/modules/virtualisation/microvm-base.nix
+++ b/modules/virtualisation/microvm-base.nix
@@ -6,6 +6,7 @@
 }:
 let
   cfg = config.sys.virtualisation.microvm;
+  registry = import ../../vms/vm-registry.nix;
   mkVmName = name: "${name}-vm";
 
   # Port forward submodule
@@ -330,6 +331,24 @@ let
       lib.filter (host: builtins.length (lib.filter (candidate: candidate == host) hosts) > 1) hosts
     );
 
+  duplicateValues =
+    values:
+    lib.unique (
+      lib.filter (value: builtins.length (lib.filter (candidate: candidate == value) values) > 1) values
+    );
+
+  registryValues = builtins.attrValues registry;
+
+  registryFieldValues = field: map (entry: toString entry.${field}) registryValues;
+
+  duplicateRegistryCids = duplicateValues (registryFieldValues "cid");
+
+  duplicateRegistryMacs = duplicateValues (registryFieldValues "mac");
+
+  duplicateRegistryIps = duplicateValues (registryFieldValues "ip");
+
+  duplicateRegistryPorts = duplicateValues (registryFieldValues "port");
+
   formatList = list: lib.concatStringsSep ", " list;
 in
 {
@@ -466,6 +485,22 @@ in
       {
         assertion = duplicateIngressHosts == [ ];
         message = "sys.virtualisation.microvm (expose/instances) defines duplicate Cloudflare ingress hosts: ${formatList duplicateIngressHosts}";
+      }
+      {
+        assertion = duplicateRegistryCids == [ ];
+        message = "vms/vm-registry.nix defines duplicate MicroVM CIDs: ${formatList duplicateRegistryCids}";
+      }
+      {
+        assertion = duplicateRegistryMacs == [ ];
+        message = "vms/vm-registry.nix defines duplicate MicroVM MAC addresses: ${formatList duplicateRegistryMacs}";
+      }
+      {
+        assertion = duplicateRegistryIps == [ ];
+        message = "vms/vm-registry.nix defines duplicate MicroVM IP addresses: ${formatList duplicateRegistryIps}";
+      }
+      {
+        assertion = duplicateRegistryPorts == [ ];
+        message = "vms/vm-registry.nix defines duplicate MicroVM service ports: ${formatList duplicateRegistryPorts}";
       }
       {
         assertion = cloudflaredEnabled || enabledCfTunnelVms == [ ];

--- a/vms/vm-registry.nix
+++ b/vms/vm-registry.nix
@@ -188,6 +188,8 @@
     dns = "10.100.0.11";
   };
 
+  # Reserved for the flaresolverr service embedded in prowlarr-vm.
+  # This is not wired as a standalone flake output by design.
   flaresolverr = {
     name = "flaresolverr";
     cid = 118;


### PR DESCRIPTION
This pull request implements a comprehensive static security audit and hardening pass, addressing several configuration and workflow weaknesses. The main improvements include stricter default Content Security Policy (CSP) for Traefik, explicit enforcement of host role exclusivity, uniqueness checks for MicroVM registry allocations, safer Trigger.dev authentication defaults, and enhanced CI security audit coverage. Documentation is updated with a new audit report reflecting these changes.

**Security and Configuration Hardening:**

* Traefik’s default CSP is now strict by default, denying inline and eval scripts; legacy allowances are only route-scoped via a new `compatibilityCsp` export in `lib/traefik.nix` and its consumers. [[1]](diffhunk://#diff-a923d8c26f6ff3ba8523b60da269db39f91c029792207ec0cb6bb5ea8d17c667L4-R8) [[2]](diffhunk://#diff-f688ab8506724a930cde1325f7e07668c5d018440628a096f9db87a82a6a63f8L129-R132) [[3]](diffhunk://#diff-f688ab8506724a930cde1325f7e07668c5d018440628a096f9db87a82a6a63f8R153-R160)
* Desktop and server host roles are now mutually exclusive, enforced via an assertion in `modules/core/roles.nix`.
* MicroVM registry allocations are checked for duplicate CID, MAC, IP, and port values at evaluation time, preventing accidental conflicts. [[1]](diffhunk://#diff-602dc9fd4c13e3a9c0bc2d54aaf8a56b7ae7e6cc611c0088bc3313e2fe330639R9) [[2]](diffhunk://#diff-602dc9fd4c13e3a9c0bc2d54aaf8a56b7ae7e6cc611c0088bc3313e2fe330639R334-R351) [[3]](diffhunk://#diff-602dc9fd4c13e3a9c0bc2d54aaf8a56b7ae7e6cc611c0088bc3313e2fe330639R489-R504)

**Authentication and Workflow Improvements:**

* Trigger.dev now defaults to a closed email allowlist unless `allowAllEmails` is explicitly set; an assertion enforces this to prevent accidental open access. [[1]](diffhunk://#diff-e463bb4ec370fc096eaa06395e99ef4ba04e6be9934defe78d308dc77d7dcdadR417-R426) [[2]](diffhunk://#diff-e463bb4ec370fc096eaa06395e99ef4ba04e6be9934defe78d308dc77d7dcdadR501-R504)
* The scheduled security audit workflow (`.github/workflows/security-audit.yml`) now also runs on pull requests and pushes to `main`, and only creates issues when secrets are found outside PRs. [[1]](diffhunk://#diff-3419faf84cde9b39944015a0edef5b52da2082b5bedf9708e54f527ac360ec5fR4-R6) [[2]](diffhunk://#diff-3419faf84cde9b39944015a0edef5b52da2082b5bedf9708e54f527ac360ec5fL13-R21) [[3]](diffhunk://#diff-3419faf84cde9b39944015a0edef5b52da2082b5bedf9708e54f527ac360ec5fL30-L98)

**Documentation Updates:**

* Added a new audit report `docs/security-audit-2026-06-27.md` summarizing the findings and remediations. References in `docs/README.md` are updated accordingly. [[1]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L28-R28) [[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R56-R57) [[3]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L78-R80) [[4]](diffhunk://#diff-336a5eaba3b1f6fa26cdbfa56f152756786d61f7aa00e8db88a7a9105927e627R1-R186)
* Clarified documentation for reserved VM allocations in `vms/vm-registry.nix`.

These changes collectively reduce configuration drift, make security exceptions more explicit, and improve CI-driven security posture validation.