### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784172433,
-        "narHash": "sha256-ZzT3rkiXV7AHM9VhH8D1GLWYH5OuiGE69gG/O6t0Mdg=",
+        "lastModified": 1784183911,
+        "narHash": "sha256-OJUrRmh/QtUeXoEdctwT3FMWfKLLLyXEcu4d9OMOgVc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0fd3f9095cb586193f052ca5c0843aa4c5e37a86",
+        "rev": "e14fd8193ba4867d39618275a9d81cfc988fc2fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/0fd3f90' (2026-07-16)
  → 'github:nix-community/NUR/e14fd81' (2026-07-16)
```