### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -255,11 +255,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1783198893,
-        "narHash": "sha256-UgdXpHgsg700hROak8RspFTfa/PDClxfyCEKs12nhxU=",
+        "lastModified": 1783278836,
+        "narHash": "sha256-k6wcqNAwY2cSdQu7lPRpvSnnNfbBSYfxTxkt7m3loIw=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "7a5214614b2f5bec4dbe1d0bddbc128c79cd2dfb",
+        "rev": "c44cf81f027f7cbdd60ac098c3caa76cf8915fac",
         "type": "github"
       },
       "original": {
@@ -565,11 +565,11 @@
     },
     "nix-secrets": {
       "locked": {
-        "lastModified": 1778342057,
-        "narHash": "sha256-QX6EJQphZj4VjEmAhkssu7gP/iagcJMEbcarTqIgDxE=",
+        "lastModified": 1783283520,
+        "narHash": "sha256-jsMB6PVzLuzfU9TV5G7lhHAEmkegbjiXxr6i573R2bk=",
         "ref": "refs/heads/master",
-        "rev": "fe974bb53ec4b8fcd17c8225ec87247498f1a3a2",
-        "revCount": 121,
+        "rev": "833c142e8786b116d0c104cbe8f4e26cc2a2d819",
+        "revCount": 122,
         "type": "git",
         "url": "ssh://git@github.com/telometto/nix-secrets.git"
       },
@@ -599,11 +599,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782467914,
-        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783273282,
-        "narHash": "sha256-WpMgaavcwj7Ttv/O28lYcuWikUDFF6Nbx+Gynem5on0=",
+        "lastModified": 1783286384,
+        "narHash": "sha256-INkBxc0CuitYepDS+/G4OPO0GjxPNJnVmKgdbq0qeB4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eeeccdc409ac6c43c7fd5abbb34b2fe3c94794a6",
+        "rev": "fe1e6d9cbbe76237360655f9e72b3b921a952b78",
         "type": "github"
       },
       "original": {
@@ -774,20 +774,17 @@
         "flake-compat": [
           "flake-compat"
         ],
-        "gitignore": [
-          "gitignore"
-        ],
         "nixpkgs": [
           "hyprland",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781733627,
-        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
         "type": "github"
       },
       "original": {
@@ -955,11 +952,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782311043,
-        "narHash": "sha256-07zLc2M3/ax+JsjxGTft17/Joua41LHE9/9AC/F9zeU=",
+        "lastModified": 1782644412,
+        "narHash": "sha256-/iSa/bL1QQFLv+uJ9gI0N87J8gOeZXvca7EjoPGKE6w=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "882ad01e195ce201b07c618bbee44a0cad8b9e5a",
+        "rev": "c01c99fc278ec68c82e9865923088f043c7c1621",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hyprland':
    'github:hyprwm/Hyprland/7a52146' (2026-07-04)
  → 'github:hyprwm/Hyprland/c44cf81' (2026-07-05)
• Updated input 'hyprland/nixpkgs':
    'github:NixOS/nixpkgs/e73de5b' (2026-06-26)
  → 'github:NixOS/nixpkgs/d407951' (2026-07-05)
• Updated input 'hyprland/pre-commit-hooks':
    'github:cachix/git-hooks.nix/3bbec39' (2026-06-17)
  → 'github:cachix/git-hooks.nix/bca82ca' (2026-07-02)
• Removed input 'hyprland/pre-commit-hooks/gitignore'
• Updated input 'hyprland/xdph':
    'github:hyprwm/xdg-desktop-portal-hyprland/882ad01' (2026-06-24)
  → 'github:hyprwm/xdg-desktop-portal-hyprland/c01c99f' (2026-06-28)
• Updated input 'nix-secrets':
    'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=fe974bb53ec4b8fcd17c8225ec87247498f1a3a2' (2026-05-09)
  → 'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=833c142e8786b116d0c104cbe8f4e26cc2a2d819' (2026-07-05)
• Updated input 'nur':
    'github:nix-community/NUR/eeeccdc' (2026-07-05)
  → 'github:nix-community/NUR/fe1e6d9' (2026-07-05)
```