### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -583,11 +583,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1782562157,
-        "narHash": "sha256-a7+T6QSeowynwZ1ZJJbP8T8ntAytvrui8kFGJmIZt2c=",
+        "lastModified": 1783370751,
+        "narHash": "sha256-E+3MIMvKuo9k+K+qLQ9YXzsBzkgHuyVLnsEbN2DFfuc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "a9cf7546a938c737b079e738de73934a13de9784",
+        "rev": "662bd6e312d2c8b212e32cb377abaee190749320",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783362494,
-        "narHash": "sha256-IH69MCG8oYpSIN8X+gmgSpVvGhvSPT69YSHh8VZkgzo=",
+        "lastModified": 1783372377,
+        "narHash": "sha256-G14PtVyUerStR6osP6kxpsPjz6pxqGptAlgQ5JUmHrs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f4e53c38a35f414b0ac6405343d052e33b5e6bdd",
+        "rev": "360a57c2c0fcde5b4153610e89b5ef4d1910173a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/a9cf754' (2026-06-27)
  → 'github:NixOS/nixos-hardware/662bd6e' (2026-07-06)
• Updated input 'nur':
    'github:nix-community/NUR/f4e53c3' (2026-07-06)
  → 'github:nix-community/NUR/360a57c' (2026-07-06)
```