### PR TITLE
Add Immich machine-learning container support

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -51,6 +51,7 @@ ______________________________________________________________________
 | Option | File | Port(s) | Purpose |
 |--------|------|---------|---------|
 | `services.ollama-container.enable` | [ollama.nix](ollama.nix) | 11434 | Standalone LLM server (ROCm/AMD or CPU image) |
+| `services.immich-machine-learning-container.enable` | [immich-machine-learning.nix](immich-machine-learning.nix) | 3003 | Standalone Immich ML worker (CUDA/NVIDIA or CPU image) |
 | `services.subgen-container.enable` | [subgen.nix](subgen.nix) | 11027 | Whisper-based subtitle generator (CPU or AMD GPU) |
 | `services.lingarr.enable` | [subtitle-stack.nix](subtitle-stack.nix) | 11025 | Full subtitle translation pipeline (lingarr + libretranslate + ollama + subgen as a pod) |
 | `services.subgen.enable` | [subtitle-stack.nix](subtitle-stack.nix) | 11027 | Subgen as part of the subtitle-stack pod |
@@ -59,6 +60,12 @@ ______________________________________________________________________
 **`ollama.nix`** — Standalone LLM inference server. Supports ROCm (AMD GPU) or
 CPU-only image selection. Usable on any host that has Podman. Enable via
 `services.ollama-container.enable = true` in a user's HM config.
+
+**`immich-machine-learning.nix`** — Standalone Immich machine-learning worker.
+Supports CUDA (NVIDIA GPU) or CPU-only image selection. Intended for keeping
+Immich's server/database/storage on a MicroVM while offloading ML inference to a
+GPU-capable host. Enable via
+`services.immich-machine-learning-container.enable = true` in a user's HM config.
 
 **`subgen.nix`** — Whisper-based automatic subtitle generation. Supports CPU
 or AMD GPU acceleration. Enable via `services.subgen-container.enable = true`.

--- a/containers/immich-machine-learning.nix
+++ b/containers/immich-machine-learning.nix
@@ -1,0 +1,119 @@
+# Standalone Immich machine-learning container.
+# Home Manager module - runs rootless via quadlet-nix.
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.immich-machine-learning-container;
+
+  imageSuffix = lib.optionalString (cfg.acceleration != "cpu") "-${cfg.acceleration}";
+  defaultImage = "ghcr.io/immich-app/immich-machine-learning:v${pkgs.immich.version}${imageSuffix}";
+in
+{
+  options.services.immich-machine-learning-container = {
+    enable = lib.mkEnableOption "Standalone Immich machine-learning container";
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 3003;
+      description = "Host port to expose the Immich machine-learning API on.";
+    };
+
+    listenAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "0.0.0.0";
+      description = "Host address to bind the published port to.";
+    };
+
+    cacheDir = lib.mkOption {
+      type = lib.types.str;
+      default = "${config.home.homeDirectory}/.local/share/immich-machine-learning/cache";
+      description = "Path for persistent Immich machine-learning model cache.";
+    };
+
+    image = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Container image to use. Defaults to the current nixpkgs Immich version with the selected acceleration suffix.";
+    };
+
+    acceleration = lib.mkOption {
+      type = lib.types.enum [
+        "cpu"
+        "cuda"
+      ];
+      default = "cuda";
+      description = "Machine-learning image acceleration backend.";
+    };
+
+    cudaDevice = lib.mkOption {
+      type = lib.types.str;
+      default = "nvidia.com/gpu=all";
+      description = "NVIDIA CDI device selector passed to Podman when CUDA acceleration is enabled.";
+    };
+
+    modelTtl = lib.mkOption {
+      type = lib.types.str;
+      default = "600";
+      description = "Seconds of inactivity before machine-learning models are unloaded.";
+    };
+
+    extraEnvironments = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      description = "Additional environment variables for the Immich machine-learning container.";
+    };
+
+    extraPodmanArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Additional arguments passed to podman run.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.user.tmpfiles.rules = [
+      "d ${cfg.cacheDir} 0755 - - -"
+    ];
+
+    virtualisation.quadlet.containers.immich-machine-learning = {
+      autoStart = true;
+      containerConfig = {
+        image = if cfg.image != null then cfg.image else defaultImage;
+        publishPorts = [
+          "${cfg.listenAddress}:${toString cfg.port}:3003"
+        ];
+        volumes = [
+          "${cfg.cacheDir}:/cache:U"
+        ];
+        environments = {
+          IMMICH_HOST = "0.0.0.0";
+          IMMICH_PORT = "3003";
+          MACHINE_LEARNING_CACHE_FOLDER = "/cache";
+          MACHINE_LEARNING_MODEL_TTL = cfg.modelTtl;
+          HF_HOME = "/cache/huggingface";
+          HF_HUB_CACHE = "/cache/huggingface/hub";
+          HF_XET_CACHE = "/cache/huggingface/xet";
+          HF_HUB_DISABLE_XET = "1";
+          XDG_CACHE_HOME = "/cache/xdg";
+          HOME = "/cache/home";
+        }
+        // lib.optionalAttrs (cfg.acceleration == "cuda") {
+          NVIDIA_VISIBLE_DEVICES = "all";
+          NVIDIA_DRIVER_CAPABILITIES = "compute,utility";
+        }
+        // cfg.extraEnvironments;
+        devices = lib.optionals (cfg.acceleration == "cuda") [
+          cfg.cudaDevice
+        ];
+        addGroups = lib.optionals (cfg.acceleration == "cuda") [
+          "keep-groups"
+        ];
+        podmanArgs = cfg.extraPodmanArgs;
+      };
+    };
+  };
+}

--- a/hosts/blizzard/security/traefik.nix
+++ b/hosts/blizzard/security/traefik.nix
@@ -52,6 +52,13 @@ let
     "100.64.0.0/10"
   ];
 
+  immichUploadTimeouts = {
+    transport.respondingTimeouts = {
+      readTimeout = "600s";
+      idleTimeout = "600s";
+    };
+  };
+
   # Plex OAuth and web clients still require inline/eval allowances; keep this
   # policy scoped to Plex-family routes instead of using it as a default.
   plexCsp = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://plex.tv https://*.plex.tv https://*.plex.direct wss://*.plex.direct; frame-src https://app.plex.tv;";
@@ -74,7 +81,9 @@ in
       api.dashboard = true;
 
       entryPoints = {
-        web = {
+        # Cloudflare Tunnel terminates public HTTPS and forwards to this
+        # entrypoint, so Immich's large uploads need the longer timeout here.
+        web = immichUploadTimeouts // {
           address = ":80";
           forwardedHeaders = { inherit trustedIPs; };
         };
@@ -140,6 +149,10 @@ in
           };
 
           gitea-xfp-https.headers.customRequestHeaders.X-Forwarded-Proto = "https";
+
+          immich-headers = traefikLib.mkSecurityHeaders {
+            requestHeaders.X-Forwarded-Proto = "https";
+          };
 
           # Django CSRF requires the Referer header, which "no-referrer" strips.
           # See: https://github.com/paperless-ngx/paperless-ngx/discussions/5684

--- a/hosts/blizzard/virtualisation/microvms.nix
+++ b/hosts/blizzard/virtualisation/microvms.nix
@@ -2,11 +2,14 @@
   self,
   VARS,
   lib,
+  pkgs,
+  consts,
   ...
 }:
 let
   reg = import ../../../vms/vm-registry.nix;
   vmUrl = name: "http://${reg.${name}.ip}:${toString reg.${name}.port}";
+  immichMlProxyPort = 3003;
 
   localhostUrl = "http://localhost:80";
 
@@ -293,12 +296,20 @@ let
     };
 
     immich = {
-      enable = false;
-      portForwards = [ (mkPortForward "tcp" 11070 null) ];
-      ingressHosts = [ "photos" ];
+      enable = true;
+      # Stage 1: boot privately for first-admin setup. For the public route,
+      # set ingressHosts = [ "photos" ], reverseProxy.enable = true, and
+      # IMMICH_ALLOW_SETUP=false in the VM environment after setup is complete.
+      portForwards = [ ];
+      ingressHosts = [ ];
       reverseProxy = {
+        enable = false;
         subdomain = "photos";
         url = vmUrl "immich";
+        middlewares = [
+          "immich-headers"
+          "crowdsec"
+        ];
       };
     };
 
@@ -331,6 +342,30 @@ let
   };
 in
 {
+  networking.firewall.interfaces."microvm-br0".allowedTCPPorts = [ immichMlProxyPort ];
+
+  systemd.services.immich-ml-proxy = {
+    description = "Proxy Immich MicroVM machine-learning requests to Kaizer";
+    after = [
+      "network-online.target"
+      "systemd-networkd.service"
+      "tailscaled.service"
+    ];
+    wants = [ "network-online.target" ];
+    wantedBy = [ "multi-user.target" ];
+
+    serviceConfig = {
+      ExecStart = "${lib.getExe pkgs.socat} TCP-LISTEN:${toString immichMlProxyPort},bind=10.100.0.1,reuseaddr,fork TCP:kaizer.boreal-ruler.ts.net:${toString immichMlProxyPort}";
+      Restart = "always";
+      RestartSec = "5s";
+      DynamicUser = true;
+      NoNewPrivileges = true;
+      PrivateTmp = true;
+      ProtectHome = true;
+      ProtectSystem = "strict";
+    };
+  };
+
   sys.virtualisation = {
     enable = true;
 

--- a/hosts/blizzard/virtualisation/microvms.nix
+++ b/hosts/blizzard/virtualisation/microvms.nix
@@ -297,13 +297,12 @@ let
 
     immich = {
       enable = true;
-      # Stage 1: boot privately for first-admin setup. For the public route,
-      # set ingressHosts = [ "photos" ], reverseProxy.enable = true, and
-      # IMMICH_ALLOW_SETUP=false in the VM environment after setup is complete.
+      # Keep the VM port off the host while publishing it through the managed
+      # Cloudflare Tunnel and Traefik route.
       portForwards = [ ];
-      ingressHosts = [ ];
+      ingressHosts = [ "photos" ];
       reverseProxy = {
-        enable = false;
+        enable = true;
         subdomain = "photos";
         url = vmUrl "immich";
         middlewares = [

--- a/hosts/kaizer/containers.nix
+++ b/hosts/kaizer/containers.nix
@@ -1,0 +1,30 @@
+# Rootless Podman containers on kaizer (managed via quadlet-nix + Home Manager)
+{ VARS, ... }:
+let
+  username = VARS.users.luke.user;
+  immichMlPort = 3003;
+in
+{
+  networking.firewall.interfaces.tailscale0.allowedTCPPorts = [ immichMlPort ];
+
+  users.users.${username} = {
+    linger = true;
+    autoSubUidGidRange = true;
+    extraGroups = [
+      "video"
+      "render"
+    ];
+  };
+
+  home-manager.users.${username} = {
+    imports = [
+      ../../containers/immich-machine-learning.nix
+    ];
+
+    services.immich-machine-learning-container = {
+      enable = true;
+      port = immichMlPort;
+      acceleration = "cuda";
+    };
+  };
+}

--- a/vms/README.md
+++ b/vms/README.md
@@ -150,10 +150,10 @@ sys.virtualisation.microvm.instances.<name> = {
 Each instance toggle is independent, so a VM can remain active while
 selectively disabling its Cloudflare Tunnel or Traefik routing.
 
-`immich` is enabled privately at `10.100.0.70:11070` for first-admin
-bootstrap. It intentionally has no raw host port forward, Cloudflare Tunnel
-ingress, or Traefik route until the setup endpoint can be disabled and the
-`photos` public route is flipped on.
+`immich` is published at `https://photos.zzxyz.no` through Cloudflare Tunnel
+and Traefik. Its raw host port is not forwarded; `10.100.0.70:11070` remains
+the direct address on the MicroVM network and through the advertised Tailscale
+subnet route.
 
 ______________________________________________________________________
 

--- a/vms/README.md
+++ b/vms/README.md
@@ -133,7 +133,7 @@ ______________________________________________________________________
 ### Host-side enablement
 
 On `blizzard`, VMs are managed via `sys.virtualisation.microvm.instances.<name>` toggles.
-Some instances are currently disabled (e.g. `adguard`, `actual`, `lidarr`, `brave`, `immich`).
+Some instances are currently disabled (e.g. `adguard`, `actual`, `lidarr`, `brave`).
 Enabled instances are exposed via:
 
 ```nix
@@ -149,6 +149,11 @@ sys.virtualisation.microvm.instances.<name> = {
 
 Each instance toggle is independent, so a VM can remain active while
 selectively disabling its Cloudflare Tunnel or Traefik routing.
+
+`immich` is enabled privately at `10.100.0.70:11070` for first-admin
+bootstrap. It intentionally has no raw host port forward, Cloudflare Tunnel
+ingress, or Traefik route until the setup endpoint can be disabled and the
+`photos` public route is flipped on.
 
 ______________________________________________________________________
 

--- a/vms/immich.nix
+++ b/vms/immich.nix
@@ -1,5 +1,7 @@
 {
   inputs,
+  VARS,
+  lib,
   ...
 }:
 let
@@ -29,6 +31,8 @@ in
     ))
   ];
 
+  # security.sudo.wheelNeedsPassword = lib.mkForce false;
+
   # SOPS configuration for this MicroVM
   # After first boot, get the VM's age key with:
   #   ssh admin@10.100.0.70 "sudo cat /persist/ssh/ssh_host_ed25519_key" | ssh-to-age
@@ -54,5 +58,20 @@ in
     host = "0.0.0.0";
     inherit (reg) port;
     openFirewall = true;
+
+    environment = {
+      TZ = "Europe/Oslo";
+      IMMICH_LOG_LEVEL = "log";
+      IMMICH_TRUSTED_PROXIES = "10.100.0.1";
+    };
+
+    ml.enable = false;
+
+    settings = {
+      machineLearning.urls = [
+        "http://10.100.0.1:3003"
+      ];
+      server.externalDomain = "https://photos.${VARS.domains.public}";
+    };
   };
 }

--- a/vms/immich.nix
+++ b/vms/immich.nix
@@ -61,6 +61,7 @@ in
 
     environment = {
       TZ = "Europe/Oslo";
+      IMMICH_ALLOW_SETUP = "false";
       IMMICH_LOG_LEVEL = "log";
       IMMICH_TRUSTED_PROXIES = "10.100.0.1";
     };
@@ -68,10 +69,16 @@ in
     ml.enable = false;
 
     settings = {
-      machineLearning.urls = [
-        "http://10.100.0.1:3003"
-      ];
+      machineLearning = {
+        clip.modelName = "ViT-SO400M-16-SigLIP2-384__webli";
+        ocr.modelName = "LATIN__PP-OCRv5_mobile";
+        urls = [
+          "http://10.100.0.1:3003"
+        ];
+      };
+      oauth.autoRegister = false;
       server.externalDomain = "https://photos.${VARS.domains.public}";
+      storageTemplate.enabled = true;
     };
   };
 }


### PR DESCRIPTION
Introduce a standalone Immich machine-learning container with configuration for rootless Podman support. Update Traefik settings to accommodate upload timeouts and enhance Immich service configurations. Update documentation to reflect these changes and provide details on the new container setup.