### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783618078,
-        "narHash": "sha256-F43DGcBoIO8xOZFAfodg3jy0VghB9NGdb6xbTYAIx1A=",
+        "lastModified": 1783689750,
+        "narHash": "sha256-iMO/Ypany7DPXD6D7sQgH7METtEUihnOvdb+A9ehn8k=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "144f4e36d0186195037da9fce80a727108978070",
+        "rev": "79e6082586b3680ff32c8e75127545058f074fa4",
         "type": "github"
       },
       "original": {
@@ -583,11 +583,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1783673680,
-        "narHash": "sha256-ardRVG+ipnyyxVdIsbLMy5foO6gDqN/yIi8v10HTJqs=",
+        "lastModified": 1783692676,
+        "narHash": "sha256-6FXlRphexzMo3HpoN0NxEl7uQoE8llWeNJrD8NMA/CY=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "0b655af52b5b89bcceb88737efdc3a7498e751ee",
+        "rev": "4471c6a218fe813ad4838c400866c8845d3eba6b",
         "type": "github"
       },
       "original": {
@@ -678,11 +678,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1783651168,
-        "narHash": "sha256-31bKrtu9iDAaXyoFZEjauookb4iy87MNhD9yCJx+9rY=",
+        "lastModified": 1783693695,
+        "narHash": "sha256-ll8SjCNgwWuou5Q64GMjuUrrqRJW1gy3uCMjd+oa9KA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1f67b2542cd28cacf647a01bad01c3ea762f5c62",
+        "rev": "dc29ee8fa098c86053cc8ef25594738f28be5b6b",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783686443,
-        "narHash": "sha256-1bDCyHf7pUbZ50pxSKvwPH5O+PEYH3LuFaByqk/jF8M=",
+        "lastModified": 1783698009,
+        "narHash": "sha256-rfSHkkXy7VgXCSzZqFobmJc//ca45jow4PLe0FSLP7E=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "67cb112dceb41c410dc1d31b5c8396df64c96f5f",
+        "rev": "34e0b4a7ec3759e23c2c98cbd9ffa48e897d09fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hm-master':
    'github:nix-community/home-manager/144f4e3' (2026-07-09)
  → 'github:nix-community/home-manager/79e6082' (2026-07-10)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/0b655af' (2026-07-10)
  → 'github:NixOS/nixos-hardware/4471c6a' (2026-07-10)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/1f67b25' (2026-07-10)
  → 'github:NixOS/nixpkgs/dc29ee8' (2026-07-10)
• Updated input 'nur':
    'github:nix-community/NUR/67cb112' (2026-07-10)
  → 'github:nix-community/NUR/34e0b4a' (2026-07-10)
```