### PR TITLE
Add autoStart option for Subgen container

### DIFF
--- a/containers/subgen.nix
+++ b/containers/subgen.nix
@@ -11,6 +11,12 @@ in
   options.services.subgen-container = {
     enable = lib.mkEnableOption "Standalone Subgen subtitle generation container";
 
+    autoStart = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Whether to start the Subgen container automatically with the user systemd session.";
+    };
+
     port = lib.mkOption {
       type = lib.types.port;
       default = 11027;
@@ -132,7 +138,7 @@ in
     ];
 
     virtualisation.quadlet.containers.subgen-standalone = {
-      autoStart = true;
+      inherit (cfg) autoStart;
       containerConfig = {
         image =
           if cfg.image != null then
@@ -190,13 +196,24 @@ in
         userns = "keep-id";
       };
 
-      unitConfig =
-        lib.mkIf
+      unitConfig = lib.mkMerge [
+        {
+          ConditionPathIsDirectory = [
+            "${cfg.mediaDir}/tv"
+            "${cfg.mediaDir}/movies"
+            cfg.modelDir
+          ];
+        }
+        (lib.mkIf
           ((cfg.environmentFiles != [ ]) && (lib.attrByPath [ "hm" "security" "sops" "enable" ] false config))
           {
             Requires = [ "sops-nix.service" ];
             After = [ "sops-nix.service" ];
-          };
+          }
+        )
+      ];
+
+      serviceConfig.TimeoutStartSec = "30s";
     };
   };
 }

--- a/containers/subgen.nix
+++ b/containers/subgen.nix
@@ -137,6 +137,10 @@ in
       }
     ];
 
+    systemd.user.tmpfiles.rules = [
+      "d ${cfg.modelDir} 0755 - - -"
+    ];
+
     virtualisation.quadlet.containers.subgen-standalone = {
       inherit (cfg) autoStart;
       containerConfig = {
@@ -165,7 +169,7 @@ in
           WEBHOOKPORT = "9000";
           TRANSCRIBE_DEVICE = if cfg.gpu.enable then "cuda" else "cpu";
           CLEAR_VRAM_ON_COMPLETE = "True";
-          MODEL_PATH = "./models";
+          MODEL_PATH = "/subgen/models";
           DEBUG = "False";
         }
         // lib.optionalAttrs (cfg.forceDetectedLanguageTo != "") {
@@ -212,8 +216,6 @@ in
           }
         )
       ];
-
-      serviceConfig.TimeoutStartSec = "30s";
     };
   };
 }

--- a/hosts/snowfall/containers.nix
+++ b/hosts/snowfall/containers.nix
@@ -24,6 +24,7 @@ in
 
       subgen-container = {
         enable = true;
+        autoStart = false;
         gpu.enable = true;
         whisperModel = "large-v3";
         mediaDir = "/mnt/media";


### PR DESCRIPTION
Introduce an `autoStart` option for the Subgen container to control its automatic startup with the user systemd session. This change enhances configuration flexibility for users.