### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -531,11 +531,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1783896341,
-        "narHash": "sha256-83EAttUL0aM8226d/3blNSuwEJggslBF3Ad8HG0oAag=",
+        "lastModified": 1783944818,
+        "narHash": "sha256-B2Xu+NYTQxgsOANKOmkUM4QXQDWMVOHL7AHu0gmWN9E=",
         "owner": "microvm-nix",
         "repo": "microvm.nix",
-        "rev": "6dab06c1886c80b5bc28276e4879e699c86b3e5e",
+        "rev": "74d8374877d0d4e0fa81480793d4ab09b2b32ba5",
         "type": "github"
       },
       "original": {
@@ -615,11 +615,11 @@
     },
     "nixpkgs-beta": {
       "locked": {
-        "lastModified": 1783703440,
-        "narHash": "sha256-O3/YajjWo001VUIgD8BwaRdSNLUFe7nZ1qV5TwhRBcw=",
+        "lastModified": 1783856661,
+        "narHash": "sha256-ZGP04e+Q6WyQJGA9ZvI5CL6+heGQldbAG9U1T9NGvmU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8f0500b9660505dc3cb647775fe9a978a74b5283",
+        "rev": "569d578509928497eddc3fdbf94a799027050be4",
         "type": "github"
       },
       "original": {
@@ -678,11 +678,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1783891814,
-        "narHash": "sha256-TXhx+yUXb24h+Wu60Ck9wVk2AuSvf172qzCmJLJlqIs=",
+        "lastModified": 1783935015,
+        "narHash": "sha256-wCWfznifGmMeHxx1zBWYnjBXOdARSgSjWh9PWoph2/0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "62290c9d1b6ff9e155da4da1de774cdd706cf48a",
+        "rev": "fa0063eb13bd6adb9ce0dc849b997dd77a6c5ee6",
         "type": "github"
       },
       "original": {
@@ -707,11 +707,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1783703440,
-        "narHash": "sha256-O3/YajjWo001VUIgD8BwaRdSNLUFe7nZ1qV5TwhRBcw=",
+        "lastModified": 1783856661,
+        "narHash": "sha256-ZGP04e+Q6WyQJGA9ZvI5CL6+heGQldbAG9U1T9NGvmU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8f0500b9660505dc3cb647775fe9a978a74b5283",
+        "rev": "569d578509928497eddc3fdbf94a799027050be4",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783934234,
-        "narHash": "sha256-IgViYcLRYu2gT+Pbi8xWHJsoh1D035DlQgZE/4pHeXU=",
+        "lastModified": 1783946189,
+        "narHash": "sha256-c/T1qEVaQfT/XhCkPtFfUoolpBzhWNcq3fzrnRA7/no=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c3038640c4fabb336eab2b4e173903c3d8f97cb1",
+        "rev": "151157f7285333911946e1bf3c8ae6fb0660ef0c",
         "type": "github"
       },
       "original": {
@@ -876,10 +876,11 @@
     "spectrum": {
       "flake": false,
       "locked": {
-        "lastModified": 1783423582,
-        "narHash": "sha256-4z10q9MX1irpGhLe+uYC6k7evEnyhb/z1eNeIf71B+g=",
-        "rev": "0adfbcb6c12f35b33b8f47dc527587d4d20eeb93",
-        "revCount": 1400,
+        "lastModified": 1783694892,
+        "narHash": "sha256-xO8f7Qng+18FK2UlB9vcrkxCaQMCt5WjCH24aW/11eg=",
+        "ref": "refs/heads/main",
+        "rev": "24c4346e30fdea8d8e80f34aec3554a15a667d24",
+        "revCount": 1410,
         "type": "git",
         "url": "https://spectrum-os.org/git/spectrum"
       },


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'microvm':
    'github:microvm-nix/microvm.nix/6dab06c' (2026-07-12)
  → 'github:microvm-nix/microvm.nix/74d8374' (2026-07-13)
• Updated input 'microvm/spectrum':
    'git+https://spectrum-os.org/git/spectrum?rev=0adfbcb6c12f35b33b8f47dc527587d4d20eeb93' (2026-07-07)
  → 'git+https://spectrum-os.org/git/spectrum?ref=refs/heads/main&rev=24c4346e30fdea8d8e80f34aec3554a15a667d24' (2026-07-10)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/8f0500b' (2026-07-10)
  → 'github:NixOS/nixpkgs/569d578' (2026-07-12)
• Updated input 'nixpkgs-beta':
    'github:NixOS/nixpkgs/8f0500b' (2026-07-10)
  → 'github:NixOS/nixpkgs/569d578' (2026-07-12)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/62290c9' (2026-07-12)
  → 'github:NixOS/nixpkgs/fa0063e' (2026-07-13)
• Updated input 'nur':
    'github:nix-community/NUR/c303864' (2026-07-13)
  → 'github:nix-community/NUR/151157f' (2026-07-13)
```