### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -255,11 +255,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1784276659,
-        "narHash": "sha256-UjU8SIFXeP1O6g8kbkxjJtMA7/pvisrCl44wd3jbKnI=",
+        "lastModified": 1784281376,
+        "narHash": "sha256-rY74gRYIjurM4fAo2u18eurwpeIRnoo4UkeWAwqE1Dk=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "5663e6d12923f4c0af3bca17a5e45de449bc0c79",
+        "rev": "229bca7b1a0238cd44eb827ae9a23d6798d37ef9",
         "type": "github"
       },
       "original": {
@@ -565,11 +565,11 @@
     },
     "nix-secrets": {
       "locked": {
-        "lastModified": 1784218640,
-        "narHash": "sha256-RBYeAlWyLMRc8yI9810eLtvjQlvOGOdk/IaVeAySlDw=",
+        "lastModified": 1784289058,
+        "narHash": "sha256-Zif/QOWEjx+19z9G80K5eyXbjB8Y5YMk4LTREz5iax4=",
         "ref": "refs/heads/master",
-        "rev": "7b51c327ac1566748cc2008541e9c718f18fe399",
-        "revCount": 126,
+        "rev": "df7e126cb7e58ba74d30cc87715fac2200e2a781",
+        "revCount": 127,
         "type": "git",
         "url": "ssh://git@github.com/telometto/nix-secrets.git"
       },
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable-small": {
       "locked": {
-        "lastModified": 1784209741,
-        "narHash": "sha256-UsR27WFapNjf1jBcI3C+p23e2rG/wIcGJy/GnpByXtQ=",
+        "lastModified": 1784280462,
+        "narHash": "sha256-DtoqIqM7VkR6NxAkcLpMwmi02USwWb3JdmNGLyhthc0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "73814047f34ebec31823b7a3087e31816788aabd",
+        "rev": "293d6abedf0478e681a4dfcfcb35b30fc796a32f",
         "type": "github"
       },
       "original": {
@@ -678,11 +678,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1784224299,
-        "narHash": "sha256-FEyouc/8OeIlHTg8zMlHsFFPxPFP09amZFiUQYuF+Xg=",
+        "lastModified": 1784280447,
+        "narHash": "sha256-uNupmWBGix4Eak5wmEsA8K8p7tesH1tEy3HnbANF9DM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fd40dc70a9554de4370b6d5d08b858f7c4e49e30",
+        "rev": "a53c7797377b2ee8b019920ab4f183937b9dfab5",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784280634,
-        "narHash": "sha256-t20FsCpkZwDxo1em/m1aX4TLhfH8X4LcGNAO5OubUOI=",
+        "lastModified": 1784290164,
+        "narHash": "sha256-Am/cOAdAcZNrJLkY/RQBlL/8sSKoXIgMmSTx2KHJeiM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6df08cc1935fe3ba6ef1e60189aa67bc3546acec",
+        "rev": "9748deb6e0acb5dabf11cbda8286ce492933c330",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hyprland':
    'github:hyprwm/Hyprland/5663e6d' (2026-07-17)
  → 'github:hyprwm/Hyprland/229bca7' (2026-07-17)
• Updated input 'nix-secrets':
    'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=7b51c327ac1566748cc2008541e9c718f18fe399' (2026-07-16)
  → 'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=df7e126cb7e58ba74d30cc87715fac2200e2a781' (2026-07-17)
• Updated input 'nixpkgs-stable-small':
    'github:NixOS/nixpkgs/7381404' (2026-07-16)
  → 'github:NixOS/nixpkgs/293d6ab' (2026-07-17)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/fd40dc7' (2026-07-16)
  → 'github:NixOS/nixpkgs/a53c779' (2026-07-17)
• Updated input 'nur':
    'github:nix-community/NUR/6df08cc' (2026-07-17)
  → 'github:nix-community/NUR/9748deb' (2026-07-17)
```