### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -678,11 +678,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1784124460,
-        "narHash": "sha256-SuzyxniSemtq2B7AopFHKfF0f+6jjWK9dhURAyp6jgs=",
+        "lastModified": 1784157011,
+        "narHash": "sha256-CEHmSwSc+5kzd6tP/4ol4KEA9fMDVSKGTam7rbBPQqw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9770f9c6f9690ddb152b3bec6de1a25507831eb5",
+        "rev": "d4a57f162b50db6d7e49580a772ccbdb3a1605a4",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784158591,
-        "narHash": "sha256-REvzywHNuWbaIJ8RTT4D7+zV6Bcuwfjn6DicwOkL128=",
+        "lastModified": 1784172433,
+        "narHash": "sha256-ZzT3rkiXV7AHM9VhH8D1GLWYH5OuiGE69gG/O6t0Mdg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "49de03da7a0efc0ee2921303f04d93dc1287abd9",
+        "rev": "0fd3f9095cb586193f052ca5c0843aa4c5e37a86",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/9770f9c' (2026-07-15)
  → 'github:NixOS/nixpkgs/d4a57f1' (2026-07-15)
• Updated input 'nur':
    'github:nix-community/NUR/49de03d' (2026-07-15)
  → 'github:nix-community/NUR/0fd3f90' (2026-07-16)
```