### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -255,11 +255,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1783539707,
-        "narHash": "sha256-3kHnWiN3gr7te1BNqP/SepJj0C0OwFxB/k5QnSUW0P0=",
+        "lastModified": 1783582777,
+        "narHash": "sha256-fsDLDZuvet2iZv6svhcMjcO5LjwHrY6VQnJAfND/N+U=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "9d284382a62433e8f94d6bcefe3762d4e6fec330",
+        "rev": "01f5c9aee4c31e5b782e99eb354ee7230b999821",
         "type": "github"
       },
       "original": {
@@ -583,11 +583,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1783370751,
-        "narHash": "sha256-E+3MIMvKuo9k+K+qLQ9YXzsBzkgHuyVLnsEbN2DFfuc=",
+        "lastModified": 1783582157,
+        "narHash": "sha256-EteIu2AVVbxzkBnBKjrbdknbpjxBkWTMNg02rXj4mgU=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "662bd6e312d2c8b212e32cb377abaee190749320",
+        "rev": "968980fba2c290b5529025636474eae8457b854c",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783579882,
-        "narHash": "sha256-ZqKO8TczKUZotdvixaezkNdnJeyekD0XpMCf1b9TBOE=",
+        "lastModified": 1783591506,
+        "narHash": "sha256-8uMzk2B+6LrZOaa7tcdpxklr1d4ebb0R9fZSU3DjT/4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f5b1cb8edde817bfe0a3a20bd22d92b49cfa1447",
+        "rev": "5e55beca70666084e0f247e5ec6704a2efa4b287",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hyprland':
    'github:hyprwm/Hyprland/9d28438' (2026-07-08)
  → 'github:hyprwm/Hyprland/01f5c9a' (2026-07-09)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/662bd6e' (2026-07-06)
  → 'github:NixOS/nixos-hardware/968980f' (2026-07-09)
• Updated input 'nur':
    'github:nix-community/NUR/f5b1cb8' (2026-07-09)
  → 'github:nix-community/NUR/5e55bec' (2026-07-09)
```