### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782964450,
-        "narHash": "sha256-2rwNd77TzZ4sDDvMam0IXFXN5IfC35mifoeKS0uAc/4=",
+        "lastModified": 1783005591,
+        "narHash": "sha256-NcLHV5uBAeggDUE2wPbKszjfyaSLsoqaYt7izOphkZw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ebc87daabc8d3f595e9a8b67107eaaa8115ad582",
+        "rev": "f469c79b955609d6a8fdd9e689be76a93b1621d7",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1782925626,
-        "narHash": "sha256-C0dCvK49AbhK+EJwV8L3zSElZoFUtAEDo4tuUiUHano=",
+        "lastModified": 1782977902,
+        "narHash": "sha256-+tfo+W3dIqHTgnXsC0dpkk66T2L43DUxJV6SUiKu90Y=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "76123ac34e4dd33cdca176d8d1d8b38b311549e3",
+        "rev": "9350e3410bd776385cb597ec45ebadaf581b634a",
         "type": "github"
       },
       "original": {
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable-small": {
       "locked": {
-        "lastModified": 1782930820,
-        "narHash": "sha256-7+g30bsdIKI8MuyQCrUW95Cn6ciJ62bqZYJLMNfC80g=",
+        "lastModified": 1782975080,
+        "narHash": "sha256-L2bjWMDizikwIRjKkd93itkHZNWO9PM/52zVRCg4Edg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "007ee0e9f0d0dfb9d24776a503c4b85acb2bdcdd",
+        "rev": "307b8052d0826c3bcfa694ac0e149fdf410ca258",
         "type": "github"
       },
       "original": {
@@ -678,11 +678,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1782953498,
-        "narHash": "sha256-sTKCP3KzBN6cu9mItLnX7lQc4brSBebeIYtCF9PwkiM=",
+        "lastModified": 1783003425,
+        "narHash": "sha256-CLVsEepcFedoiIwXVlAYam9bbTt3mmTJXgGrvoLDDFM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "09f54b49a3d7bb98f0e51166dd37dd56da58319b",
+        "rev": "6147971a7160e60cf691651d97cc8411395f5d90",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782975327,
-        "narHash": "sha256-+2gKWSi8sHAo5E96xYL7k51uxYMunCFxH1Rzbh3wiTU=",
+        "lastModified": 1783009993,
+        "narHash": "sha256-jXaNLiirjcfJIix9OukdPE1BN2nVmLgGAkdVMyAEjmI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4214bd7b331e9faa50fe5bc09291c51fabede297",
+        "rev": "80c9cd0d779449dcd784b5b401158a308052ac5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hm-master':
    'github:nix-community/home-manager/ebc87da' (2026-07-02)
  → 'github:nix-community/home-manager/f469c79' (2026-07-02)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/76123ac' (2026-07-01)
  → 'github:hyprwm/Hyprland/9350e34' (2026-07-02)
• Updated input 'nixpkgs-stable-small':
    'github:NixOS/nixpkgs/007ee0e' (2026-07-01)
  → 'github:NixOS/nixpkgs/307b805' (2026-07-02)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/09f54b4' (2026-07-02)
  → 'github:NixOS/nixpkgs/6147971' (2026-07-02)
• Updated input 'nur':
    'github:nix-community/NUR/4214bd7' (2026-07-02)
  → 'github:nix-community/NUR/80c9cd0' (2026-07-02)
```