### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783503806,
-        "narHash": "sha256-joXGl44X8Mz4Y3W8sqRs7h7z1xUcGnQdaLWVe9FpkOY=",
+        "lastModified": 1783512494,
+        "narHash": "sha256-FLT8/giExJlGussbUPYRnotRIU6L0RnE55PcyFbSrQA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8481a3f29f9a910317b9003b3ac29844ed0bb44d",
+        "rev": "c26c3621c7726ddcdc9ed08a7147be0821036a0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/8481a3f' (2026-07-08)
  → 'github:nix-community/NUR/c26c362' (2026-07-08)
```