### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable-small": {
       "locked": {
-        "lastModified": 1783901513,
-        "narHash": "sha256-VwlRz4FaK7lFti0pTUlTY5mn0HbVDCKaaIGlo3UNoJA=",
+        "lastModified": 1783944360,
+        "narHash": "sha256-8cdMBB3kyjEw+DXmO8VetsirUu+JvOqq/gHrzSK52Vg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "74258951b6f86d69cc7c08b1860ec5e391384f59",
+        "rev": "2da3921f5b8d88ccadb75e7caa6df47a0b00d58d",
         "type": "github"
       },
       "original": {
@@ -678,11 +678,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1783935015,
-        "narHash": "sha256-wCWfznifGmMeHxx1zBWYnjBXOdARSgSjWh9PWoph2/0=",
+        "lastModified": 1783978241,
+        "narHash": "sha256-7kK0Y/fIV2NTKArkd/eZGaFg+dEmgP8KDRsGK2vB5M4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fa0063eb13bd6adb9ce0dc849b997dd77a6c5ee6",
+        "rev": "a8b81d3cc8d35af7bc98694696bea61ad4f8fca7",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783977114,
-        "narHash": "sha256-RXWtLkJ5D/gwet6r+HOqlB9W/W0YHW8K1MQWrwdgErk=",
+        "lastModified": 1783980621,
+        "narHash": "sha256-cvODnNth/Hhnlyw3QW6y4QSIGcj28ZQ0QCROBfL0mAU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4cdd778730d538dd893668cd9ae0d59772a6ac17",
+        "rev": "b2ab6ad092e546b801cad645f8a9911aeb01c487",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs-stable-small':
    'github:NixOS/nixpkgs/7425895' (2026-07-13)
  → 'github:NixOS/nixpkgs/2da3921' (2026-07-13)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/fa0063e' (2026-07-13)
  → 'github:NixOS/nixpkgs/a8b81d3' (2026-07-13)
• Updated input 'nur':
    'github:nix-community/NUR/4cdd778' (2026-07-13)
  → 'github:nix-community/NUR/b2ab6ad' (2026-07-13)
```