### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -565,11 +565,11 @@
     },
     "nix-secrets": {
       "locked": {
-        "lastModified": 1784038497,
-        "narHash": "sha256-jsMB6PVzLuzfU9TV5G7lhHAEmkegbjiXxr6i573R2bk=",
+        "lastModified": 1784142535,
+        "narHash": "sha256-zESnX0H1FLSc8bjVK2nah5QsqpMwnH8DnfTapKrhSiU=",
         "ref": "refs/heads/master",
-        "rev": "d9936faf869f16feb7cb4ca5d33e0ea25d6a523a",
-        "revCount": 124,
+        "rev": "3a084eb7513951dbcc6a92c5db8b7c05e85a4f34",
+        "revCount": 125,
         "type": "git",
         "url": "ssh://git@github.com/telometto/nix-secrets.git"
       },
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable-small": {
       "locked": {
-        "lastModified": 1784113276,
-        "narHash": "sha256-EQSc+5dtKeYAukjbFIVHIU9mqzUmyVkRJB0uas1y8Tw=",
+        "lastModified": 1784147059,
+        "narHash": "sha256-GXX5aSDwmaO/xT1ieg/N+6nbo/XvZE9TNCx0+LCKbdA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "489b2361bda37b7ee35e04ddf4be96048fe12cce",
+        "rev": "07fd8b9f6cfc6ad50f0991a23974d45778ef5777",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784137696,
-        "narHash": "sha256-QQ6SFxzzuFtixA8+kcs+5iqKDYeMCgEegyU98Pxc91o=",
+        "lastModified": 1784149327,
+        "narHash": "sha256-kJHrGd/Yx0ABYSOo1RYdtDZ5do5/t3bLuzF3GiKszsY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e19cadda50f55271042c52c04e6d8d5eea0406d8",
+        "rev": "f709525e312460fc806ee86b3f73f13ab429a6ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nix-secrets':
    'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=d9936faf869f16feb7cb4ca5d33e0ea25d6a523a' (2026-07-14)
  → 'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=3a084eb7513951dbcc6a92c5db8b7c05e85a4f34' (2026-07-15)
• Updated input 'nixpkgs-stable-small':
    'github:NixOS/nixpkgs/489b236' (2026-07-15)
  → 'github:NixOS/nixpkgs/07fd8b9' (2026-07-15)
• Updated input 'nur':
    'github:nix-community/NUR/e19cadd' (2026-07-15)
  → 'github:nix-community/NUR/f709525' (2026-07-15)
```