### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -531,11 +531,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1784056390,
-        "narHash": "sha256-L1EoUkfu8Gq20c0upqU0ZJqEDmcsQkFQSKBEuj2bevc=",
+        "lastModified": 1784114346,
+        "narHash": "sha256-K7vhRb7e4Np6sti8EfcIr/YgpBEPc7owxBeETE4T3PE=",
         "owner": "microvm-nix",
         "repo": "microvm.nix",
-        "rev": "da9643e8937dedefdd3499379174d013900e2e1a",
+        "rev": "a8ddffe21a84b533b38c16cf63e9c5fda4a19743",
         "type": "github"
       },
       "original": {
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable-small": {
       "locked": {
-        "lastModified": 1784083649,
-        "narHash": "sha256-IYsYLsIASHYJD5PadK5eFZuvUh1l9WOc4kWpNnUF1Zk=",
+        "lastModified": 1784113276,
+        "narHash": "sha256-EQSc+5dtKeYAukjbFIVHIU9mqzUmyVkRJB0uas1y8Tw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2a39bdbef9100c1bbcd476d2b4d9bb21bf86a770",
+        "rev": "489b2361bda37b7ee35e04ddf4be96048fe12cce",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784107669,
-        "narHash": "sha256-i9ECPxxEMP2N62kJWz757B5ff2EAAx/1cY+jLRz13WE=",
+        "lastModified": 1784115720,
+        "narHash": "sha256-sYkmty+ZqvpQ+rETXdNlV/VZi6znPBdNMg4oIBS0BCg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a2ae8809074f0dc22cb805e04f4bf42e90e68e6c",
+        "rev": "f9f255cf48b09487dcca39747e944d6c2ea3bf05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'microvm':
    'github:microvm-nix/microvm.nix/da9643e' (2026-07-14)
  → 'github:microvm-nix/microvm.nix/a8ddffe' (2026-07-15)
• Updated input 'nixpkgs-stable-small':
    'github:NixOS/nixpkgs/2a39bdb' (2026-07-15)
  → 'github:NixOS/nixpkgs/489b236' (2026-07-15)
• Updated input 'nur':
    'github:nix-community/NUR/a2ae880' (2026-07-15)
  → 'github:nix-community/NUR/f9f255c' (2026-07-15)
```