### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783417368,
-        "narHash": "sha256-LIgDxiekmW3jlWqUfQkR7NnIThuMVyooQyFOrsCSK6o=",
+        "lastModified": 1783427370,
+        "narHash": "sha256-PVYfd3CcDefzkWRtQOglKIvHwVguN6zODGpX54FKCt8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4d1cc8f6df84f8bf9bda27b139e44df230e80046",
+        "rev": "ec51793364d79517a816296bced01c2287a742be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/4d1cc8f' (2026-07-07)
  → 'github:nix-community/NUR/ec51793' (2026-07-07)
```