### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -255,11 +255,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1783871351,
-        "narHash": "sha256-DJEsxRTORO8IYsk8Uoo5gRFr1aUwR2PaX3XSGq7rvkU=",
+        "lastModified": 1783881054,
+        "narHash": "sha256-FeiCDFKENNVFt/PMAqYiCUAJQm+SCPItcilh613dEjQ=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "c4cfe0e830dbac770fc58acceab357799cb615ba",
+        "rev": "f4b9c1ab240f5c5d2b5a2e659113361e476772a5",
         "type": "github"
       },
       "original": {
@@ -565,11 +565,11 @@
     },
     "nix-secrets": {
       "locked": {
-        "lastModified": 1783283520,
-        "narHash": "sha256-jsMB6PVzLuzfU9TV5G7lhHAEmkegbjiXxr6i573R2bk=",
+        "lastModified": 1783887672,
+        "narHash": "sha256-3zPSs+oNZqdu9jDcPsZpPLyu973yn3N6mXk7a2Dy+P0=",
         "ref": "refs/heads/master",
-        "rev": "833c142e8786b116d0c104cbe8f4e26cc2a2d819",
-        "revCount": 122,
+        "rev": "80dfe6b7f89c9dc0f2136e34682d79f51c8a4349",
+        "revCount": 123,
         "type": "git",
         "url": "ssh://git@github.com/telometto/nix-secrets.git"
       },
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783877971,
-        "narHash": "sha256-08JXk0fV2fl3gc18BjpUBOsQrXu2YxwQT9nMJuO6Lg0=",
+        "lastModified": 1783890289,
+        "narHash": "sha256-dk+lr9Nx2Z9M4XrC+Cac1BgrXqyY5lFXHxyOhmM8LcY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ff370e1bc2a5f952d004e7e28d11ee5c7dbbaf3",
+        "rev": "eb2addfca6eb05e0e37e8ef6a33d34b131cad0b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hyprland':
    'github:hyprwm/Hyprland/c4cfe0e' (2026-07-12)
  → 'github:hyprwm/Hyprland/f4b9c1a' (2026-07-12)
• Updated input 'nix-secrets':
    'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=833c142e8786b116d0c104cbe8f4e26cc2a2d819' (2026-07-05)
  → 'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=80dfe6b7f89c9dc0f2136e34682d79f51c8a4349' (2026-07-12)
• Updated input 'nur':
    'github:nix-community/NUR/4ff370e' (2026-07-12)
  → 'github:nix-community/NUR/eb2addf' (2026-07-12)
```