### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -583,11 +583,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1783692676,
-        "narHash": "sha256-6FXlRphexzMo3HpoN0NxEl7uQoE8llWeNJrD8NMA/CY=",
+        "lastModified": 1783792734,
+        "narHash": "sha256-50rvY9GdFvpYDcMLcD/4cWSi0hVxArT5wsGlVsHy8eY=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "4471c6a218fe813ad4838c400866c8845d3eba6b",
+        "rev": "8efb4337e857949f4cfac86d12ef1066f417f31f",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783781396,
-        "narHash": "sha256-aksKD/uLLuu17Sqaz4Ae2zbExheI5v/U9j9778eCD5U=",
+        "lastModified": 1783792757,
+        "narHash": "sha256-4DwpsrJeowyd5ndc76RXUxjhtb3elUSWOP2ltAT23Ws=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "29c4c5612e67bce09ee3f2f988bebe51ff9e6b81",
+        "rev": "a3688bd7a26655458aa50411b825b1a39721357c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/4471c6a' (2026-07-10)
  → 'github:NixOS/nixos-hardware/8efb433' (2026-07-11)
• Updated input 'nur':
    'github:nix-community/NUR/29c4c56' (2026-07-11)
  → 'github:nix-community/NUR/a3688bd' (2026-07-11)
```