### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783024095,
-        "narHash": "sha256-oE+TNK98Pl7nHW4VU1oBvUKD5JR45U+py/NJmLoTNHI=",
+        "lastModified": 1783099620,
+        "narHash": "sha256-prQSM9PGnrfSaqknJOZ3DCQKbpMiXAWLVC5SHbjLcJ4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a4d410db95a6416d1008049330bd86b85b5db45a",
+        "rev": "b2e4390ff35319c52935d6a700b615da4c0f204d",
         "type": "github"
       },
       "original": {
@@ -678,11 +678,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1783044540,
-        "narHash": "sha256-MvaWA0Kz+P0M+5KOtPJN71+h+SXaoFkMIM8PPyVLHPs=",
+        "lastModified": 1783089885,
+        "narHash": "sha256-02ary8OtZROV9b1sqlNaU2NEhzA706qmTBfX8Alvyk0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7008f632a9c5162d4ad399018ba10ffd13af4c90",
+        "rev": "04b4e759e84353279524e23661cd1622f76df6ed",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783092278,
-        "narHash": "sha256-zUFXwr0d6GtBy1wJEicampBeEOWdAcejPUn4l7Mor5c=",
+        "lastModified": 1783102545,
+        "narHash": "sha256-JdAE4mrruinhums7+UDUN4NQMm6ZHgl0Q9KgC/Os4AY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a6f867120d89b250f775a1e65b8661f04fb8f4de",
+        "rev": "feb21e9939def95494872b556cc0a7bb54913ff1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hm-master':
    'github:nix-community/home-manager/a4d410d' (2026-07-02)
  → 'github:nix-community/home-manager/b2e4390' (2026-07-03)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/7008f63' (2026-07-03)
  → 'github:NixOS/nixpkgs/04b4e75' (2026-07-03)
• Updated input 'nur':
    'github:nix-community/NUR/a6f8671' (2026-07-03)
  → 'github:nix-community/NUR/feb21e9' (2026-07-03)
```