### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783005591,
-        "narHash": "sha256-NcLHV5uBAeggDUE2wPbKszjfyaSLsoqaYt7izOphkZw=",
+        "lastModified": 1783024095,
+        "narHash": "sha256-oE+TNK98Pl7nHW4VU1oBvUKD5JR45U+py/NJmLoTNHI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f469c79b955609d6a8fdd9e689be76a93b1621d7",
+        "rev": "a4d410db95a6416d1008049330bd86b85b5db45a",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1782977902,
-        "narHash": "sha256-+tfo+W3dIqHTgnXsC0dpkk66T2L43DUxJV6SUiKu90Y=",
+        "lastModified": 1783027142,
+        "narHash": "sha256-kQqdgS844acOr1uXejmqolWaKGx7KR33lK/hx1VRKDE=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "9350e3410bd776385cb597ec45ebadaf581b634a",
+        "rev": "420f112bc6e0f0fe28c9a348969ebcc9fd8ad56f",
         "type": "github"
       },
       "original": {
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable-small": {
       "locked": {
-        "lastModified": 1782975080,
-        "narHash": "sha256-L2bjWMDizikwIRjKkd93itkHZNWO9PM/52zVRCg4Edg=",
+        "lastModified": 1783014552,
+        "narHash": "sha256-htsCMj3F1QHmBHcadpwxA+mVcgTCvPXOZLg1M82/zdM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "307b8052d0826c3bcfa694ac0e149fdf410ca258",
+        "rev": "5863b64722a3967028f5ad22f79875b52ce82007",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783015612,
-        "narHash": "sha256-Xv6QrhtI1Rj1WTi17s85Tv+4ZrIIzzwJqmhbSgaONTQ=",
+        "lastModified": 1783025151,
+        "narHash": "sha256-OgwhCmdiSxlm3ry8vC6n0/QOHS/0UQiEWROWF9MyT7I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e63cf13fe97fc58608a7256150ecb6fc95cc3ad8",
+        "rev": "1ef8b1ea253b477b2e4f25a93e8dbb4b9f08f695",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hm-master':
    'github:nix-community/home-manager/f469c79' (2026-07-02)
  → 'github:nix-community/home-manager/a4d410d' (2026-07-02)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/9350e34' (2026-07-02)
  → 'github:hyprwm/Hyprland/420f112' (2026-07-02)
• Updated input 'nixpkgs-stable-small':
    'github:NixOS/nixpkgs/307b805' (2026-07-02)
  → 'github:NixOS/nixpkgs/5863b64' (2026-07-02)
• Updated input 'nur':
    'github:nix-community/NUR/e63cf13' (2026-07-02)
  → 'github:nix-community/NUR/1ef8b1e' (2026-07-02)
```