### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -255,11 +255,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1784020214,
-        "narHash": "sha256-RCJt+v55pUNIAXJ4DaUBZjnquoXgHzD3joj4kqJfNSI=",
+        "lastModified": 1784025900,
+        "narHash": "sha256-ZAnvkVf1o8A+r0BQ6JOR3CNA+1NVbnvO3KUXNqV8Gfs=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "b348ff780c24a7ed7e1df61a85317054037469ec",
+        "rev": "e0d9283897724403ea8574b3ed419d2678a39231",
         "type": "github"
       },
       "original": {
@@ -678,11 +678,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1783978241,
-        "narHash": "sha256-7kK0Y/fIV2NTKArkd/eZGaFg+dEmgP8KDRsGK2vB5M4=",
+        "lastModified": 1784023459,
+        "narHash": "sha256-SdAl2p+bZEwh5akQ0vkaKBnS6yQduvj7kf24q6FHvxY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a8b81d3cc8d35af7bc98694696bea61ad4f8fca7",
+        "rev": "5b6151d7156c90731f5723e0751d2b8684c62433",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784020983,
-        "narHash": "sha256-9HcFxA11pk9kKoAylnOip86nPvPqs2zQRy6YM6FyCvI=",
+        "lastModified": 1784028934,
+        "narHash": "sha256-PCMK7VSZKK4duNX8j2gv85z1Pb5xP5eGl2R7K4l4Iyk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ac66aa2cef1651dc819a867623c05f0a9de013d2",
+        "rev": "b4722337bc41cbfe938173415bc519e9de3542f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hyprland':
    'github:hyprwm/Hyprland/b348ff7' (2026-07-14)
  → 'github:hyprwm/Hyprland/e0d9283' (2026-07-14)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/a8b81d3' (2026-07-13)
  → 'github:NixOS/nixpkgs/5b6151d' (2026-07-14)
• Updated input 'nur':
    'github:nix-community/NUR/ac66aa2' (2026-07-14)
  → 'github:nix-community/NUR/b472233' (2026-07-14)
```