### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -615,11 +615,11 @@
     },
     "nixpkgs-beta": {
       "locked": {
-        "lastModified": 1783148766,
-        "narHash": "sha256-uslt2pqShTIXDdAHRHv2QkYLsVdY8Oqwz0EA48/RSM8=",
+        "lastModified": 1783389287,
+        "narHash": "sha256-0xIy4dVLqq47rA+mRy0hXDfjhQd4E5PoIns/RmB7nR4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a50de1b7d8a586adc18d2395c19de7d6058e6030",
+        "rev": "0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c",
         "type": "github"
       },
       "original": {
@@ -707,11 +707,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1783148766,
-        "narHash": "sha256-uslt2pqShTIXDdAHRHv2QkYLsVdY8Oqwz0EA48/RSM8=",
+        "lastModified": 1783389287,
+        "narHash": "sha256-0xIy4dVLqq47rA+mRy0hXDfjhQd4E5PoIns/RmB7nR4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a50de1b7d8a586adc18d2395c19de7d6058e6030",
+        "rev": "0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783459590,
-        "narHash": "sha256-ExXI+f95Q5lZPnLERy6dG+5S2GYIUI+0jPWpya7fgeU=",
+        "lastModified": 1783467553,
+        "narHash": "sha256-cDPniyGeBKK6YsZpFdTrNy9YzrsnLfVsfjh7DG5x3Vg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4cacc665dda13f80b861ccd3a0f059b95d39e663",
+        "rev": "8244967a1c7f9a39b846cba7f94da719d4e65286",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/a50de1b' (2026-07-04)
  → 'github:NixOS/nixpkgs/0ad6f47' (2026-07-07)
• Updated input 'nixpkgs-beta':
    'github:NixOS/nixpkgs/a50de1b' (2026-07-04)
  → 'github:NixOS/nixpkgs/0ad6f47' (2026-07-07)
• Updated input 'nur':
    'github:nix-community/NUR/4cacc66' (2026-07-07)
  → 'github:nix-community/NUR/8244967' (2026-07-07)
```