### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -678,11 +678,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1783264223,
-        "narHash": "sha256-3Uiwx/j6LYuQH3hYkPLOZrKjLtQO03fPkO3K0hIp8Jc=",
+        "lastModified": 1783306753,
+        "narHash": "sha256-yBvwRKoVMLe2a1nQvFZCDN5/zjiO2MiMzuIJWc/VW9U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "28d4faad49f8095ec21ebf0454aa8e9c7d7d0af9",
+        "rev": "38f52fc9057a249e1e9c93e2781e439aad5a10bd",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783310842,
-        "narHash": "sha256-fgf5LDk5JTgNFMl+mabd9dNuc2IlhR69U2f82w2yiFw=",
+        "lastModified": 1783322592,
+        "narHash": "sha256-PUdLhg22DYDarbDoIV/k282eWS2cOpRb/5STfe+0mlg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2375bc43b5f0a554ecc13e5ae856233693b72dac",
+        "rev": "696415fb46e4266478d6f254f05bfe7285f784a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/28d4faa' (2026-07-05)
  → 'github:NixOS/nixpkgs/38f52fc' (2026-07-06)
• Updated input 'nur':
    'github:nix-community/NUR/2375bc4' (2026-07-06)
  → 'github:nix-community/NUR/696415f' (2026-07-06)
```