### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782749631,
-        "narHash": "sha256-slFTUgDy0KTPA4LBAmC/9SngDq8GCPdX+ZR0yQHHN1E=",
+        "lastModified": 1782881387,
+        "narHash": "sha256-HvlS1KDGXDjd1bNzzPvH1mkDJATlDAfVYfTh//wJBEA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5d72a29fc36ac21adae6ae35568fe5ee6700850f",
+        "rev": "d32537981c036473cf6990ae03176a5d84c43b29",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1782755845,
-        "narHash": "sha256-pMax4dvo/BbKCO2zvCT8fgziiWbfXGhRH0/5uF8pyd0=",
+        "lastModified": 1782893559,
+        "narHash": "sha256-l92uUHanb7vX8ss30kkM+oX5vc2T4zwa+NY4sjYcIUE=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "254d6bae775258b554e1d3a4a853f3bc244190d9",
+        "rev": "1b63ceecdfc6c33b68b677b8285ac621fc2b058f",
         "type": "github"
       },
       "original": {
@@ -615,11 +615,11 @@
     },
     "nixpkgs-beta": {
       "locked": {
-        "lastModified": 1782535326,
-        "narHash": "sha256-ZeRxu4yn6shd3SNF5ZUQb4r7BaVo1zBKMjRhfoNSBmw=",
+        "lastModified": 1782691344,
+        "narHash": "sha256-i5nw9BYYsMDAaOC4J+JmTof6b2GhlyH076awYRNrTV8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "714a5f8c4ead6b31148d829288440ed033ccc041",
+        "rev": "1f01958ffb5b3545c96d9ef2f4e24c5e5e1eb846",
         "type": "github"
       },
       "original": {
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable-small": {
       "locked": {
-        "lastModified": 1782755272,
-        "narHash": "sha256-KpiFOTKLSzNIhn4DDSDdWTBA9KxP7VOqsEfpdmW6gaI=",
+        "lastModified": 1782888529,
+        "narHash": "sha256-oduWsYkQVjaaL1vzGkU3JdmfPdPXWja/g8SYpqJt3U8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bf5c25c93a825fb0544c67357b62a9764a65c2ba",
+        "rev": "677a406d412bda6608d291b5d4958afd02aabaab",
         "type": "github"
       },
       "original": {
@@ -678,11 +678,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1782774429,
-        "narHash": "sha256-1tRFhlVVSBP2UAyJ4fWV3wRxofOZQCIWmbXJS/kQw7U=",
+        "lastModified": 1782860505,
+        "narHash": "sha256-7beKprxZK6AT2aNMCLFUBew5g18GfWZYAbWIuxK7R3c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c3db893991ef9cf1902c661c2d61249bcfb051dc",
+        "rev": "39b92caca76274e7673f27b09d6c3734df0ed931",
         "type": "github"
       },
       "original": {
@@ -707,11 +707,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1782535326,
-        "narHash": "sha256-ZeRxu4yn6shd3SNF5ZUQb4r7BaVo1zBKMjRhfoNSBmw=",
+        "lastModified": 1782691344,
+        "narHash": "sha256-i5nw9BYYsMDAaOC4J+JmTof6b2GhlyH076awYRNrTV8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "714a5f8c4ead6b31148d829288440ed033ccc041",
+        "rev": "1f01958ffb5b3545c96d9ef2f4e24c5e5e1eb846",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782800163,
-        "narHash": "sha256-p3ldSZbH0PvVDOt9lVr3mZvEhTKe7Qs5yvTbBsk5lu4=",
+        "lastModified": 1782898037,
+        "narHash": "sha256-lFGqUfNalB6aL4jS/qyLhW6xUaiv61wm0PxnfLmGi6U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b666fdefb99accf2d567740575b16d341c8983b1",
+        "rev": "fa4ab73073f38b56c5d5d41b00933f07f3545243",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hm-master':
    'github:nix-community/home-manager/5d72a29' (2026-06-29)
  → 'github:nix-community/home-manager/d325379' (2026-07-01)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/254d6ba' (2026-06-29)
  → 'github:hyprwm/Hyprland/1b63cee' (2026-07-01)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/714a5f8' (2026-06-27)
  → 'github:NixOS/nixpkgs/1f01958' (2026-06-29)
• Updated input 'nixpkgs-beta':
    'github:NixOS/nixpkgs/714a5f8' (2026-06-27)
  → 'github:NixOS/nixpkgs/1f01958' (2026-06-29)
• Updated input 'nixpkgs-stable-small':
    'github:NixOS/nixpkgs/bf5c25c' (2026-06-29)
  → 'github:NixOS/nixpkgs/677a406' (2026-07-01)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/c3db893' (2026-06-29)
  → 'github:NixOS/nixpkgs/39b92ca' (2026-06-30)
• Updated input 'nur':
    'github:nix-community/NUR/b666fde' (2026-06-30)
  → 'github:nix-community/NUR/fa4ab73' (2026-07-01)
```