### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable-small": {
       "locked": {
-        "lastModified": 1784054616,
-        "narHash": "sha256-M+vxJLSwdMWa00Xkt/bJEFTW9ZRAAmLlNyj8KpvGJFs=",
+        "lastModified": 1784083649,
+        "narHash": "sha256-IYsYLsIASHYJD5PadK5eFZuvUh1l9WOc4kWpNnUF1Zk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6e63924c156fab00e11365891b879673b49c268d",
+        "rev": "2a39bdbef9100c1bbcd476d2b4d9bb21bf86a770",
         "type": "github"
       },
       "original": {
@@ -678,11 +678,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1784054773,
-        "narHash": "sha256-skqZ6Oiha3ui4gNZKYLXZhePMgE6d57+5zBEpseHsP4=",
+        "lastModified": 1784087100,
+        "narHash": "sha256-4jFMNTCCFYP7BfYanzw31ESHRDiOfShYEd/kI+T0ks8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fe05ec9b1349594d887fdcc137586e91290a1fc2",
+        "rev": "c552e6d492ac42d6039dc92a4dd7d608aced167a",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784086088,
-        "narHash": "sha256-wkj/aG4poFVOh1NBwlwapf52U/EJ5P3ByipbmpFLG1Y=",
+        "lastModified": 1784096816,
+        "narHash": "sha256-kq09VsSJBqs3O8XxrTpWLjHTAjkKJsLhVLJAtj0Qh+4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a6bfc3f2672b816124d3430e0f979ac0b3056bd2",
+        "rev": "7adc69d83d4c7c44f600bee94062f3716194a746",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs-stable-small':
    'github:NixOS/nixpkgs/6e63924' (2026-07-14)
  → 'github:NixOS/nixpkgs/2a39bdb' (2026-07-15)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/fe05ec9' (2026-07-14)
  → 'github:NixOS/nixpkgs/c552e6d' (2026-07-15)
• Updated input 'nur':
    'github:nix-community/NUR/a6bfc3f' (2026-07-15)
  → 'github:nix-community/NUR/7adc69d' (2026-07-15)
```