### PR TITLE
Update datasource configurations and metrics

### DIFF
--- a/dashboards/host/blizzard/power-consumption-historical.json
+++ b/dashboards/host/blizzard/power-consumption-historical.json
@@ -19,11 +19,21 @@
   "templating": {
     "list": [
       {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "label": "Datasource",
+        "refresh": 1,
+        "options": []
+      },
+      {
         "name": "host",
         "type": "query",
         "datasource": {
           "type": "prometheus",
-          "uid": "victoriametrics"
+          "uid": "${datasource}"
         },
         "query": "label_values(node_rapl_package_joules_total, source_host)",
         "refresh": 1,
@@ -50,7 +60,7 @@
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "victoriametrics"
+        "uid": "${datasource}"
       },
       "targets": [
         {
@@ -59,7 +69,7 @@
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "victoriametrics"
+            "uid": "${datasource}"
           }
         }
       ],
@@ -208,7 +218,7 @@
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "victoriametrics"
+        "uid": "${datasource}"
       },
       "targets": [
         {
@@ -217,7 +227,7 @@
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "victoriametrics"
+            "uid": "${datasource}"
           }
         }
       ],
@@ -290,7 +300,7 @@
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "victoriametrics"
+        "uid": "${datasource}"
       },
       "targets": [
         {
@@ -299,7 +309,7 @@
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "victoriametrics"
+            "uid": "${datasource}"
           }
         }
       ],
@@ -380,7 +390,7 @@
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "victoriametrics"
+        "uid": "${datasource}"
       },
       "targets": [
         {
@@ -389,7 +399,7 @@
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "victoriametrics"
+            "uid": "${datasource}"
           }
         }
       ],
@@ -470,7 +480,7 @@
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "victoriametrics"
+        "uid": "${datasource}"
       },
       "targets": [
         {
@@ -479,7 +489,7 @@
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "victoriametrics"
+            "uid": "${datasource}"
           }
         }
       ],
@@ -553,7 +563,7 @@
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "victoriametrics"
+        "uid": "${datasource}"
       },
       "targets": [
         {
@@ -562,7 +572,7 @@
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "victoriametrics"
+            "uid": "${datasource}"
           }
         }
       ],
@@ -686,7 +696,7 @@
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "victoriametrics"
+        "uid": "${datasource}"
       },
       "targets": [
         {
@@ -695,7 +705,7 @@
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "victoriametrics"
+            "uid": "${datasource}"
           }
         }
       ],
@@ -856,7 +866,7 @@
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "victoriametrics"
+        "uid": "${datasource}"
       },
       "targets": [
         {
@@ -865,7 +875,7 @@
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "victoriametrics"
+            "uid": "${datasource}"
           }
         }
       ],
@@ -924,7 +934,7 @@
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "victoriametrics"
+        "uid": "${datasource}"
       },
       "targets": [
         {
@@ -933,7 +943,7 @@
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "victoriametrics"
+            "uid": "${datasource}"
           },
           "instant": true
         }
@@ -994,7 +1004,7 @@
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "victoriametrics"
+        "uid": "${datasource}"
       },
       "targets": [
         {
@@ -1003,7 +1013,7 @@
           "refId": "A",
           "datasource": {
             "type": "prometheus",
-            "uid": "victoriametrics"
+            "uid": "${datasource}"
           }
         }
       ],

--- a/dashboards/host/blizzard/ups-monitoring.json
+++ b/dashboards/host/blizzard/ups-monitoring.json
@@ -1124,11 +1124,7 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": true,
-          "text": "VictoriaMetrics (Long-term)",
-          "value": "victoriametrics"
-        },
+        "current": {},
         "hide": 0,
         "includeAll": false,
         "label": "Datasource",

--- a/dashboards/host/blizzard/zfs-overview.json
+++ b/dashboards/host/blizzard/zfs-overview.json
@@ -2169,11 +2169,7 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": true,
-          "text": "VictoriaMetrics (Long-term)",
-          "value": "victoriametrics"
-        },
+        "current": {},
         "hide": 0,
         "includeAll": false,
         "label": "Datasource",

--- a/dashboards/shared/arr-services.json
+++ b/dashboards/shared/arr-services.json
@@ -1992,11 +1992,7 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": true,
-          "text": "VictoriaMetrics (Long-term)",
-          "value": "victoriametrics"
-        },
+        "current": {},
         "hide": 0,
         "includeAll": false,
         "label": "Datasource",

--- a/dashboards/shared/electricity-prices.json
+++ b/dashboards/shared/electricity-prices.json
@@ -1267,11 +1267,7 @@
         "name": "datasource",
         "type": "datasource",
         "query": "prometheus",
-        "current": {
-          "selected": true,
-          "text": "VictoriaMetrics (Long-term)",
-          "value": "victoriametrics"
-        },
+        "current": {},
         "hide": 0,
         "label": "Datasource",
         "refresh": 1,

--- a/dashboards/shared/power-consumption.json
+++ b/dashboards/shared/power-consumption.json
@@ -30,7 +30,7 @@
       },
       "targets": [
         {
-          "expr": "sum(irate(node_rapl_package_joules_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum(irate(node_rapl_package_joules_total{source_host=~\"$host\"}[$__rate_interval]))",
           "refId": "A",
           "instant": true,
           "datasource": {
@@ -92,7 +92,7 @@
       },
       "targets": [
         {
-          "expr": "sum(node_hwmon_power_average_watt{instance=~\"$instance\", sensor=\"power1\"}) > vector(0)",
+          "expr": "sum(node_hwmon_power_average_watt{source_host=~\"$host\", sensor=\"power1\"}) > vector(0)",
           "refId": "A",
           "instant": true,
           "datasource": {
@@ -154,7 +154,7 @@
       },
       "targets": [
         {
-          "expr": "sum(irate(node_rapl_package_joules_total{instance=~\"$instance\"}[$__rate_interval])) + (sum(node_hwmon_power_average_watt{instance=~\"$instance\", sensor=\"power1\"}) or vector(0))",
+          "expr": "sum(irate(node_rapl_package_joules_total{source_host=~\"$host\"}[$__rate_interval])) + (sum(node_hwmon_power_average_watt{source_host=~\"$host\", sensor=\"power1\"}) or vector(0))",
           "refId": "A",
           "instant": true,
           "datasource": {
@@ -216,7 +216,7 @@
       },
       "targets": [
         {
-          "expr": "(sum(irate(node_rapl_package_joules_total{instance=~\"$instance\"}[$__rate_interval])) + (sum(node_hwmon_power_average_watt{instance=~\"$instance\", sensor=\"power1\"}) or vector(0))) / 1000 * 24 * scalar(max(electricity_total_cost_nok_per_kwh{tax=\"incl_mva\"}))",
+          "expr": "(sum(irate(node_rapl_package_joules_total{source_host=~\"$host\"}[$__rate_interval])) + (sum(node_hwmon_power_average_watt{source_host=~\"$host\", sensor=\"power1\"}) or vector(0))) / 1000 * 24 * scalar(max(electricity_total_cost_nok_per_kwh{tax=\"incl_mva\"}))",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -274,7 +274,7 @@
       },
       "targets": [
         {
-          "expr": "max_over_time(sum(irate(node_rapl_package_joules_total{instance=~\"$instance\"}[1m]))[24h:1m]) or max_over_time(sum(irate(node_rapl_package_joules_total{instance=~\"$instance\"}[1m]))[1h:1m])",
+          "expr": "max_over_time(sum(irate(node_rapl_package_joules_total{source_host=~\"$host\"}[1m]))[24h:1m]) or max_over_time(sum(irate(node_rapl_package_joules_total{source_host=~\"$host\"}[1m]))[1h:1m])",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -316,7 +316,7 @@
       },
       "targets": [
         {
-          "expr": "max_over_time((sum(irate(node_rapl_package_joules_total{instance=~\"$instance\"}[1m])) + (sum(node_hwmon_power_average_watt{instance=~\"$instance\", sensor=\"power1\"}) or vector(0)))[24h:1m]) or max_over_time((sum(irate(node_rapl_package_joules_total{instance=~\"$instance\"}[1m])) + (sum(node_hwmon_power_average_watt{instance=~\"$instance\", sensor=\"power1\"}) or vector(0)))[1h:1m])",
+          "expr": "max_over_time((sum(irate(node_rapl_package_joules_total{source_host=~\"$host\"}[1m])) + (sum(node_hwmon_power_average_watt{source_host=~\"$host\", sensor=\"power1\"}) or vector(0)))[24h:1m]) or max_over_time((sum(irate(node_rapl_package_joules_total{source_host=~\"$host\"}[1m])) + (sum(node_hwmon_power_average_watt{source_host=~\"$host\", sensor=\"power1\"}) or vector(0)))[1h:1m])",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -418,7 +418,7 @@
       },
       "targets": [
         {
-          "expr": "avg_over_time(sum(irate(node_rapl_package_joules_total{instance=~\"$instance\"}[1m]))[1h:])",
+          "expr": "avg_over_time(sum(irate(node_rapl_package_joules_total{source_host=~\"$host\"}[1m]))[1h:])",
           "legendFormat": "CPU",
           "refId": "A",
           "instant": true,
@@ -429,7 +429,7 @@
           }
         },
         {
-          "expr": "avg_over_time(sum(irate(node_rapl_package_joules_total{instance=~\"$instance\"}[1m]))[24h:])",
+          "expr": "avg_over_time(sum(irate(node_rapl_package_joules_total{source_host=~\"$host\"}[1m]))[24h:])",
           "legendFormat": "CPU",
           "refId": "B",
           "instant": true,
@@ -440,7 +440,7 @@
           }
         },
         {
-          "expr": "avg_over_time(sum(node_hwmon_power_average_watt{instance=~\"$instance\", sensor=\"power1\"})[1h:]) or vector(0)",
+          "expr": "avg_over_time(sum(node_hwmon_power_average_watt{source_host=~\"$host\", sensor=\"power1\"})[1h:]) or vector(0)",
           "legendFormat": "GPU",
           "refId": "C",
           "instant": true,
@@ -451,7 +451,7 @@
           }
         },
         {
-          "expr": "avg_over_time(sum(node_hwmon_power_average_watt{instance=~\"$instance\", sensor=\"power1\"})[24h:]) or vector(0)",
+          "expr": "avg_over_time(sum(node_hwmon_power_average_watt{source_host=~\"$host\", sensor=\"power1\"})[24h:]) or vector(0)",
           "legendFormat": "GPU",
           "refId": "D",
           "instant": true,
@@ -462,7 +462,7 @@
           }
         },
         {
-          "expr": "avg_over_time(sum(irate(node_rapl_package_joules_total{instance=~\"$instance\"}[1m]))[1h:]) + (avg_over_time(sum(node_hwmon_power_average_watt{instance=~\"$instance\", sensor=\"power1\"})[1h:]) or vector(0))",
+          "expr": "avg_over_time(sum(irate(node_rapl_package_joules_total{source_host=~\"$host\"}[1m]))[1h:]) + (avg_over_time(sum(node_hwmon_power_average_watt{source_host=~\"$host\", sensor=\"power1\"})[1h:]) or vector(0))",
           "legendFormat": "Total",
           "refId": "E",
           "instant": true,
@@ -473,7 +473,7 @@
           }
         },
         {
-          "expr": "avg_over_time(sum(irate(node_rapl_package_joules_total{instance=~\"$instance\"}[1m]))[24h:]) + (avg_over_time(sum(node_hwmon_power_average_watt{instance=~\"$instance\", sensor=\"power1\"})[24h:]) or vector(0))",
+          "expr": "avg_over_time(sum(irate(node_rapl_package_joules_total{source_host=~\"$host\"}[1m]))[24h:]) + (avg_over_time(sum(node_hwmon_power_average_watt{source_host=~\"$host\", sensor=\"power1\"})[24h:]) or vector(0))",
           "legendFormat": "Total",
           "refId": "F",
           "instant": true,
@@ -615,7 +615,7 @@
       },
       "targets": [
         {
-          "expr": "(sum(increase(node_rapl_package_joules_total{instance=~\"$instance\"}[1h])) / 3600000 + (avg_over_time(sum(node_hwmon_power_average_watt{instance=~\"$instance\", sensor=\"power1\"})[1h:]) or vector(0)) * 3600 / 3600000) * scalar(max(electricity_total_cost_nok_per_kwh{tax=\"incl_mva\"}))",
+          "expr": "(sum(increase(node_rapl_package_joules_total{source_host=~\"$host\"}[1h])) / 3600000 + (avg_over_time(sum(node_hwmon_power_average_watt{source_host=~\"$host\", sensor=\"power1\"})[1h:]) or vector(0)) * 3600 / 3600000) * scalar(max(electricity_total_cost_nok_per_kwh{tax=\"incl_mva\"}))",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -677,7 +677,7 @@
       },
       "targets": [
         {
-          "expr": "sum(irate(node_rapl_package_joules_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum(irate(node_rapl_package_joules_total{source_host=~\"$host\"}[$__rate_interval]))",
           "legendFormat": "CPU",
           "refId": "A",
           "datasource": {
@@ -686,7 +686,7 @@
           }
         },
         {
-          "expr": "sum(node_hwmon_power_average_watt{instance=~\"$instance\", sensor=\"power1\"}) or vector(0)",
+          "expr": "sum(node_hwmon_power_average_watt{source_host=~\"$host\", sensor=\"power1\"}) or vector(0)",
           "legendFormat": "GPU",
           "refId": "B",
           "datasource": {
@@ -695,7 +695,7 @@
           }
         },
         {
-          "expr": "sum(irate(node_rapl_package_joules_total{instance=~\"$instance\"}[$__rate_interval])) + (sum(node_hwmon_power_average_watt{instance=~\"$instance\", sensor=\"power1\"}) or vector(0))",
+          "expr": "sum(irate(node_rapl_package_joules_total{source_host=~\"$host\"}[$__rate_interval])) + (sum(node_hwmon_power_average_watt{source_host=~\"$host\", sensor=\"power1\"}) or vector(0))",
           "legendFormat": "Total",
           "refId": "C",
           "datasource": {
@@ -801,7 +801,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (index) (irate(node_rapl_core_joules_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum by (index) (irate(node_rapl_core_joules_total{source_host=~\"$host\"}[$__rate_interval]))",
           "legendFormat": "Core {{index}}",
           "refId": "A",
           "datasource": {
@@ -847,7 +847,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(node_rapl_package_joules_total{instance=~\"$instance\"}[$__range])) / 3600000",
+          "expr": "sum(increase(node_rapl_package_joules_total{source_host=~\"$host\"}[$__range])) / 3600000",
           "legendFormat": "CPU (kWh)",
           "refId": "A",
           "datasource": {
@@ -856,7 +856,7 @@
           }
         },
         {
-          "expr": "(sum(node_hwmon_power_average_watt{instance=~\"$instance\", sensor=\"power1\"}) or vector(0)) * $__range_s / 3600000",
+          "expr": "(sum(node_hwmon_power_average_watt{source_host=~\"$host\", sensor=\"power1\"}) or vector(0)) * $__range_s / 3600000",
           "legendFormat": "GPU (kWh est.)",
           "refId": "B",
           "datasource": {
@@ -1120,7 +1120,7 @@
       },
       "targets": [
         {
-          "expr": "(sum(irate(node_rapl_package_joules_total{instance=~\"$instance\"}[$__rate_interval])) + (sum(node_hwmon_power_average_watt{instance=~\"$instance\", sensor=\"power1\"}) or vector(0))) / 1000 * scalar(max(electricity_total_cost_nok_per_kwh{tax=\"incl_mva\"}))",
+          "expr": "(sum(irate(node_rapl_package_joules_total{source_host=~\"$host\"}[$__rate_interval])) + (sum(node_hwmon_power_average_watt{source_host=~\"$host\", sensor=\"power1\"}) or vector(0))) / 1000 * scalar(max(electricity_total_cost_nok_per_kwh{tax=\"incl_mva\"}))",
           "legendFormat": "Cost Rate",
           "refId": "A",
           "datasource": {
@@ -1195,7 +1195,7 @@
       },
       "targets": [
         {
-          "expr": "(sum(irate(node_rapl_package_joules_total{instance=~\"$instance\"}[$__rate_interval])) + (sum(node_hwmon_power_average_watt{instance=~\"$instance\", sensor=\"power1\"}) or vector(0))) / 1000 * scalar(max(electricity_total_cost_nok_per_kwh{tax=\"incl_mva\"}))",
+          "expr": "(sum(irate(node_rapl_package_joules_total{source_host=~\"$host\"}[$__rate_interval])) + (sum(node_hwmon_power_average_watt{source_host=~\"$host\", sensor=\"power1\"}) or vector(0))) / 1000 * scalar(max(electricity_total_cost_nok_per_kwh{tax=\"incl_mva\"}))",
           "legendFormat": "Cost Rate",
           "refId": "A",
           "datasource": {
@@ -1271,7 +1271,7 @@
       },
       "targets": [
         {
-          "expr": "(sum(irate(node_rapl_package_joules_total{instance=~\"$instance\"}[$__rate_interval])) + (sum(node_hwmon_power_average_watt{instance=~\"$instance\", sensor=\"power1\"}) or vector(0))) / 1000 * scalar(max(electricity_total_cost_nok_per_kwh{tax=\"incl_mva\"}))",
+          "expr": "(sum(irate(node_rapl_package_joules_total{source_host=~\"$host\"}[$__rate_interval])) + (sum(node_hwmon_power_average_watt{source_host=~\"$host\", sensor=\"power1\"}) or vector(0))) / 1000 * scalar(max(electricity_total_cost_nok_per_kwh{tax=\"incl_mva\"}))",
           "legendFormat": "Cost Rate (kr/h)",
           "refId": "A",
           "datasource": {
@@ -1339,29 +1339,25 @@
         "name": "datasource",
         "type": "datasource",
         "query": "prometheus",
-        "current": {
-          "selected": true,
-          "text": "VictoriaMetrics (Long-term)",
-          "value": "victoriametrics"
-        },
+        "current": {},
         "hide": 0,
         "label": "Datasource",
         "refresh": 1,
         "options": []
       },
       {
-        "name": "instance",
+        "name": "host",
         "type": "query",
         "datasource": {
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "query": "label_values(up{job=\"node\"}, instance)",
+        "query": "label_values(up{job=\"node\"}, source_host)",
         "current": {},
         "refresh": 2,
         "includeAll": true,
         "allValue": ".*",
-        "label": "Instance",
+        "label": "Host",
         "hide": 0
       }
     ]

--- a/hosts/blizzard/monitoring/victoriametrics.nix
+++ b/hosts/blizzard/monitoring/victoriametrics.nix
@@ -15,6 +15,7 @@ _: {
     grafanaDatasource = {
       enable = true;
       name = "VictoriaMetrics (Long-term)";
+      uid = null;
       isDefault = true;
     };
   };

--- a/hosts/blizzard/monitoring/victoriametrics.nix
+++ b/hosts/blizzard/monitoring/victoriametrics.nix
@@ -15,7 +15,6 @@ _: {
     grafanaDatasource = {
       enable = true;
       name = "VictoriaMetrics (Long-term)";
-      uid = "victoriametrics";
       isDefault = true;
     };
   };

--- a/modules/services/grafana.nix
+++ b/modules/services/grafana.nix
@@ -62,6 +62,20 @@ in
         '';
       };
 
+      deleteDatasources = lib.mkOption {
+        type = lib.types.listOf lib.types.attrs;
+        default = [ ];
+        description = "Datasource deletion rules to run before provisioning datasources";
+        example = lib.literalExpression ''
+          [
+            {
+              name = "Prometheus";
+              orgId = 1;
+            }
+          ]
+        '';
+      };
+
       dashboards = lib.mkOption {
         type = lib.types.attrsOf lib.types.path;
         default = { };
@@ -143,6 +157,14 @@ in
 
         datasources.settings = {
           apiVersion = 1;
+          deleteDatasources =
+            lib.optionals (config.sys.services.prometheus.enable or false) [
+              {
+                name = "Prometheus";
+                orgId = 1;
+              }
+            ]
+            ++ cfg.provision.deleteDatasources;
           datasources =
             lib.optionals (config.sys.services.prometheus.enable or false) [
               {

--- a/modules/services/prometheus.nix
+++ b/modules/services/prometheus.nix
@@ -1,6 +1,18 @@
 { lib, config, ... }:
 let
   cfg = config.sys.services.prometheus;
+
+  addSourceHostRelabel =
+    scrapeConfig:
+    scrapeConfig
+    // {
+      relabel_configs = (scrapeConfig.relabel_configs or [ ]) ++ [
+        {
+          target_label = "source_host";
+          replacement = config.networking.hostName;
+        }
+      ];
+    };
 in
 {
   options.sys.services.prometheus = {
@@ -100,7 +112,7 @@ in
         scrape_interval = cfg.scrapeInterval;
       };
 
-      scrapeConfigs =
+      scrapeConfigs = map addSourceHostRelabel (
         lib.optionals (config.sys.services.prometheusExporters.node.enable or false) [
           {
             job_name = "node";
@@ -125,7 +137,8 @@ in
             ];
           }
         ]
-        ++ cfg.extraScrapeConfigs;
+        ++ cfg.extraScrapeConfigs
+      );
     };
 
     networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];

--- a/modules/services/victoriametrics.nix
+++ b/modules/services/victoriametrics.nix
@@ -81,9 +81,9 @@ in
       };
 
       uid = lib.mkOption {
-        type = lib.types.str;
+        type = lib.types.nullOr lib.types.str;
         default = "victoriametrics";
-        description = "Stable Grafana datasource UID for VictoriaMetrics";
+        description = "Optional stable Grafana datasource UID for VictoriaMetrics";
       };
 
       isDefault = lib.mkOption {
@@ -192,22 +192,36 @@ in
 
     # Add VictoriaMetrics as Grafana datasource
     # VictoriaMetrics is 100% compatible with Prometheus datasource type
-    sys.services.grafana.provision.datasources =
+    sys.services.grafana.provision.deleteDatasources =
       lib.mkIf (cfg.grafanaDatasource.enable && config.sys.services.grafana.enable or false)
         [
           {
-            inherit (cfg.grafanaDatasource) name uid isDefault;
-            type = "prometheus"; # VictoriaMetrics is PromQL-compatible
-            access = "proxy";
-            url = "http://127.0.0.1:${toString cfg.port}";
-            editable = false;
-            jsonData = {
-              # VictoriaMetrics supports Prometheus-compatible API
-              httpMethod = "POST";
-              # Enable range queries for better performance
-              manageAlerts = false;
-            };
+            inherit (cfg.grafanaDatasource) name;
+            orgId = 1;
           }
+        ];
+
+    sys.services.grafana.provision.datasources =
+      lib.mkIf (cfg.grafanaDatasource.enable && config.sys.services.grafana.enable or false)
+        [
+          (
+            {
+              inherit (cfg.grafanaDatasource) name isDefault;
+              type = "prometheus"; # VictoriaMetrics is PromQL-compatible
+              access = "proxy";
+              url = "http://127.0.0.1:${toString cfg.port}";
+              editable = false;
+              jsonData = {
+                # VictoriaMetrics supports Prometheus-compatible API
+                httpMethod = "POST";
+                # Enable range queries for better performance
+                manageAlerts = false;
+              };
+            }
+            // lib.optionalAttrs (cfg.grafanaDatasource.uid != null) {
+              inherit (cfg.grafanaDatasource) uid;
+            }
+          )
         ];
 
     # Open firewall if requested


### PR DESCRIPTION
Refactor datasource configurations to eliminate hardcoded values and introduce variable usage. Enhance power consumption metrics by utilizing `source_host` for relabeling. Add an option for deleting datasources before provisioning. Adjust Grafana datasource UID to be optional.