### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable-small": {
       "locked": {
-        "lastModified": 1783282179,
-        "narHash": "sha256-Htv/wQPw81OFLQN3Fc8ZBR8Nb2QPtds+/PVpMkMQ10A=",
+        "lastModified": 1783389287,
+        "narHash": "sha256-0xIy4dVLqq47rA+mRy0hXDfjhQd4E5PoIns/RmB7nR4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c387489856353b6a83488a2b6a7b8db2dc61202b",
+        "rev": "0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c",
         "type": "github"
       },
       "original": {
@@ -678,11 +678,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1783306753,
-        "narHash": "sha256-yBvwRKoVMLe2a1nQvFZCDN5/zjiO2MiMzuIJWc/VW9U=",
+        "lastModified": 1783394305,
+        "narHash": "sha256-uOKjaaVPYY6sn+lvcSq+hv1WKR1AYcXeebHFZLMgvz4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "38f52fc9057a249e1e9c93e2781e439aad5a10bd",
+        "rev": "50a1dd57142b57851ddf1aac58c2225166439547",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783397707,
-        "narHash": "sha256-Y2wy79WMvVRhoXYXtXTj4k/Q6Oq56zdgLq2fejBHAuo=",
+        "lastModified": 1783407703,
+        "narHash": "sha256-nZD+kenOZMx9Viqv3vO41hFoLcWVE3g2Bj7qeog6nUg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "11fdf9a426f36ed411e1675cbdbac035497f0c2c",
+        "rev": "a1d58434f60ac80597c01de70ada9440362b2797",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs-stable-small':
    'github:NixOS/nixpkgs/c387489' (2026-07-05)
  → 'github:NixOS/nixpkgs/0ad6f47' (2026-07-07)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/38f52fc' (2026-07-06)
  → 'github:NixOS/nixpkgs/50a1dd5' (2026-07-07)
• Updated input 'nur':
    'github:nix-community/NUR/11fdf9a' (2026-07-07)
  → 'github:nix-community/NUR/a1d5843' (2026-07-07)
```