### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783297275,
-        "narHash": "sha256-cR/w/0JTULmr6T/+1WCnOJsWwQ/+tXy7DvVkWIcYSEI=",
+        "lastModified": 1783310842,
+        "narHash": "sha256-fgf5LDk5JTgNFMl+mabd9dNuc2IlhR69U2f82w2yiFw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5060ff78fe8b39349b339e748a4c1e8b27340825",
+        "rev": "2375bc43b5f0a554ecc13e5ae856233693b72dac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/5060ff7' (2026-07-06)
  → 'github:nix-community/NUR/2375bc4' (2026-07-06)
```