### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable-small": {
       "locked": {
-        "lastModified": 1784680941,
-        "narHash": "sha256-lP36xDSDM2BChHtWT3IvsLAR52EY34Z7R/IB5NgHSiM=",
+        "lastModified": 1784755387,
+        "narHash": "sha256-uxq8JKEE6bjRst96QKwH5snLXC5QkrqoY+CYuhGqGQg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c41845294cf9f43f0264771c7c62592419e116c",
+        "rev": "2b7a84e696b76759b60bea1eafd62fa34fb96a6e",
         "type": "github"
       },
       "original": {
@@ -678,11 +678,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1784730354,
-        "narHash": "sha256-K9yMlQyAUf9T1BVcmfJRqOgdpfLABojXWUIt+qZ/2TU=",
+        "lastModified": 1784763249,
+        "narHash": "sha256-8YUiO/yckouAUAHbZuzUnQN8KaYIV2m8TCu8Ai/oYzk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b281be14dde2d2a8ce3870f450da3d5637ad67b6",
+        "rev": "2526016ba5d102028225a372d676f639e22ae5d1",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784778050,
-        "narHash": "sha256-O9QZrhvMcX3pRJcD8dBcxW0agahp4DUshHhtPEgAYGs=",
+        "lastModified": 1784788792,
+        "narHash": "sha256-qXfboFKxTUTFO1092oJ1UHoidWcEMdET2xNtR1H3eq8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2acfa8f7c3e26762d777b50f64e848448b679fb2",
+        "rev": "ecfc809be9da070ffd3e3b3b30849b2a371fe1ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs-stable-small':
    'github:NixOS/nixpkgs/0c41845' (2026-07-22)
  → 'github:NixOS/nixpkgs/2b7a84e' (2026-07-22)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/b281be1' (2026-07-22)
  → 'github:NixOS/nixpkgs/2526016' (2026-07-22)
• Updated input 'nur':
    'github:nix-community/NUR/2acfa8f' (2026-07-23)
  → 'github:nix-community/NUR/ecfc809' (2026-07-23)
```