### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782936463,
-        "narHash": "sha256-uFboRoG7fBgdP592N1wcNSA87ohssab6m+VuRxEUnIY=",
+        "lastModified": 1782964450,
+        "narHash": "sha256-2rwNd77TzZ4sDDvMam0IXFXN5IfC35mifoeKS0uAc/4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "74b38179ac0820af3ea4a240ff12668fb2b8c72e",
+        "rev": "ebc87daabc8d3f595e9a8b67107eaaa8115ad582",
         "type": "github"
       },
       "original": {
@@ -678,11 +678,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1782915142,
-        "narHash": "sha256-xD+RttHOID/wIQ9MglPYjWI7hJxAn16OPOZQO/p5LEw=",
+        "lastModified": 1782953498,
+        "narHash": "sha256-sTKCP3KzBN6cu9mItLnX7lQc4brSBebeIYtCF9PwkiM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8465ac306246eef81317cd771e7c27c8ac415aef",
+        "rev": "09f54b49a3d7bb98f0e51166dd37dd56da58319b",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782945118,
-        "narHash": "sha256-DkQWgJw+HLaPFrk/kczuQBzl8JssfanvJZSIv9kEjx8=",
+        "lastModified": 1782965775,
+        "narHash": "sha256-2H6uooXX6WNQ/4O++bCBGYGVLakITe2NnW2xl0bhsLM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "417fe25573cf69998ac80b07a3e1d10fa6c5c8fa",
+        "rev": "e4332529db12a20975987a27ee7e1a1b788feb36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hm-master':
    'github:nix-community/home-manager/74b3817' (2026-07-01)
  → 'github:nix-community/home-manager/ebc87da' (2026-07-02)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/8465ac3' (2026-07-01)
  → 'github:NixOS/nixpkgs/09f54b4' (2026-07-02)
• Updated input 'nur':
    'github:nix-community/NUR/417fe25' (2026-07-01)
  → 'github:nix-community/NUR/e433252' (2026-07-02)
```