### PR TITLE
Enhance MicroVM public HTTP publication configuration

### DIFF
--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -6,6 +6,7 @@ on:
             - "**.nix"
             - "flake.lock"
             - "treefmt.nix"
+            - ".github/workflows/flake-check.yml"
             - "modules/services/scripts/cloudflare_metrics.py"
             - "tests/cloudflare_metrics/**"
             - "dashboards/host/blizzard/cloudflare-overview.json"
@@ -14,6 +15,7 @@ on:
         paths:
             - "**.nix"
             - "flake.lock"
+            - ".github/workflows/flake-check.yml"
             - "modules/services/scripts/cloudflare_metrics.py"
             - "tests/cloudflare_metrics/**"
             - "dashboards/host/blizzard/cloudflare-overview.json"
@@ -47,19 +49,23 @@ jobs:
 
             - name: Run flake check
               run: |
-                  echo "## 🔍 Flake Check Results" >> $GITHUB_STEP_SUMMARY
                   output_file=$(mktemp)
                   trap 'rm -f "$output_file"' EXIT
-
-                  if nix flake check --no-build >"$output_file" 2>&1; then
-                    echo "✅ All flake outputs evaluate successfully" >> $GITHUB_STEP_SUMMARY
-                  else
-                    echo "❌ Flake check failed" >> $GITHUB_STEP_SUMMARY
-                    echo '```' >> $GITHUB_STEP_SUMMARY
-                    bash .github/scripts/redact-secrets.sh < "$output_file" >> $GITHUB_STEP_SUMMARY
-                    echo '```' >> $GITHUB_STEP_SUMMARY
-                    exit 1
-                  fi
+                  {
+                    echo "## 🔍 Flake Check Results"
+                    if nix flake check --no-build >"$output_file" 2>&1; then
+                      echo "✅ All flake outputs evaluate successfully"
+                    else
+                      echo "❌ Flake check failed"
+                      echo '```'
+                      bash .github/scripts/redact-secrets.sh < "$output_file"
+                      echo '```'
+                      exit 1
+                    fi
+                  } >> "$GITHUB_STEP_SUMMARY"
 
             - name: Run Cloudflare metrics tests
               run: nix build .#checks.x86_64-linux.cloudflare-metrics --no-link --print-build-logs
+
+            - name: Run MicroVM publication tests
+              run: nix build .#checks.x86_64-linux.microvm-publication --no-link --print-build-logs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,10 @@ Enable in a host file: `sys.role.desktop.enable = true;`
 - `vms/vm-registry.nix` — single source of truth for CID, MAC, IP, memory, vCPU per VM.
 - `vms/mkMicrovmConfig.nix` — helper that generates common network/storage config from a registry entry.
 - `vms/base.nix` — shared hardened base (SSH keys, admin user, firewall).
+- `modules/virtualisation/microvm-base.nix` — host-side instance lifecycle, NAT forwarding, and standard public HTTP publication.
+- Standard publication is explicit under `sys.virtualisation.microvm.instances.<name>.publication`; enabling a VM never publishes it automatically.
+- A publication supplies only `enable`, one hostname label, and a compatibility-policy name. The module derives the registry target and renders Cloudflare Tunnel plus Traefik configuration.
+- Compatibility-policy middleware mappings live beside the host Traefik configuration. Raw port forwarding and bespoke routes such as Matrix stay outside the publication interface.
 
 ### Lib helpers
 
@@ -104,6 +108,7 @@ Enable in a host file: `sys.role.desktop.enable = true;`
 | New system feature | `modules/<category>/<name>.nix` | Auto-loaded; use `sys.*` options |
 | New HM feature | `home/<category>/<name>.nix` | Auto-loaded; use `hm.*` options |
 | New host | `hosts/<hostname>/` | Register in `flake.nix` via `mkHost` |
+| Standard public MicroVM route | `hosts/<hostname>/virtualisation/microvms.nix` | Enable `instances.<name>.publication`; use a registered compatibility policy |
 | Per-host HM tweak | `home/overrides/host/<hostname>.nix` | Imported explicitly by HM |
 | Per-user HM tweak | `home/overrides/user/<user>-<host>.nix` | Imported explicitly by HM |
 | Sensitive data | `nix-secrets` flake (`VARS`) | Never commit to this repo |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,10 @@ Enable in a host file: `sys.role.desktop.enable = true;`
 - `vms/vm-registry.nix` — single source of truth for CID, MAC, IP, memory, vCPU per VM.
 - `vms/mkMicrovmConfig.nix` — helper that generates common network/storage config from a registry entry.
 - `vms/base.nix` — shared hardened base (SSH keys, admin user, firewall).
+- `modules/virtualisation/microvm-base.nix` — host-side instance lifecycle, NAT forwarding, and standard public HTTP publication.
+- Standard publication is explicit under `sys.virtualisation.microvm.instances.<name>.publication`; enabling a VM never publishes it automatically.
+- A publication supplies only `enable`, one hostname label, and a compatibility-policy name. The module derives the registry target and renders Cloudflare Tunnel plus Traefik configuration.
+- Compatibility-policy middleware mappings live beside the host Traefik configuration. Raw port forwarding and bespoke routes such as Matrix stay outside the publication interface.
 
 ### Lib helpers
 
@@ -120,6 +124,7 @@ Enable in a host file: `sys.role.desktop.enable = true;`
 | New system feature | `modules/<category>/<name>.nix` | Auto-loaded; use `sys.*` options |
 | New HM feature | `home/<category>/<name>.nix` | Auto-loaded; use `hm.*` options |
 | New host | `hosts/<hostname>/` | Register in `flake.nix` via `mkHost` |
+| Standard public MicroVM route | `hosts/<hostname>/virtualisation/microvms.nix` | Enable `instances.<name>.publication`; use a registered compatibility policy |
 | Per-role HM tweak | `home/overrides/role/<role>.nix` | Imported by HM when `sys.role.<role>.enable = true` |
 | Per-host HM tweak | `home/overrides/host/<hostname>.nix` | Imported explicitly by HM |
 | Cross-host per-user HM tweak | `home/overrides/user/<user>.nix` | Imported for that user on every host |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,34 @@
+# Infrastructure Configuration
+
+This context describes how hosts and their workloads are made available to
+clients while keeping application publication distinct from network access.
+
+## Language
+
+**Public HTTP publication**:
+An explicitly enabled, hostname-based path that makes one enabled workload target
+available to public web clients through the managed HTTP edge. Each publication
+has exactly one hostname under the canonical public domain and one target.
+_Avoid_: Public exposure, ingress
+
+**Canonical public domain**:
+The domain suffix under which standard public HTTP publications are named.
+_Avoid_: Base domain, primary domain
+
+**Publication policy**:
+The security, abuse-protection, and workload-compatibility requirements attached
+to a public HTTP publication. Every standard publication policy includes abuse
+protection and a strict security baseline, and describes intent rather than
+edge-specific configuration.
+_Avoid_: Middleware list, route configuration
+
+**Compatibility policy**:
+A named, route-scoped variation of the strict publication policy required by a
+workload that cannot operate under the baseline. It changes only the behavior
+that is incompatible.
+_Avoid_: Header override, custom middleware chain
+
+**Network exposure**:
+Transport-layer reachability that makes a workload port accessible beyond its
+private VM network. It does not imply public HTTP availability.
+_Avoid_: Publication

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ flowchart LR
 | [modules/](modules/) | System modules (`sys.*` options) — auto-loaded |
 | [home/](home/) | Home Manager modules (`hm.*` options) — auto-loaded |
 | [hosts/](hosts/) | Host configurations — auto-loaded per host |
-| [vms/](vms/) | MicroVM definitions (25 wired VM outputs) |
+| [vms/](vms/) | MicroVM definitions (26 wired VM outputs) |
 | [containers/](containers/) | Rootless Podman containers (Home Manager modules) |
 | [lib/](lib/) | Shared helpers (Traefik, Grafana, constants) |
 | [dashboards/](dashboards/) | Grafana dashboard JSON files |

--- a/docs/Project_Architecture_Blueprint.md
+++ b/docs/Project_Architecture_Blueprint.md
@@ -43,6 +43,7 @@ ______________________________________________________________________
 | `formatter.x86_64-linux` | treefmt wrapper (nixfmt, shfmt, yamlfmt, mdformat, jsonfmt, ruff) |
 | `checks.x86_64-linux.formatting` | treefmt formatting check |
 | `checks.x86_64-linux.cloudflare-metrics` | Cloudflare metrics Python unit tests |
+| `checks.x86_64-linux.microvm-publication` | Rendered publication contract and failure-case evaluation tests |
 | `devShells.x86_64-linux.default` | nil, nixfmt, deadnix, statix, sops, ssh-to-age |
 
 There are no `homeConfigurations`, `packages`, `apps`, or `templates` outputs.
@@ -382,6 +383,27 @@ flowchart TD
 Note: MicroVMs use `cloud-hypervisor` as the hypervisor. They do **not** use `system-loader.nix`
 and therefore do not inherit host-only modules.
 
+### Host-side lifecycle and public HTTP publication
+
+The physical host manages instances through
+`sys.virtualisation.microvm.instances.<name>`. Enabling an instance starts the
+VM but never publishes it. Standard public HTTP publication is a separate,
+instance-local intent containing one hostname label and one named compatibility
+policy.
+
+`modules/virtualisation/microvm-base.nix` combines that intent with the
+canonical public domain, the registry-owned VM IP and primary port, and the
+host's compatibility-policy mapping. It validates the complete publication,
+then renders Cloudflare Tunnel ingress and the matching Traefik router/service
+together. CrowdSec is mandatory, and the built-in strict security policy cannot
+be overridden.
+
+Raw port forwarding remains a separate transport concern. Host services and
+bespoke multi-host or path routes, including Matrix discovery, remain explicit
+in the host Cloudflare and Traefik configuration. See the canonical
+[publication diagram and configuration example](../vms/README.md#host-side-enablement)
+and [ADR 0001](adr/0001-model-public-http-publication-as-instance-intent.md).
+
 ### VM inventory
 
 | VM | IP | Port | RAM | vCPU | Notes |
@@ -472,7 +494,7 @@ ______________________________________________________________________
 | File | Exports | Purpose |
 |------|---------|---------|
 | `lib/constants.nix` | `{ tailscale.suffix = "mole-delta.ts.net"; }` | Loaded once as `consts` in `flake.nix`; shared strings across all modules |
-| `lib/traefik.nix` | `mkSecurityHeaders`, `mkRoutes`, `mkReverseProxyOptions`, `mkTraefikDynamicConfig`, `mkCfTunnelAssertion`, `defaultPermissionsPolicy`, `defaultCsp` | Generates Traefik router/middleware config and Cloudflare tunnel assertions |
+| `lib/traefik.nix` | `mkSecurityHeaders`, `mkRoutes`, `mkReverseProxyOptions`, `mkTraefikDynamicConfig`, `mkCfTunnelAssertion`, `defaultPermissionsPolicy`, `defaultCsp` | Generates shared headers and host-service or bespoke route config; standard MicroVM publication is rendered by `microvm-base.nix` |
 | `lib/grafana-dashboards.nix` | `fetchGrafanaDashboard`, `community.*`, `custom.*`, `all` | Fetches Grafana.com dashboards by ID; bundles community (node-exporter-full, kubernetes-cluster) and custom (arr-services, cloudflare-overview, zfs-overview, power-consumption, ups-monitoring, electricity-prices) sets |
 | `lib/grafana.nix` | `prometheusDatasource`, `mkRow`, `mkGauge`, `mkStat`, `mkTimeseries`, `mkBargauge`, `mkTarget`, `mkDashboard`, default field configs | Nix-native Grafana panel/dashboard builders |
 
@@ -561,16 +583,20 @@ ______________________________________________________________________
 | Task | Command |
 |------|---------|
 | Format all files | `nix fmt` |
-| Run all flake checks locally (formatting + Cloudflare metrics tests) | `nix flake check` |
+| Run all flake checks locally | `nix flake check` |
 | Check with trace on failure | `nix flake check --show-trace` |
 | Evaluate all flake outputs without building | `nix flake check --no-build` |
 | Run only the Cloudflare metrics tests | `nix build .#checks.x86_64-linux.cloudflare-metrics --no-link --print-build-logs` |
+| Run only the MicroVM publication tests | `nix build .#checks.x86_64-linux.microvm-publication --no-link --print-build-logs` |
 | Build without switching | `nix build .#nixosConfigurations.<host>.config.system.build.toplevel` |
 | Apply to current host | `sudo nixos-rebuild switch --flake .#<hostname>` |
 | Test without switching | `sudo nixos-rebuild test --flake .#<hostname>` |
 | Dry run (show what changes) | `nixos-rebuild dry-run --flake .#<hostname>` |
 
-The `flake-check.yml` CI workflow uses `nix flake check --no-build` for evaluation, then explicitly builds `checks.x86_64-linux.cloudflare-metrics` so the Python unit tests execute. Host evaluations run separately in `validate-config.yml`.
+The `flake-check.yml` CI workflow uses `nix flake check --no-build` for
+evaluation, then explicitly builds the Cloudflare metrics and MicroVM
+publication checks so their tests execute. Host evaluations run separately in
+`validate-config.yml`.
 
 Hosts: `snowfall`, `blizzard`, `avalanche`, `kaizer`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,12 +25,14 @@ flowchart LR
     subgraph Reference["Information-Oriented"]
         RA["Reference: Architecture\nreference-architecture.md"]
         RC["Reference: CI\nreference-ci.md"]
+        CTX["Infrastructure Context\n../CONTEXT.md"]
         CL["Credential Lifecycle\ncredential-lifecycle.md"]
         SA["Security Audit\nsecurity-audit-2026-06-27.md"]
         BP["Architecture Blueprint\nProject_Architecture_Blueprint.md"]
     end
     subgraph Understanding["Understanding-Oriented"]
         EX["Explanation: Design\nexplanation-design.md"]
+        ADR["Architecture Decisions\nadr/"]
     end
 ```
 
@@ -50,6 +52,8 @@ flowchart LR
 
 - [reference-architecture.md](reference-architecture.md) —
   Quick reference for options and patterns
+- [CONTEXT.md](../CONTEXT.md) —
+  Canonical infrastructure domain language
 - [reference-ci.md](reference-ci.md) —
   CI workflows, checks, and automation
 - [credential-lifecycle.md](credential-lifecycle.md) —
@@ -64,6 +68,7 @@ flowchart LR
 #### Explanation
 
 - [explanation-design.md](explanation-design.md) — Design decisions and rationale
+- [adr/0001-model-public-http-publication-as-instance-intent.md](adr/0001-model-public-http-publication-as-instance-intent.md) — Why standard public HTTP publication is modeled as instance intent
 - [architecture-risks-and-improvements.md](architecture-risks-and-improvements.md) — Known risks and improvement backlog
 - [security-audit-2026-06-01.md](security-audit-2026-06-01.md) — Security audit report (2026-06-01)
 
@@ -82,6 +87,8 @@ flowchart LR
 | Add a new user | [How-To: Add Hosts and Users](how-to-add-host-and-users.md) |
 | Understand the architecture | [Architecture Blueprint](Project_Architecture_Blueprint.md) |
 | Find option namespaces | [Reference: Architecture](reference-architecture.md) |
+| Use the canonical infrastructure language | [Infrastructure Context](../CONTEXT.md) |
+| Review architecture decisions | [Public HTTP Publication ADR](adr/0001-model-public-http-publication-as-instance-intent.md) |
 | Review credential lifecycle | [Credential Lifecycle](credential-lifecycle.md) |
 | Operate Pocket ID | [Pocket ID Operations](pocket-id.md) |
 | Operate Immich OAuth | [Immich OAuth Operations](immich.md) |

--- a/docs/adr/0001-model-public-http-publication-as-instance-intent.md
+++ b/docs/adr/0001-model-public-http-publication-as-instance-intent.md
@@ -1,0 +1,9 @@
+# Model public HTTP publication as instance intent
+
+Standard MicroVM public HTTP publication is an explicit, instance-local intent
+containing one hostname label and one validated compatibility policy. The host
+module derives the registry target and renders Cloudflare Tunnel and Traefik
+configuration together; raw port forwarding and bespoke routes remain separate.
+We chose this restrictive interface over provider-specific passthrough because
+it prevents partial publication, keeps security policy centralized, and makes
+the standard path deep enough to hide its two adapter implementations.

--- a/docs/adr/0001-model-public-http-publication-as-instance-intent.md
+++ b/docs/adr/0001-model-public-http-publication-as-instance-intent.md
@@ -7,3 +7,9 @@ configuration together; raw port forwarding and bespoke routes remain separate.
 We chose this restrictive interface over provider-specific passthrough because
 it prevents partial publication, keeps security policy centralized, and makes
 the standard path deep enough to hide its two adapter implementations.
+
+When a workload also needs a supplemental host or path route, that route must
+reuse the managed publication service and be gated by the publication intent.
+Matrix follows this pattern: `matrix.<domain>` is a standard publication, while
+the root-domain `/.well-known/matrix/` discovery route remains explicit and is
+present only while the Matrix publication is enabled.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -2,13 +2,13 @@
 
 The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
 
-| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| Label in mattpocock/skills | Label in our tracker | Meaning |
 | -------------------------- | -------------------- | ---------------------------------------- |
-| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
-| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
-| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
-| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
-| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+| `needs-triage` | `needs-triage` | Maintainer needs to evaluate this issue |
+| `needs-info` | `needs-info` | Waiting on reporter for more information |
+| `ready-for-agent` | `ready-for-agent` | Fully specified, ready for an AFK agent |
+| `ready-for-human` | `ready-for-human` | Requires human implementation |
+| `wontfix` | `wontfix` | Will not be actioned |
 
 When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
 

--- a/docs/architecture-risks-and-improvements.md
+++ b/docs/architecture-risks-and-improvements.md
@@ -1,11 +1,10 @@
 # Architecture Risks and Improvements
 
-> **Last reviewed: 2026-07-16**
+> **Last reviewed: 2026-07-25**
 
 This report captures documentation drift, operational risks, and future
 improvement opportunities discovered during a source-guided architecture
-review. It is intentionally documentation-only: no code, secrets, flake inputs,
-or workflow behavior were changed as part of this audit.
+review.
 
 ______________________________________________________________________
 
@@ -26,7 +25,6 @@ Most important follow-ups:
    strongly.
 1. Keep credential lifecycle guidance and private `VARS.users` validation
    aligned as the private schema evolves.
-1. Revisit default Traefik CSP compatibility trade-offs.
 
 ______________________________________________________________________
 
@@ -39,10 +37,14 @@ ______________________________________________________________________
 - System options live under `sys.*`; Home Manager options live under `hm.*`.
 - `modules/core/sops.nix` only declares service-specific secrets when their
   consumers are enabled, which avoids dangling SOPS requirements.
-- `modules/virtualisation/microvm-base.nix` already validates many host-side
-  exposure problems, including duplicate forwarded ports, duplicate Cloudflare
-  ingress hosts, missing VM flakes for enabled instances, and missing IPs for
-  port-forwarded instances.
+- `modules/virtualisation/microvm-base.nix` keeps VM lifecycle, transport-layer
+  forwarding, and public HTTP publication distinct. It rejects duplicate
+  forwarded ports and invalid or partial publications, including disabled or
+  unregistered targets, duplicate hostnames, unknown policies, and missing
+  Cloudflare or Traefik adapters.
+- Standard MicroVM publications render Cloudflare Tunnel and Traefik
+  configuration from one instance-local intent, with mandatory CrowdSec and a
+  closed set of route-scoped compatibility policies.
 - `vms/vm-registry.nix` validates allocation uniqueness, IPv4 prefixes and
   gateways, effective tap IDs, dedicated bridges, and subnet overlap whenever
   the registry is imported.
@@ -124,7 +126,7 @@ ______________________________________________________________________
 | Area | Risk | Current mitigation | Future improvement |
 |------|------|--------------------|--------------------|
 | Secret files | `.gitignore` excludes `nix-secrets/`, `vars/`, and `result`, but not `.env` variants | `security-audit.yml` runs secret scanning | Add `.env`, `.env.local`, `.env.*.local`, `*.key`, `*.pem`, and `*.crt` to `.gitignore` in a config cleanup pass |
-| Traefik CSP | `lib/traefik.nix` default CSP permits `'unsafe-inline'` and `'unsafe-eval'` | Central helper makes future changes straightforward | Move toward nonce/hash-based CSP where service compatibility allows |
+| Publication compatibility policies | Some applications cannot use the strict security-header baseline unchanged | Compatibility exceptions are named, route-scoped, centrally mapped, and still include CrowdSec | Keep exceptions narrow and remove policies when workloads become compatible with `strict` |
 | SOPS access | Missing host recipients cause activation/runtime failures for secret consumers | Private `nix-secrets` and CI deploy key keep secrets out of this repo | Keep `docs/sops-setup-guide.md` as the single source of truth for recipient setup |
 | Log redaction | `.github/scripts/redact-secrets.sh` handles common token/key patterns | CI failure output is filtered before summaries | Periodically expand patterns for new token formats and environment names |
 
@@ -158,8 +160,6 @@ These are intentionally not implemented in this documentation pass.
 1. Extend credential lifecycle checks if private `vars.nix` metadata becomes
    mandatory instead of advisory.
 1. Extend `.gitignore` for common local secret file patterns.
-1. Review Traefik CSP defaults and introduce stricter per-service policies
-   where compatible.
 1. Add a workflow or script check for host discovery and VM registry/output
    consistency.
 
@@ -179,7 +179,10 @@ ______________________________________________________________________
 - [`vms/prowlarr.nix`](../vms/prowlarr.nix)
 - [`vms/flaresolverr.nix`](../vms/flaresolverr.nix)
 - [`hosts/blizzard/virtualisation/microvms.nix`](../hosts/blizzard/virtualisation/microvms.nix)
+- [`hosts/blizzard/security/traefik.nix`](../hosts/blizzard/security/traefik.nix)
+- [`hosts/blizzard/services/cloudflared.nix`](../hosts/blizzard/services/cloudflared.nix)
 - [`lib/traefik.nix`](../lib/traefik.nix)
+- [`tests/microvm-publication.nix`](../tests/microvm-publication.nix)
 - [`treefmt.nix`](../treefmt.nix)
 - [`.github/workflows/flake-check.yml`](../.github/workflows/flake-check.yml)
 - [`.github/workflows/validate-config.yml`](../.github/workflows/validate-config.yml)

--- a/docs/reference-architecture.md
+++ b/docs/reference-architecture.md
@@ -15,6 +15,7 @@ Information reference for this repo's moving parts, options, and commands.
 | `formatter.x86_64-linux` | treefmt wrapper (`nix fmt`) |
 | `checks.x86_64-linux.formatting` | treefmt formatting check |
 | `checks.x86_64-linux.cloudflare-metrics` | Cloudflare metrics Python unit tests |
+| `checks.x86_64-linux.microvm-publication` | Rendered publication contract and failure-case evaluation tests |
 | `devShells.x86_64-linux.default` | Dev shell with nil, nixfmt, deadnix, statix, sops, ssh-to-age |
 
 ### `mkHost` — what it always injects
@@ -167,7 +168,11 @@ Operational tools used across the repo.
 | disko | Disk layout (included but not active) | `hosts/snowfall/disko.nix` (on hold) |
 | auto-upgrade | Monthly NixOS upgrades (server role only) | `modules/services/auto-upgrade.nix` |
 
-Locally, `nix flake check` evaluates and builds both the formatting check and the Cloudflare metrics test derivation. The `flake-check.yml` CI workflow first runs `nix flake check --no-build` to evaluate all flake outputs, then explicitly builds `checks.x86_64-linux.cloudflare-metrics` to run its Python unit tests. Full host evaluation is handled separately by the `validate-config.yml` CI workflow.
+Locally, `nix flake check` evaluates and builds the formatting, Cloudflare
+metrics, and MicroVM publication checks. The `flake-check.yml` CI workflow first
+runs `nix flake check --no-build` to evaluate all flake outputs, then explicitly
+builds both executable test checks. Full host evaluation is handled separately
+by the `validate-config.yml` CI workflow.
 
 ______________________________________________________________________
 
@@ -193,6 +198,35 @@ VMs do **not** use `system-loader.nix`. They are built with a minimal module set
 
 See [`vms/README.md`](../vms/README.md) for the full VM list and per-VM details.
 
+### Host-side instance lifecycle and publication
+
+[`modules/virtualisation/microvm-base.nix`](../modules/virtualisation/microvm-base.nix)
+owns host-side MicroVM lifecycle, raw port forwarding, and the standard public
+HTTP publication path.
+
+| Option | Purpose |
+|--------|---------|
+| `sys.virtualisation.microvm.instances.<name>.enable` | Start and manage the registered VM instance |
+| `sys.virtualisation.microvm.instances.<name>.portForward.ports` | Optional transport-layer forwarding, independent of publication |
+| `sys.virtualisation.microvm.instances.<name>.publication.enable` | Explicitly enable standard public HTTP publication |
+| `sys.virtualisation.microvm.instances.<name>.publication.hostname` | One DNS label under the canonical public domain |
+| `sys.virtualisation.microvm.instances.<name>.publication.policy` | Named compatibility policy; defaults to the built-in `strict` policy |
+| `sys.virtualisation.microvm.publication.canonicalDomain` | Domain suffix for standard publications |
+| `services.traefik.publicationPolicyMiddlewares` | Host-owned mapping from compatibility-policy names to Traefik middleware implementations |
+
+For each enabled publication, the module derives the backend from the VM
+registry and renders Cloudflare Tunnel ingress plus a matching Traefik router
+and service. CrowdSec is appended automatically. The built-in `strict` policy
+uses `security-headers` and cannot be redefined.
+
+Evaluation rejects publications with disabled instances, missing or malformed
+hostnames, unknown policies or registry targets, duplicate hostnames, an
+unset canonical domain, or disabled Cloudflare/Traefik adapters. Host routes,
+raw port forwarding, and bespoke multi-host or path routes such as Matrix stay
+outside this interface. See the
+[publication diagram](../vms/README.md#host-side-enablement) and
+[ADR 0001](adr/0001-model-public-http-publication-as-instance-intent.md).
+
 ______________________________________________________________________
 
 ## Podman Containers (quadlet-nix)
@@ -210,6 +244,9 @@ ______________________________________________________________________
 - `mkSecurityHeaders { ... }`: Generate Traefik middleware attrsets with customisable security response headers (X-Frame-Options, CSP, etc.). Pass `null` to any header to omit it.
 - `mkRoutes { domain; defaultMiddlewares? }`: Generate `{ routers; services; }` from a concise routing table mapping service names to subdomains and URLs.
 - `mkReverseProxyOptions`, `mkTraefikDynamicConfig`, `mkCfTunnelAssertion`: Per-service reverse proxy options used by `modules/services/*.nix`.
+
+These helpers support host services and bespoke routes. Standard public
+MicroVM routes use the publication interface described above.
 
 ______________________________________________________________________
 
@@ -237,7 +274,7 @@ nix build .#nixosConfigurations.<hostname>.config.system.build.toplevel
 # Format all files (nixfmt, shfmt, yamlfmt, mdformat, jsonfmt, ruff)
 nix fmt
 
-# Evaluate and build the formatting and Cloudflare metrics checks
+# Evaluate and build all checks
 nix flake check
 
 # Evaluate all flake outputs without building them (as CI does first)
@@ -245,6 +282,9 @@ nix flake check --no-build
 
 # Build and run only the Cloudflare metrics unit-test check
 nix build .#checks.x86_64-linux.cloudflare-metrics --no-link --print-build-logs
+
+# Build and run only the MicroVM publication contract check
+nix build .#checks.x86_64-linux.microvm-publication --no-link --print-build-logs
 
 # Dev shell (includes nil, nixfmt, deadnix, statix, sops, ssh-to-age)
 nix develop

--- a/docs/reference-ci.md
+++ b/docs/reference-ci.md
@@ -74,7 +74,7 @@ ______________________________________________________________________
 | Workflow | Trigger | Purpose | Auto-commits? |
 |----------|---------|---------|--------------|
 | `auto-format.yml` | PR / push to main / manual | Runs `nix fmt`, commits formatted changes back to the branch, comments on PR, enables auto-merge | Yes — formats in-place |
-| `flake-check.yml` | PR / push to main / manual (filtered to Nix/flake inputs and Cloudflare collector, test, and dashboard files) | Runs `nix flake check --no-build`, redacts secrets in failure output, and builds the `cloudflare-metrics` check to execute its Python tests | No |
+| `flake-check.yml` | PR / push to main / manual (filtered to its workflow file, Nix/flake inputs, and Cloudflare collector, test, and dashboard files) | Runs `nix flake check --no-build`, redacts secrets in failure output, and builds the `cloudflare-metrics` and `microvm-publication` checks to execute their tests | No |
 | `validate-config.yml` | PR / push to main / manual | Discovers hosts via `mkHost` grep, evaluates each host's `config.system.build.toplevel` with `nix eval` in a matrix, and evaluates the Home Manager users attrset | No |
 | `change-impact-analysis.yml` | PR | Diffs changed files under `hosts/`, `modules/`, `home/`, `vms/`, `lib/`, `flake.*`, posts impact report as a PR comment | No |
 | `compliance-check.yml` | PR / push / cron Mon 09:00 | Runs `deadnix` and other Nix linters, comments results | No |
@@ -132,7 +132,7 @@ These run on every pull request:
 | Workflow | What it checks |
 |----------|---------------|
 | `auto-format.yml` | Formats all files and commits back; if this commits, the PR diff is automatically clean |
-| `flake-check.yml` | Evaluates the flake for Nix errors and runs the Cloudflare metrics test check when Nix/flake inputs or the collector, tests, and dashboard contract change |
+| `flake-check.yml` | Evaluates the flake for Nix errors and runs the Cloudflare metrics and MicroVM publication checks when Nix/flake inputs or the collector, tests, and dashboard contract change |
 | `validate-config.yml` | Evaluates each host's `config.system.build.toplevel` with `nix eval` in a matrix (does not perform a full build) |
 | `change-impact-analysis.yml` | Posts a comment summarising which layer (hosts, modules, home, vms, lib, flake) is affected |
 | `compliance-check.yml` | Dead-code linting and other Nix hygiene checks |

--- a/flake.nix
+++ b/flake.nix
@@ -162,6 +162,12 @@
               python -m unittest discover -s tests/cloudflare_metrics -p 'test_*.py'
               touch $out
             '';
+
+        microvm-publication = import ./tests/microvm-publication.nix {
+          inherit self;
+          inherit (self.nixosConfigurations) blizzard;
+          pkgs = nixpkgs.legacyPackages.${system};
+        };
       };
 
       devShells.${system}.default = nixpkgs.legacyPackages.${system}.mkShell {

--- a/hosts/blizzard/security/traefik.nix
+++ b/hosts/blizzard/security/traefik.nix
@@ -7,9 +7,7 @@
   ...
 }:
 let
-  reg = import ../../../vms/vm-registry.nix;
   traefikLib = import ../../../lib/traefik.nix { inherit lib; };
-  vmUrl = name: "http://${reg.${name}.ip}:${toString reg.${name}.port}";
   vmInstances = config.sys.virtualisation.microvm.instances;
   hostRoutes = {
     lingarr = {
@@ -26,7 +24,9 @@ let
     };
   };
   generated = traefikLib.mkRoutes { domain = VARS.domains.public; } hostRoutes;
-  matrixSynapseEnabled = vmInstances."matrix-synapse".enable or false;
+  matrixSynapsePublished =
+    (vmInstances."matrix-synapse".enable or false)
+    && (vmInstances."matrix-synapse".publication.enable or false);
 
   trustedIPs = [
     "127.0.0.1/32"
@@ -55,6 +55,7 @@ in
     firefly-proxy = [ "firefly-headers" ];
     immich-web = [ "immich-headers" ];
     legacy-app-shell = [ "app-compat-headers" ];
+    matrix-compatible = [ "matrix-headers" ];
     oidc-provider = [ "pocket-id-headers" ];
     plex-compatible = [ "plex-headers" ];
     sabnzbd-ui = [ "sabnzbd-headers" ];
@@ -237,27 +238,19 @@ in
               middlewares = [ "security-headers" ];
             };
           }
-          // lib.optionalAttrs matrixSynapseEnabled {
-            matrix-synapse = {
-              rule = "Host(`matrix.${VARS.domains.public}`)";
-              service = "matrix-synapse";
-              entryPoints = [ "web" ];
-              middlewares = [ "matrix-headers" ];
-            };
-
+          // lib.optionalAttrs matrixSynapsePublished {
             matrix-well-known = {
               rule = "Host(`${VARS.domains.public}`) && PathPrefix(`/.well-known/matrix/`)";
               service = "matrix-synapse";
               entryPoints = [ "web" ];
-              middlewares = [ "matrix-headers" ];
+              middlewares = [
+                "matrix-headers"
+                "crowdsec"
+              ];
             };
           };
 
-        services =
-          generated.services
-          // lib.optionalAttrs matrixSynapseEnabled {
-            matrix-synapse.loadBalancer.servers = [ { url = vmUrl "matrix-synapse"; } ];
-          };
+        services = generated.services;
       };
     };
   };

--- a/hosts/blizzard/security/traefik.nix
+++ b/hosts/blizzard/security/traefik.nix
@@ -11,22 +11,6 @@ let
   traefikLib = import ../../../lib/traefik.nix { inherit lib; };
   vmUrl = name: "http://${reg.${name}.ip}:${toString reg.${name}.port}";
   vmInstances = config.sys.virtualisation.microvm.instances;
-  enabledVmReverseProxies = lib.filterAttrs (
-    _: instance: instance.enable && instance.reverseProxy.enable
-  ) vmInstances;
-  generatedVmRoutes = builtins.mapAttrs (
-    _: instance:
-    {
-      inherit (instance.reverseProxy)
-        subdomain
-        url
-        entryPoints
-        ;
-    }
-    // lib.optionalAttrs (instance.reverseProxy.middlewares != null) {
-      inherit (instance.reverseProxy) middlewares;
-    }
-  ) enabledVmReverseProxies;
   hostRoutes = {
     lingarr = {
       subdomain = "lingarr";
@@ -41,7 +25,7 @@ let
       url = "http://127.0.0.1:11080";
     };
   };
-  generated = traefikLib.mkRoutes { domain = VARS.domains.public; } (generatedVmRoutes // hostRoutes);
+  generated = traefikLib.mkRoutes { domain = VARS.domains.public; } hostRoutes;
   matrixSynapseEnabled = vmInstances."matrix-synapse".enable or false;
 
   trustedIPs = [
@@ -64,6 +48,22 @@ let
   plexCsp = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://plex.tv https://*.plex.tv https://*.plex.direct wss://*.plex.direct; frame-src https://app.plex.tv;";
 in
 {
+  services.traefik.publicationPolicyMiddlewares = {
+    browser-in-browser = [ "firefox-headers" ];
+    csrf-compatible = [ "csrf-safe-headers" ];
+    dynamic-app-shell = [ "trigger-headers" ];
+    firefly-proxy = [ "firefly-headers" ];
+    immich-web = [ "immich-headers" ];
+    legacy-app-shell = [ "app-compat-headers" ];
+    oidc-provider = [ "pocket-id-headers" ];
+    plex-compatible = [ "plex-headers" ];
+    sabnzbd-ui = [ "sabnzbd-headers" ];
+    strict-forwarded-https = [
+      "security-headers"
+      "gitea-xfp-https"
+    ];
+  };
+
   # Trust model: Traefik ↔ VM communication uses plain HTTP over an isolated
   # bridge network (10.100.0.0/24) that is not routable from external networks.
   services.traefik = {

--- a/hosts/blizzard/services/cloudflared.nix
+++ b/hosts/blizzard/services/cloudflared.nix
@@ -6,13 +6,15 @@
     tunnelId = "ce54cb73-83b2-4628-8246-26955d280641";
     credentialsFile = config.sys.secrets.cloudflaredCredentialsFile;
 
-    # VM-specific tunnel routes are declared per-VM via cfTunnel in microvms.nix.
-    # Only host-level services that are not managed by a MicroVM belong here.
+    # Standard MicroVM publications are rendered from microvms.nix. Only
+    # host-level services and bespoke routes such as Matrix belong here.
     ingress = {
       "dashboard.${VARS.domains.public}" = "http://localhost:80";
       "metrics.${VARS.domains.public}" = "http://localhost:80";
       "lingarr.${VARS.domains.public}" = "http://localhost:80";
       "nominatim.${VARS.domains.public}" = "http://localhost:80";
+      "matrix.${VARS.domains.public}" = "http://localhost:80";
+      "${VARS.domains.public}" = "http://localhost:80";
     };
   };
 }

--- a/hosts/blizzard/services/cloudflared.nix
+++ b/hosts/blizzard/services/cloudflared.nix
@@ -7,13 +7,14 @@
     credentialsFile = config.sys.secrets.cloudflaredCredentialsFile;
 
     # Standard MicroVM publications are rendered from microvms.nix. Only
-    # host-level services and bespoke routes such as Matrix belong here.
+    # host-level services and ingress needed by bespoke path routes belong here.
     ingress = {
       "dashboard.${VARS.domains.public}" = "http://localhost:80";
       "metrics.${VARS.domains.public}" = "http://localhost:80";
       "lingarr.${VARS.domains.public}" = "http://localhost:80";
       "nominatim.${VARS.domains.public}" = "http://localhost:80";
-      "matrix.${VARS.domains.public}" = "http://localhost:80";
+      # Matrix's root-domain discovery route shares this host-level ingress.
+      # The matrix.<domain> workload route is a managed MicroVM publication.
       "${VARS.domains.public}" = "http://localhost:80";
     };
   };

--- a/hosts/blizzard/virtualisation/microvms.nix
+++ b/hosts/blizzard/virtualisation/microvms.nix
@@ -8,19 +8,7 @@
 }:
 let
   reg = import ../../../vms/vm-registry.nix;
-  vmUrl = name: "http://${reg.${name}.ip}:${toString reg.${name}.port}";
   immichMlProxyPort = 3003;
-
-  localhostUrl = "http://localhost:80";
-
-  mkPublicIngress =
-    subdomains:
-    builtins.listToAttrs (
-      map (subdomain: {
-        name = "${subdomain}.${VARS.domains.public}";
-        value = localhostUrl;
-      }) subdomains
-    );
 
   mkPortForward =
     proto: sourcePort: destPort:
@@ -41,8 +29,7 @@ let
     // {
       vmConfig = spec.vmConfig or { };
       portForward.ports = spec.portForwards or [ ];
-      cfTunnel.ingress = mkPublicIngress (spec.ingressHosts or [ ]) // (spec.extraIngress or { });
-      reverseProxy = spec.reverseProxy or { };
+      publication = spec.publication or { };
     };
 
   vmSpecs = {
@@ -54,144 +41,105 @@ let
         (mkPortForward "tcp" 853 null)
         (mkPortForward "tcp" 11010 null)
       ];
-      ingressHosts = [ "adguard" ];
+      publication.hostname = "adguard";
     };
 
     actual = {
       enable = false;
-      ingressHosts = [ "actual" ];
-      reverseProxy = {
-        subdomain = "actual";
-        url = vmUrl "actual";
-      };
+      publication.hostname = "actual";
     };
 
     searx = {
       enable = true;
-      ingressHosts = [ "search" ];
-      reverseProxy = {
-        subdomain = "search";
-        url = vmUrl "searx";
+      publication = {
+        enable = true;
+        hostname = "search";
       };
     };
 
     overseerr = {
       enable = true;
-      ingressHosts = [ "requests" ];
-      reverseProxy = {
-        subdomain = "requests";
-        url = vmUrl "overseerr";
-        middlewares = [
-          "plex-headers"
-          "crowdsec"
-        ];
+      publication = {
+        enable = true;
+        hostname = "requests";
+        policy = "plex-compatible";
       };
     };
 
     ombi = {
       enable = false;
-      ingressHosts = [ "ombi" ];
-      reverseProxy = {
-        subdomain = "ombi";
-        url = vmUrl "ombi";
-      };
+      publication.hostname = "ombi";
     };
 
     tautulli = {
       enable = true;
-      ingressHosts = [ "tautulli" ];
-      reverseProxy = {
-        subdomain = "tautulli";
-        url = vmUrl "tautulli";
-        middlewares = [
-          "plex-headers"
-          "crowdsec"
-        ];
+      publication = {
+        enable = true;
+        hostname = "tautulli";
+        policy = "plex-compatible";
       };
     };
 
     gitea = {
       enable = true;
-      ingressHosts = [ "git" ];
-      reverseProxy = {
-        subdomain = "git";
-        url = vmUrl "gitea";
-        middlewares = [
-          "security-headers"
-          "gitea-xfp-https"
-          "crowdsec"
-        ];
+      publication = {
+        enable = true;
+        hostname = "git";
+        policy = "strict-forwarded-https";
       };
     };
 
     sonarr = {
       enable = true;
-      ingressHosts = [ "series" ];
-      reverseProxy = {
-        subdomain = "series";
-        url = vmUrl "sonarr";
-        middlewares = [
-          "app-compat-headers"
-          "crowdsec"
-        ];
+      publication = {
+        enable = true;
+        hostname = "series";
+        policy = "legacy-app-shell";
       };
     };
 
     radarr = {
       enable = true;
-      ingressHosts = [ "movies" ];
-      reverseProxy = {
-        subdomain = "movies";
-        url = vmUrl "radarr";
-        middlewares = [
-          "app-compat-headers"
-          "crowdsec"
-        ];
+      publication = {
+        enable = true;
+        hostname = "movies";
+        policy = "legacy-app-shell";
       };
     };
 
     prowlarr = {
       enable = true;
-      ingressHosts = [ "indexer" ];
-      reverseProxy = {
-        subdomain = "indexer";
-        url = vmUrl "prowlarr";
-        middlewares = [
-          "app-compat-headers"
-          "crowdsec"
-        ];
+      publication = {
+        enable = true;
+        hostname = "indexer";
+        policy = "legacy-app-shell";
       };
     };
 
     bazarr = {
       enable = true;
-      ingressHosts = [ "subs" ];
-      reverseProxy = {
-        subdomain = "subs";
-        url = vmUrl "bazarr";
-        middlewares = [
-          "app-compat-headers"
-          "crowdsec"
-        ];
+      publication = {
+        enable = true;
+        hostname = "subs";
+        policy = "legacy-app-shell";
       };
     };
 
     readarr = {
       enable = true;
-      ingressHosts = [ "books" ];
-      reverseProxy = {
-        subdomain = "books";
-        url = vmUrl "readarr";
-        middlewares = [
-          "app-compat-headers"
-          "crowdsec"
-        ];
+      publication = {
+        enable = true;
+        hostname = "books";
+        policy = "legacy-app-shell";
       };
     };
 
     lidarr = {
       enable = false;
-      ingressHosts = [ "music" ];
+      publication = {
+        hostname = "music";
+        policy = "legacy-app-shell";
+      };
     };
 
     qbittorrent = {
@@ -202,14 +150,10 @@ let
     sabnzbd = {
       enable = true;
       portForwards = [ (mkPortForward "tcp" 11031 null) ];
-      ingressHosts = [ "sab" ];
-      reverseProxy = {
-        subdomain = "sab";
-        url = vmUrl "sabnzbd";
-        middlewares = [
-          "sabnzbd-headers"
-          "crowdsec"
-        ];
+      publication = {
+        enable = true;
+        hostname = "sab";
+        policy = "sabnzbd-ui";
       };
     };
 
@@ -224,14 +168,10 @@ let
         (mkPortForward "tcp" 11052 null)
         (mkPortForward "tcp" 11053 null)
       ];
-      ingressHosts = [ "ff" ];
-      reverseProxy = {
-        subdomain = "ff";
-        url = vmUrl "firefox";
-        middlewares = [
-          "firefox-headers"
-          "crowdsec"
-        ];
+      publication = {
+        enable = true;
+        hostname = "ff";
+        policy = "browser-in-browser";
       };
     };
 
@@ -241,62 +181,41 @@ let
         (mkPortForward "tcp" 11054 null)
         (mkPortForward "tcp" 11055 null)
       ];
-      ingressHosts = [ "brave" ];
+      publication = {
+        hostname = "brave";
+        policy = "browser-in-browser";
+      };
     };
 
     matrix-synapse = {
       enable = true;
       portForwards = [ (mkPortForward "tcp" 11060 null) ];
-      ingressHosts = [ "matrix" ];
-      extraIngress = {
-        "${VARS.domains.public}" = localhostUrl;
-      };
-      reverseProxy = {
-        enable = false;
-        subdomain = "matrix";
-        url = vmUrl "matrix-synapse";
-      };
     };
 
     paperless = {
       enable = false;
       portForwards = [ (mkPortForward "tcp" 11061 null) ];
-      ingressHosts = [ "docs" ];
-      reverseProxy = {
-        subdomain = "docs";
-        url = vmUrl "paperless";
-        middlewares = [
-          "csrf-safe-headers"
-          "crowdsec"
-        ];
+      publication = {
+        hostname = "docs";
+        policy = "csrf-compatible";
       };
     };
 
     firefly = {
       enable = false;
       portForwards = [ (mkPortForward "tcp" 11062 null) ];
-      ingressHosts = [ "finance" ];
-      reverseProxy = {
-        subdomain = "finance";
-        url = vmUrl "firefly";
-        middlewares = [
-          "firefly-headers"
-          "crowdsec"
-        ];
+      publication = {
+        hostname = "finance";
+        policy = "firefly-proxy";
       };
     };
 
     "firefly-importer" = {
       enable = false;
       portForwards = [ (mkPortForward "tcp" 11063 null) ];
-      ingressHosts = [ "finimport" ];
-      reverseProxy = {
-        subdomain = "finimport";
-        url = vmUrl "firefly-importer";
-        middlewares = [
-          "firefly-headers"
-          "crowdsec"
-        ];
+      publication = {
+        hostname = "finimport";
+        policy = "firefly-proxy";
       };
     };
 
@@ -305,56 +224,34 @@ let
       # Keep the VM port off the host while publishing it through the managed
       # Cloudflare Tunnel and Traefik route.
       portForwards = [ ];
-      ingressHosts = [ "photos" ];
-      reverseProxy = {
+      publication = {
         enable = true;
-        subdomain = "photos";
-        url = vmUrl "immich";
-        middlewares = [
-          "immich-headers"
-          "crowdsec"
-        ];
+        hostname = "photos";
+        policy = "immich-web";
       };
     };
 
     mealie = {
       enable = false;
       portForwards = [ (mkPortForward "tcp" 11071 null) ];
-      ingressHosts = [ "recipes" ];
-      reverseProxy = {
-        subdomain = "recipes";
-        url = vmUrl "mealie";
-        middlewares = [
-          "security-headers"
-          "crowdsec"
-        ];
-      };
+      publication.hostname = "recipes";
     };
 
     trigger = {
       enable = false;
-      ingressHosts = [ "triggers" ];
-      reverseProxy = {
-        subdomain = "triggers";
-        url = vmUrl "trigger";
-        middlewares = [
-          "trigger-headers"
-          "crowdsec"
-        ];
+      publication = {
+        hostname = "triggers";
+        policy = "dynamic-app-shell";
       };
     };
 
     "pocket-id" = {
       enable = true;
       vmConfig.restartIfChanged = true;
-      ingressHosts = [ "id" ];
-      reverseProxy = {
-        subdomain = "id";
-        url = vmUrl "pocket-id";
-        middlewares = [
-          "pocket-id-headers"
-          "crowdsec"
-        ];
+      publication = {
+        enable = true;
+        hostname = "id";
+        policy = "oidc-provider";
       };
     };
   };
@@ -392,6 +289,7 @@ in
 
       externalInterface = "enp8s0";
       stateDir = "/flash/enc/vms";
+      publication.canonicalDomain = VARS.domains.public;
 
       instances = builtins.mapAttrs mkInstance vmSpecs;
     };

--- a/hosts/blizzard/virtualisation/microvms.nix
+++ b/hosts/blizzard/virtualisation/microvms.nix
@@ -190,6 +190,11 @@ let
     matrix-synapse = {
       enable = true;
       portForwards = [ (mkPortForward "tcp" 11060 null) ];
+      publication = {
+        enable = true;
+        hostname = "matrix";
+        policy = "matrix-compatible";
+      };
     };
 
     paperless = {

--- a/lib/README.md
+++ b/lib/README.md
@@ -45,6 +45,11 @@ set of options (domain, pathPrefix, cfTunnel, etc.) and the same Traefik
 router/service config block. These helpers generate both from a single
 descriptor.
 
+These helpers remain appropriate for host services and bespoke routes.
+Standard public MicroVM routes use the provider-neutral publication interface
+in `modules/virtualisation/microvm-base.nix`; see
+[vms/README.md](../vms/README.md#host-side-enablement).
+
 **Usage pattern — adding reverse-proxy options to a service module:**
 
 ```nix

--- a/modules/services/traefik.nix
+++ b/modules/services/traefik.nix
@@ -38,6 +38,12 @@ in
         default = { };
       };
     };
+
+    publicationPolicyMiddlewares = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.listOf lib.types.str);
+      default = { };
+      description = "Traefik middleware implementations for public HTTP compatibility policies.";
+    };
   };
 
   options.sys.services.traefik = {

--- a/modules/virtualisation/microvm-base.nix
+++ b/modules/virtualisation/microvm-base.nix
@@ -169,12 +169,8 @@ let
     ) (builtins.attrValues requestedPublications)
     ++ lib.optional (requestedPublicationNames != [ ]) "crowdsec"
   );
-  availableTraefikMiddlewares = lib.unique (
-    lib.flatten (
-      lib.mapAttrsToList (
-        _: file: builtins.attrNames (file.settings.http.middlewares or { })
-      ) config.services.traefik.dynamic.files
-    )
+  availableTraefikMiddlewares = builtins.attrNames (
+    config.services.traefik.dynamic.files.core.settings.http.middlewares or { }
   );
   publicationMissingMiddlewares = lib.filter (
     middleware: !(lib.elem middleware availableTraefikMiddlewares)
@@ -498,7 +494,7 @@ in
       }
       {
         assertion = publicationMissingMiddlewares == [ ];
-        message = "sys.virtualisation.microvm.instances selects publication middleware that is not defined in services.traefik.dynamic.files: ${formatList publicationMissingMiddlewares}";
+        message = "sys.virtualisation.microvm.instances selects publication middleware that is not defined in services.traefik.dynamic.files.core: ${formatList publicationMissingMiddlewares}";
       }
       {
         assertion = !strictPolicyOverridden;

--- a/modules/virtualisation/microvm-base.nix
+++ b/modules/virtualisation/microvm-base.nix
@@ -46,7 +46,10 @@ let
       policy = lib.mkOption {
         type = lib.types.str;
         default = "strict";
-        description = "Publication compatibility policy.";
+        description = ''
+          Registered publication compatibility policy whose middleware
+          references must exist.
+        '';
       };
     };
   };
@@ -54,6 +57,19 @@ let
   instanceModule =
     { name, config, ... }:
     {
+      imports = [
+        (lib.mkRemovedOptionModule [ "cfTunnel" ] ''
+          Use publication for managed public HTTP routes, or define a bespoke
+          host-level Cloudflare Tunnel ingress when the standard publication
+          contract is not sufficient.
+        '')
+        (lib.mkRemovedOptionModule [ "reverseProxy" ] ''
+          Use publication for managed public HTTP routes, or define a bespoke
+          host-level Traefik route when the standard publication contract is
+          not sufficient.
+        '')
+      ];
+
       options = {
         enable = lib.mkEnableOption "MicroVM instance ${name}";
 
@@ -115,6 +131,20 @@ let
   strictPolicyOverridden = builtins.hasAttr "strict" config.services.traefik.publicationPolicyMiddlewares;
   requestedPublications = lib.filterAttrs (_: instance: instance.publication.enable) cfg.instances;
   requestedPublicationNames = builtins.attrNames requestedPublications;
+  canonicalDomainLabels =
+    if cfg.publication.canonicalDomain == null then
+      [ ]
+    else
+      lib.splitString "." cfg.publication.canonicalDomain;
+  canonicalDomainValid =
+    cfg.publication.canonicalDomain == null
+    || (
+      builtins.stringLength cfg.publication.canonicalDomain <= 253
+      && builtins.length canonicalDomainLabels >= 2
+      && lib.all (
+        label: builtins.match "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$" label != null
+      ) canonicalDomainLabels
+    );
   publicationMissingHostnames = builtins.attrNames (
     lib.filterAttrs (_: instance: instance.publication.hostname == null) requestedPublications
   );
@@ -130,6 +160,25 @@ let
       _: instance: !(builtins.hasAttr instance.publication.policy publicationPolicies)
     ) requestedPublications
   );
+  requestedPublicationMiddlewares = lib.unique (
+    lib.concatMap (
+      instance:
+      lib.optionals (builtins.hasAttr instance.publication.policy publicationPolicies) (
+        publicationPolicies.${instance.publication.policy}
+      )
+    ) (builtins.attrValues requestedPublications)
+    ++ lib.optional (requestedPublicationNames != [ ]) "crowdsec"
+  );
+  availableTraefikMiddlewares = lib.unique (
+    lib.flatten (
+      lib.mapAttrsToList (
+        _: file: builtins.attrNames (file.settings.http.middlewares or { })
+      ) config.services.traefik.dynamic.files
+    )
+  );
+  publicationMissingMiddlewares = lib.filter (
+    middleware: !(lib.elem middleware availableTraefikMiddlewares)
+  ) requestedPublicationMiddlewares;
   publicationUnknownTargets = lib.filter (
     name: !(builtins.hasAttr name registry)
   ) requestedPublicationNames;
@@ -343,6 +392,23 @@ let
   formatList = list: lib.concatStringsSep ", " list;
 in
 {
+  imports = [
+    (lib.mkRemovedOptionModule [ "sys" "virtualisation" "microvm" "hypervisor" ] ''
+      The host-wide hypervisor option was not applied to generated instances.
+      Configure the hypervisor in each guest configuration when required.
+    '')
+    (lib.mkRemovedOptionModule [ "sys" "virtualisation" "microvm" "autostart" ] ''
+      Use sys.virtualisation.microvm.instances.<name>.autostart instead.
+    '')
+    (lib.mkRemovedOptionModule [ "sys" "virtualisation" "microvm" "vms" ] ''
+      Use sys.virtualisation.microvm.instances.<name>.flake and vmConfig instead.
+    '')
+    (lib.mkRemovedOptionModule [ "sys" "virtualisation" "microvm" "expose" ] ''
+      Use sys.virtualisation.microvm.instances.<name>.portForward and
+      sys.virtualisation.microvm.instances.<name>.publication instead.
+    '')
+  ];
+
   options.sys.virtualisation.microvm = {
     enable = lib.mkEnableOption "microvm.nix host for running lightweight VMs";
 
@@ -360,7 +426,7 @@ in
       canonicalDomain = lib.mkOption {
         type = lib.types.nullOr lib.types.str;
         default = null;
-        description = "Canonical domain used by public HTTP publications.";
+        description = "Lowercase DNS domain used by public HTTP publications.";
       };
 
     };
@@ -415,6 +481,10 @@ in
         message = "sys.virtualisation.microvm.publication.canonicalDomain must be set when publications are enabled";
       }
       {
+        assertion = canonicalDomainValid;
+        message = "sys.virtualisation.microvm.publication.canonicalDomain must be a lowercase DNS domain with at least two valid labels";
+      }
+      {
         assertion = publicationMissingHostnames == [ ];
         message = "sys.virtualisation.microvm.instances enables publication without a hostname for: ${formatList publicationMissingHostnames}";
       }
@@ -425,6 +495,10 @@ in
       {
         assertion = publicationUnknownPolicies == [ ];
         message = "sys.virtualisation.microvm.instances selects unknown publication policies for: ${formatList publicationUnknownPolicies}";
+      }
+      {
+        assertion = publicationMissingMiddlewares == [ ];
+        message = "sys.virtualisation.microvm.instances selects publication middleware that is not defined in services.traefik.dynamic.files: ${formatList publicationMissingMiddlewares}";
       }
       {
         assertion = !strictPolicyOverridden;

--- a/modules/virtualisation/microvm-base.nix
+++ b/modules/virtualisation/microvm-base.nix
@@ -57,19 +57,6 @@ let
   instanceModule =
     { name, config, ... }:
     {
-      imports = [
-        (lib.mkRemovedOptionModule [ "cfTunnel" ] ''
-          Use publication for managed public HTTP routes, or define a bespoke
-          host-level Cloudflare Tunnel ingress when the standard publication
-          contract is not sufficient.
-        '')
-        (lib.mkRemovedOptionModule [ "reverseProxy" ] ''
-          Use publication for managed public HTTP routes, or define a bespoke
-          host-level Traefik route when the standard publication contract is
-          not sufficient.
-        '')
-      ];
-
       options = {
         enable = lib.mkEnableOption "MicroVM instance ${name}";
 
@@ -115,6 +102,20 @@ let
           type = lib.types.submodule publicationModule;
           default = { };
           description = "Public HTTP publication for this VM.";
+        };
+
+        cfTunnel = lib.mkOption {
+          type = lib.types.nullOr lib.types.attrs;
+          default = null;
+          visible = false;
+          description = "Removed legacy Cloudflare Tunnel configuration.";
+        };
+
+        reverseProxy = lib.mkOption {
+          type = lib.types.nullOr lib.types.attrs;
+          default = null;
+          visible = false;
+          description = "Removed legacy Traefik reverse proxy configuration.";
         };
       };
 
@@ -192,6 +193,12 @@ let
   duplicatePublicationHostnames = duplicateValues publicationHostnames;
   publicationDisabledTargets = builtins.attrNames (
     lib.filterAttrs (_: instance: instance.publication.enable && !instance.enable) cfg.instances
+  );
+  instancesUsingRemovedCfTunnel = builtins.attrNames (
+    lib.filterAttrs (_: instance: instance.cfTunnel != null) cfg.instances
+  );
+  instancesUsingRemovedReverseProxy = builtins.attrNames (
+    lib.filterAttrs (_: instance: instance.reverseProxy != null) cfg.instances
   );
 
   publicationIngress = builtins.listToAttrs (
@@ -515,6 +522,14 @@ in
       {
         assertion = duplicatePublicationHostnames == [ ];
         message = "sys.virtualisation.microvm.instances defines duplicate publication hostnames: ${formatList duplicatePublicationHostnames}";
+      }
+      {
+        assertion = instancesUsingRemovedCfTunnel == [ ];
+        message = "sys.virtualisation.microvm.instances uses the removed cfTunnel option for: ${formatList instancesUsingRemovedCfTunnel}. Use publication or a bespoke host-level Cloudflare Tunnel ingress instead";
+      }
+      {
+        assertion = instancesUsingRemovedReverseProxy == [ ];
+        message = "sys.virtualisation.microvm.instances uses the removed reverseProxy option for: ${formatList instancesUsingRemovedReverseProxy}. Use publication or a bespoke host-level Traefik route instead";
       }
     ];
 

--- a/modules/virtualisation/microvm-base.nix
+++ b/modules/virtualisation/microvm-base.nix
@@ -170,8 +170,12 @@ let
     ) (builtins.attrValues requestedPublications)
     ++ lib.optional (requestedPublicationNames != [ ]) "crowdsec"
   );
-  availableTraefikMiddlewares = builtins.attrNames (
-    config.services.traefik.dynamic.files.core.settings.http.middlewares or { }
+  availableTraefikMiddlewares = lib.unique (
+    lib.flatten (
+      lib.mapAttrsToList (
+        _: file: builtins.attrNames (file.settings.http.middlewares or { })
+      ) config.services.traefik.dynamic.files
+    )
   );
   publicationMissingMiddlewares = lib.filter (
     middleware: !(lib.elem middleware availableTraefikMiddlewares)
@@ -501,7 +505,7 @@ in
       }
       {
         assertion = publicationMissingMiddlewares == [ ];
-        message = "sys.virtualisation.microvm.instances selects publication middleware that is not defined in services.traefik.dynamic.files.core: ${formatList publicationMissingMiddlewares}";
+        message = "sys.virtualisation.microvm.instances selects publication middleware that is not defined in services.traefik.dynamic.files: ${formatList publicationMissingMiddlewares}";
       }
       {
         assertion = !strictPolicyOverridden;

--- a/modules/virtualisation/microvm-base.nix
+++ b/modules/virtualisation/microvm-base.nix
@@ -33,97 +33,23 @@ let
     };
   };
 
-  # VM exposure submodule (for cfTunnel and portForward per-VM)
-  vmExposeModule = lib.types.submodule {
+  publicationModule = {
     options = {
-      ip = lib.mkOption {
+      enable = lib.mkEnableOption "public HTTP publication";
+
+      hostname = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "Hostname label under the canonical public domain.";
+      };
+
+      policy = lib.mkOption {
         type = lib.types.str;
-        description = "IP address of the VM on the microvm bridge (e.g., 10.100.0.10).";
-      };
-
-      portForward = {
-        enable = lib.mkOption {
-          type = lib.types.bool;
-          default = false;
-          description = "Enable port forwarding from host to this VM.";
-        };
-        ports = lib.mkOption {
-          type = lib.types.listOf portForwardModule;
-          default = [ ];
-          description = "List of ports to forward from host to VM.";
-          example = [
-            {
-              proto = "both";
-              sourcePort = 53;
-            }
-            {
-              proto = "tcp";
-              sourcePort = 3000;
-            }
-          ];
-        };
-      };
-
-      cfTunnel = {
-        enable = lib.mkOption {
-          type = lib.types.bool;
-          default = false;
-          description = ''
-            
-                        Enable Cloudflare Tunnel ingress for this VM's services.
-                        Requires sys.services.cloudflared to be configured on the host.
-          '';
-        };
-        ingress = lib.mkOption {
-          type = lib.types.attrsOf lib.types.str;
-          default = { };
-          description = "Cloudflare Tunnel ingress rules for this VM.";
-          example = {
-            "adguard.example.com" = "http://10.100.0.10:80";
-            "dns.example.com" = "tcp://10.100.0.10:53";
-          };
-        };
+        default = "strict";
+        description = "Publication compatibility policy.";
       };
     };
   };
-
-  reverseProxyModule =
-    { config, ... }:
-    {
-      options = {
-        enable = lib.mkOption {
-          type = lib.types.bool;
-          default = false;
-          description = "Enable Traefik reverse proxy configuration for this VM.";
-        };
-
-        subdomain = lib.mkOption {
-          type = lib.types.nullOr lib.types.str;
-          default = null;
-          description = "Subdomain used for standard hostname-based routing.";
-        };
-
-        url = lib.mkOption {
-          type = lib.types.nullOr lib.types.str;
-          default = null;
-          description = "Backend URL for the reverse proxy target.";
-        };
-
-        middlewares = lib.mkOption {
-          type = lib.types.nullOr (lib.types.listOf lib.types.str);
-          default = null;
-          description = "Traefik middlewares applied to the generated router.";
-        };
-
-        entryPoints = lib.mkOption {
-          type = lib.types.listOf lib.types.str;
-          default = [ "web" ];
-          description = "Traefik entry points applied to the generated router.";
-        };
-      };
-
-      config.enable = lib.mkDefault (config.subdomain != null && config.url != null);
-    };
 
   instanceModule =
     { name, config, ... }:
@@ -169,35 +95,79 @@ let
           };
         };
 
-        cfTunnel = {
-          enable = lib.mkOption {
-            type = lib.types.bool;
-            default = false;
-            description = "Enable Cloudflare Tunnel ingress for this VM.";
-          };
-
-          ingress = lib.mkOption {
-            type = lib.types.attrsOf lib.types.str;
-            default = { };
-            description = "Cloudflare Tunnel ingress rules for this VM.";
-          };
-        };
-
-        reverseProxy = lib.mkOption {
-          type = lib.types.submodule reverseProxyModule;
+        publication = lib.mkOption {
+          type = lib.types.submodule publicationModule;
           default = { };
-          description = "Traefik reverse proxy configuration for this VM.";
+          description = "Public HTTP publication for this VM.";
         };
       };
 
       config = {
         autostart = lib.mkDefault config.enable;
         portForward.enable = lib.mkDefault (config.enable && config.portForward.ports != [ ]);
-        cfTunnel.enable = lib.mkDefault (config.enable && config.cfTunnel.ingress != { });
       };
     };
 
   enabledInstances = lib.filterAttrs (_: instance: instance.enable) cfg.instances;
+  publicationPolicies = config.services.traefik.publicationPolicyMiddlewares // {
+    strict = [ "security-headers" ];
+  };
+  strictPolicyOverridden = builtins.hasAttr "strict" config.services.traefik.publicationPolicyMiddlewares;
+  requestedPublications = lib.filterAttrs (_: instance: instance.publication.enable) cfg.instances;
+  requestedPublicationNames = builtins.attrNames requestedPublications;
+  publicationMissingHostnames = builtins.attrNames (
+    lib.filterAttrs (_: instance: instance.publication.hostname == null) requestedPublications
+  );
+  publicationInvalidHostnames = builtins.attrNames (
+    lib.filterAttrs (
+      _: instance:
+      instance.publication.hostname != null
+      && builtins.match "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$" instance.publication.hostname == null
+    ) requestedPublications
+  );
+  publicationUnknownPolicies = builtins.attrNames (
+    lib.filterAttrs (
+      _: instance: !(builtins.hasAttr instance.publication.policy publicationPolicies)
+    ) requestedPublications
+  );
+  publicationUnknownTargets = lib.filter (
+    name: !(builtins.hasAttr name registry)
+  ) requestedPublicationNames;
+  enabledPublications = lib.filterAttrs (
+    name: instance:
+    instance.enable
+    && instance.publication.hostname != null
+    && builtins.hasAttr instance.publication.policy publicationPolicies
+    && builtins.hasAttr name registry
+    && cfg.publication.canonicalDomain != null
+  ) requestedPublications;
+  publicationHostnames = lib.mapAttrsToList (
+    _: instance: "${instance.publication.hostname}.${cfg.publication.canonicalDomain}"
+  ) enabledPublications;
+  duplicatePublicationHostnames = duplicateValues publicationHostnames;
+  publicationDisabledTargets = builtins.attrNames (
+    lib.filterAttrs (_: instance: instance.publication.enable && !instance.enable) cfg.instances
+  );
+
+  publicationIngress = builtins.listToAttrs (
+    lib.mapAttrsToList (_: instance: {
+      name = "${instance.publication.hostname}.${cfg.publication.canonicalDomain}";
+      value = "http://localhost:80";
+    }) enabledPublications
+  );
+
+  publicationRouters = lib.mapAttrs (name: instance: {
+    rule = "Host(`${instance.publication.hostname}.${cfg.publication.canonicalDomain}`)";
+    service = name;
+    entryPoints = [ "web" ];
+    middlewares = publicationPolicies.${instance.publication.policy} ++ [ "crowdsec" ];
+  }) enabledPublications;
+
+  publicationServices = lib.mapAttrs (name: _: {
+    loadBalancer.servers = [
+      { url = "http://${registry.${name}.ip}:${toString registry.${name}.port}"; }
+    ];
+  }) enabledPublications;
 
   # Registry entries can opt into a dedicated host bridge. Only materialise
   # that topology when the matching VM instance is enabled on this host.
@@ -303,24 +273,9 @@ let
     lib.filterAttrs (_: instance: instance.autostart) enabledInstances
   );
 
-  derivedExpose = builtins.listToAttrs (
-    lib.mapAttrsToList (name: instance: {
-      name = mkVmName name;
-      value = {
-        inherit (instance) ip portForward cfTunnel;
-      };
-    }) enabledInstances
-  );
-
-  allVms = derivedVms // cfg.vms;
-
-  allAutostart = lib.unique (derivedAutostart ++ cfg.autostart);
-
-  allExpose = derivedExpose // cfg.expose;
-
-  # Generate NAT forwardPorts from VM expose configs
+  # Generate NAT forwardPorts from enabled VM instances.
   mkForwardPorts =
-    vmName: vmCfg:
+    _: vmCfg:
     lib.optionals vmCfg.portForward.enable (
       lib.flatten (
         map (
@@ -344,22 +299,7 @@ let
       )
     );
 
-  # Collect all forward ports from all VMs
-  allForwardPorts = lib.flatten (lib.mapAttrsToList mkForwardPorts allExpose);
-
-  # Collect all cfTunnel ingress rules
-  allCfTunnelIngress = lib.mkMerge (
-    lib.mapAttrsToList (
-      _: vmCfg:
-      lib.optionalAttrs (vmCfg.cfTunnel.enable && vmCfg.cfTunnel.ingress != { }) vmCfg.cfTunnel.ingress
-    ) allExpose
-  );
-
-  exposedVmNames = builtins.attrNames allExpose;
-
-  unknownExposeVms = lib.filter (name: !(lib.hasAttr name allVms)) exposedVmNames;
-
-  unknownAutostartVms = lib.filter (name: !(lib.hasAttr name allVms)) allAutostart;
+  allForwardPorts = lib.flatten (lib.mapAttrsToList mkForwardPorts enabledInstances);
 
   enabledInstanceNames = builtins.attrNames enabledInstances;
 
@@ -375,34 +315,16 @@ let
     instance.portForward.enable && instance.ip == null
   ) enabledInstanceNames;
 
-  reverseProxyMissingFields = lib.filter (
-    name:
-    let
-      instance = enabledInstances.${name};
-    in
-    instance.reverseProxy.enable
-    && (instance.reverseProxy.subdomain == null || instance.reverseProxy.url == null)
-  ) enabledInstanceNames;
-
   portForwardEnabledWithoutPorts = lib.filter (
     name:
     let
-      vmCfg = allExpose.${name};
+      vmCfg = enabledInstances.${name};
     in
     vmCfg.portForward.enable && vmCfg.portForward.ports == [ ]
-  ) exposedVmNames;
-
-  cfTunnelEnabledWithoutIngress = lib.filter (
-    name:
-    let
-      vmCfg = allExpose.${name};
-    in
-    vmCfg.cfTunnel.enable && vmCfg.cfTunnel.ingress == { }
-  ) exposedVmNames;
+  ) enabledInstanceNames;
 
   cloudflaredEnabled = config.sys.services.cloudflared.enable or false;
-
-  enabledCfTunnelVms = lib.filter (name: allExpose.${name}.cfTunnel.enable) exposedVmNames;
+  traefikEnabled = config.services.traefik.enable or false;
 
   duplicateForwardPortKeys =
     let
@@ -410,18 +332,6 @@ let
     in
     lib.unique (
       lib.filter (key: builtins.length (lib.filter (candidate: candidate == key) keys) > 1) keys
-    );
-
-  duplicateIngressHosts =
-    let
-      hosts = lib.flatten (
-        lib.mapAttrsToList (
-          _: vmCfg: lib.optionals vmCfg.cfTunnel.enable (builtins.attrNames vmCfg.cfTunnel.ingress)
-        ) allExpose
-      );
-    in
-    lib.unique (
-      lib.filter (host: builtins.length (lib.filter (candidate: candidate == host) hosts) > 1) hosts
     );
 
   duplicateValues =
@@ -436,46 +346,23 @@ in
   options.sys.virtualisation.microvm = {
     enable = lib.mkEnableOption "microvm.nix host for running lightweight VMs";
 
-    hypervisor = lib.mkOption {
-      type = lib.types.enum [
-        "qemu"
-        "cloud-hypervisor"
-        "firecracker"
-        "crosvm"
-        "kvmtool"
-      ];
-      default = "cloud-hypervisor";
-      description = ''
-        
-                Default hypervisor for MicroVMs.
-                - cloud-hypervisor: Good security/features balance (Rust-based)
-                - firecracker: Minimal attack surface, used by AWS Lambda
-                - qemu: Most features but larger attack surface
-      '';
-    };
-
-    autostart = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
-      default = [ ];
-      description = "List of MicroVM names to automatically start on boot.";
-    };
-
-    vms = lib.mkOption {
-      type = lib.types.attrsOf lib.types.anything;
-      default = { };
-      description = "MicroVM definitions to be merged into microvm.vms.";
-    };
-
     instances = lib.mkOption {
       type = lib.types.attrsOf (lib.types.submodule instanceModule);
       default = { };
       description = ''
-        
-                Logical per-VM host configuration.
-                Use this namespace to opt a VM into a host and control related
-                exposure toggles such as port forwarding, Cloudflare Tunnel, and
-                reverse proxy generation.
+        Logical per-VM host configuration. Use this namespace to opt a VM into
+        a host and control instance-local port forwarding and public HTTP
+        publication.
       '';
+    };
+
+    publication = {
+      canonicalDomain = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "Canonical domain used by public HTTP publications.";
+      };
+
     };
 
     stateDir = lib.mkOption {
@@ -499,39 +386,6 @@ in
       '';
     };
 
-    expose = lib.mkOption {
-      type = lib.types.attrsOf vmExposeModule;
-      default = { };
-      description = ''
-        
-                Per-VM exposure configuration for port forwarding and Cloudflare Tunnel.
-                Keys are VM names (for documentation), values configure how to expose the VM.
-      '';
-      example = {
-        adguard-vm = {
-          ip = "10.100.0.10";
-          portForward = {
-            enable = true;
-            ports = [
-              {
-                proto = "both";
-                sourcePort = 53;
-              }
-              {
-                proto = "tcp";
-                sourcePort = 3000;
-              }
-            ];
-          };
-          cfTunnel = {
-            enable = true;
-            ingress = {
-              "adguard.example.com" = "http://10.100.0.10:80";
-            };
-          };
-        };
-      };
-    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -545,42 +399,58 @@ in
         message = "sys.virtualisation.microvm.instances enables port forwarding without an IP for: ${formatList missingIpPortForwardInstances}";
       }
       {
-        assertion = reverseProxyMissingFields == [ ];
-        message = "sys.virtualisation.microvm.instances enables reverseProxy without both subdomain and url for: ${formatList reverseProxyMissingFields}";
-      }
-      {
-        assertion = unknownExposeVms == [ ];
-        message = "sys.virtualisation.microvm.expose contains unknown VMs: ${formatList unknownExposeVms}";
-      }
-      {
-        assertion = unknownAutostartVms == [ ];
-        message = "sys.virtualisation.microvm.autostart contains unknown VMs: ${formatList unknownAutostartVms}";
-      }
-      {
         assertion = portForwardEnabledWithoutPorts == [ ];
-        message = "sys.virtualisation.microvm (expose/instances) enables port forwarding without ports for: ${formatList portForwardEnabledWithoutPorts}";
-      }
-      {
-        assertion = cfTunnelEnabledWithoutIngress == [ ];
-        message = "sys.virtualisation.microvm (expose/instances) enables Cloudflare Tunnel without ingress rules for: ${formatList cfTunnelEnabledWithoutIngress}";
+        message = "sys.virtualisation.microvm.instances enables port forwarding without ports for: ${formatList portForwardEnabledWithoutPorts}";
       }
       {
         assertion = duplicateForwardPortKeys == [ ];
-        message = "sys.virtualisation.microvm (expose/instances) defines duplicate forwarded source ports: ${formatList duplicateForwardPortKeys}";
+        message = "sys.virtualisation.microvm.instances defines duplicate forwarded source ports: ${formatList duplicateForwardPortKeys}";
       }
       {
-        assertion = duplicateIngressHosts == [ ];
-        message = "sys.virtualisation.microvm (expose/instances) defines duplicate Cloudflare ingress hosts: ${formatList duplicateIngressHosts}";
+        assertion = publicationDisabledTargets == [ ];
+        message = "sys.virtualisation.microvm.instances enables publication for disabled VMs: ${formatList publicationDisabledTargets}";
       }
       {
-        assertion = cloudflaredEnabled || enabledCfTunnelVms == [ ];
-        message = "sys.virtualisation.microvm (expose/instances) enables Cloudflare Tunnel for ${formatList enabledCfTunnelVms}, but sys.services.cloudflared.enable is false";
+        assertion = requestedPublicationNames == [ ] || cfg.publication.canonicalDomain != null;
+        message = "sys.virtualisation.microvm.publication.canonicalDomain must be set when publications are enabled";
+      }
+      {
+        assertion = publicationMissingHostnames == [ ];
+        message = "sys.virtualisation.microvm.instances enables publication without a hostname for: ${formatList publicationMissingHostnames}";
+      }
+      {
+        assertion = publicationInvalidHostnames == [ ];
+        message = "sys.virtualisation.microvm.instances uses invalid publication hostname labels for: ${formatList publicationInvalidHostnames}";
+      }
+      {
+        assertion = publicationUnknownPolicies == [ ];
+        message = "sys.virtualisation.microvm.instances selects unknown publication policies for: ${formatList publicationUnknownPolicies}";
+      }
+      {
+        assertion = !strictPolicyOverridden;
+        message = "services.traefik.publicationPolicyMiddlewares cannot redefine the built-in strict policy";
+      }
+      {
+        assertion = publicationUnknownTargets == [ ];
+        message = "sys.virtualisation.microvm.instances enables publication without a registry target for: ${formatList publicationUnknownTargets}";
+      }
+      {
+        assertion = cloudflaredEnabled || requestedPublicationNames == [ ];
+        message = "sys.virtualisation.microvm.instances enables publication for ${formatList requestedPublicationNames}, but sys.services.cloudflared.enable is false";
+      }
+      {
+        assertion = traefikEnabled || requestedPublicationNames == [ ];
+        message = "sys.virtualisation.microvm.instances enables publication for ${formatList requestedPublicationNames}, but services.traefik.enable is false";
+      }
+      {
+        assertion = duplicatePublicationHostnames == [ ];
+        message = "sys.virtualisation.microvm.instances defines duplicate publication hostnames: ${formatList duplicatePublicationHostnames}";
       }
     ];
 
     microvm = {
-      autostart = allAutostart;
-      vms = allVms;
+      autostart = derivedAutostart;
+      vms = derivedVms;
       inherit (cfg) stateDir;
     };
 
@@ -644,8 +514,12 @@ in
       };
     };
 
-    # Add VM services to Cloudflare Tunnel ingress
     sys.services.cloudflared.ingress = lib.mkIf (config.sys.services.cloudflared.enable or false
-    ) allCfTunnelIngress;
+    ) publicationIngress;
+
+    services.traefik.dynamic.files.microvm-publications.settings.http = {
+      routers = publicationRouters;
+      services = publicationServices;
+    };
   };
 }

--- a/tests/microvm-publication.nix
+++ b/tests/microvm-publication.nix
@@ -308,15 +308,13 @@ let
       (
         { lib, ... }:
         {
-          sys.virtualisation.microvm.publication.canonicalDomain =
-            lib.mkForce "https://not-a-domain.example";
+          sys.virtualisation.microvm.publication.canonicalDomain = lib.mkForce "https://not-a-domain.example";
         }
       )
     ];
   };
 
-  invalidCanonicalDomainEvaluation =
-    builtins.tryEval invalidCanonicalDomain.config.system.build.toplevel.drvPath;
+  invalidCanonicalDomainEvaluation = builtins.tryEval invalidCanonicalDomain.config.system.build.toplevel.drvPath;
 
   undefinedMiddleware = blizzard.extendModules {
     modules = [
@@ -333,8 +331,7 @@ let
     ];
   };
 
-  undefinedMiddlewareEvaluation =
-    builtins.tryEval undefinedMiddleware.config.system.build.toplevel.drvPath;
+  undefinedMiddlewareEvaluation = builtins.tryEval undefinedMiddleware.config.system.build.toplevel.drvPath;
 
   removedHostOption = blizzard.extendModules {
     modules = [
@@ -344,8 +341,7 @@ let
     ];
   };
 
-  removedHostOptionEvaluation =
-    builtins.tryEval removedHostOption.config.system.build.toplevel.drvPath;
+  removedHostOptionEvaluation = builtins.tryEval removedHostOption.config.system.build.toplevel.drvPath;
 
   removedInstanceOption = blizzard.extendModules {
     modules = [
@@ -355,16 +351,14 @@ let
     ];
   };
 
-  removedInstanceOptionEvaluation =
-    builtins.tryEval removedInstanceOption.config.system.build.toplevel.drvPath;
+  removedInstanceOptionEvaluation = builtins.tryEval removedInstanceOption.config.system.build.toplevel.drvPath;
 
   matrixPublicationDisabled = blizzard.extendModules {
     modules = [
       (
         { lib, ... }:
         {
-          sys.virtualisation.microvm.instances.matrix-synapse.publication.enable =
-            lib.mkForce false;
+          sys.virtualisation.microvm.instances.matrix-synapse.publication.enable = lib.mkForce false;
         }
       )
     ];

--- a/tests/microvm-publication.nix
+++ b/tests/microvm-publication.nix
@@ -4,6 +4,129 @@
   self,
 }:
 let
+  lib = pkgs.lib;
+
+  productionCfg = blizzard.config;
+  productionTunnel =
+    productionCfg.services.cloudflared.tunnels.${productionCfg.sys.services.cloudflared.tunnelId};
+  productionHttp = productionCfg.services.traefik.dynamicConfigOptions.http;
+  productionPublicationHttp =
+    productionCfg.services.traefik.dynamic.files.microvm-publications.settings.http;
+
+  # Keep this inventory explicit so a production publication cannot disappear,
+  # change host, lose policy middleware, or point at a different backend
+  # without updating the expected contract.
+  productionPublications = {
+    bazarr = {
+      hostname = "subs";
+      middlewares = [ "app-compat-headers" ];
+      backend = "http://10.100.0.23:11023";
+    };
+    firefox = {
+      hostname = "ff";
+      middlewares = [ "firefox-headers" ];
+      backend = "http://10.100.0.52:11052";
+    };
+    gitea = {
+      hostname = "git";
+      middlewares = [
+        "security-headers"
+        "gitea-xfp-https"
+      ];
+      backend = "http://10.100.0.50:11050";
+    };
+    immich = {
+      hostname = "photos";
+      middlewares = [ "immich-headers" ];
+      backend = "http://10.100.0.70:11070";
+    };
+    matrix-synapse = {
+      hostname = "matrix";
+      middlewares = [ "matrix-headers" ];
+      backend = "http://10.100.0.60:11060";
+    };
+    overseerr = {
+      hostname = "requests";
+      middlewares = [ "plex-headers" ];
+      backend = "http://10.100.0.40:11040";
+    };
+    pocket-id = {
+      hostname = "id";
+      middlewares = [ "pocket-id-headers" ];
+      backend = "http://10.100.1.2:11081";
+    };
+    prowlarr = {
+      hostname = "indexer";
+      middlewares = [ "app-compat-headers" ];
+      backend = "http://10.100.0.20:11020";
+    };
+    radarr = {
+      hostname = "movies";
+      middlewares = [ "app-compat-headers" ];
+      backend = "http://10.100.0.22:11022";
+    };
+    readarr = {
+      hostname = "books";
+      middlewares = [ "app-compat-headers" ];
+      backend = "http://10.100.0.24:11024";
+    };
+    sabnzbd = {
+      hostname = "sab";
+      middlewares = [ "sabnzbd-headers" ];
+      backend = "http://10.100.0.31:11031";
+    };
+    searx = {
+      hostname = "search";
+      middlewares = [ "security-headers" ];
+      backend = "http://10.100.0.12:11012";
+    };
+    sonarr = {
+      hostname = "series";
+      middlewares = [ "app-compat-headers" ];
+      backend = "http://10.100.0.21:11021";
+    };
+    tautulli = {
+      hostname = "tautulli";
+      middlewares = [ "plex-headers" ];
+      backend = "http://10.100.0.42:11042";
+    };
+  };
+
+  expectedProductionPublicationHttp = {
+    routers = lib.mapAttrs (name: publication: {
+      rule = "Host(`${publication.hostname}.zzxyz.no`)";
+      service = name;
+      entryPoints = [ "web" ];
+      middlewares = publication.middlewares ++ [ "crowdsec" ];
+    }) productionPublications;
+    services = lib.mapAttrs (_: publication: {
+      loadBalancer.servers = [ { url = publication.backend; } ];
+    }) productionPublications;
+  };
+
+  expectedProductionTunnelOrigins = builtins.listToAttrs (
+    lib.mapAttrsToList (_: publication: {
+      name = "${publication.hostname}.zzxyz.no";
+      value = "http://localhost:80";
+    }) productionPublications
+  );
+  actualProductionTunnelOrigins = builtins.listToAttrs (
+    lib.mapAttrsToList (_: publication: {
+      name = "${publication.hostname}.zzxyz.no";
+      value = productionTunnel.ingress."${publication.hostname}.zzxyz.no";
+    }) productionPublications
+  );
+
+  expectedMatrixWellKnownRouter = {
+    rule = "Host(`zzxyz.no`) && PathPrefix(`/.well-known/matrix/`)";
+    service = "matrix-synapse";
+    entryPoints = [ "web" ];
+    middlewares = [
+      "matrix-headers"
+      "crowdsec"
+    ];
+  };
+
   publishedQbittorrent = blizzard.extendModules {
     modules = [
       {
@@ -179,7 +302,84 @@ let
   };
 
   invalidHostnameEvaluation = builtins.tryEval invalidHostname.config.system.build.toplevel.drvPath;
+
+  invalidCanonicalDomain = blizzard.extendModules {
+    modules = [
+      (
+        { lib, ... }:
+        {
+          sys.virtualisation.microvm.publication.canonicalDomain =
+            lib.mkForce "https://not-a-domain.example";
+        }
+      )
+    ];
+  };
+
+  invalidCanonicalDomainEvaluation =
+    builtins.tryEval invalidCanonicalDomain.config.system.build.toplevel.drvPath;
+
+  undefinedMiddleware = blizzard.extendModules {
+    modules = [
+      {
+        services.traefik.publicationPolicyMiddlewares.undefined-middleware = [
+          "middleware-name-typo"
+        ];
+        sys.virtualisation.microvm.instances.qbittorrent.publication = {
+          enable = true;
+          hostname = "downloads-undefined-middleware-test";
+          policy = "undefined-middleware";
+        };
+      }
+    ];
+  };
+
+  undefinedMiddlewareEvaluation =
+    builtins.tryEval undefinedMiddleware.config.system.build.toplevel.drvPath;
+
+  removedHostOption = blizzard.extendModules {
+    modules = [
+      {
+        sys.virtualisation.microvm.autostart = [ "qbittorrent-vm" ];
+      }
+    ];
+  };
+
+  removedHostOptionEvaluation =
+    builtins.tryEval removedHostOption.config.system.build.toplevel.drvPath;
+
+  removedInstanceOption = blizzard.extendModules {
+    modules = [
+      {
+        sys.virtualisation.microvm.instances.qbittorrent.cfTunnel.enable = true;
+      }
+    ];
+  };
+
+  removedInstanceOptionEvaluation =
+    builtins.tryEval removedInstanceOption.config.system.build.toplevel.drvPath;
+
+  matrixPublicationDisabled = blizzard.extendModules {
+    modules = [
+      (
+        { lib, ... }:
+        {
+          sys.virtualisation.microvm.instances.matrix-synapse.publication.enable =
+            lib.mkForce false;
+        }
+      )
+    ];
+  };
+
+  matrixDisabledCfg = matrixPublicationDisabled.config;
+  matrixDisabledTunnel =
+    matrixDisabledCfg.services.cloudflared.tunnels.${matrixDisabledCfg.sys.services.cloudflared.tunnelId};
+  matrixDisabledHttp = matrixDisabledCfg.services.traefik.dynamicConfigOptions.http;
+  matrixDisabledPublicationHttp =
+    matrixDisabledCfg.services.traefik.dynamic.files.microvm-publications.settings.http;
 in
+assert productionPublicationHttp == expectedProductionPublicationHttp;
+assert actualProductionTunnelOrigins == expectedProductionTunnelOrigins;
+assert productionHttp.routers.matrix-well-known == expectedMatrixWellKnownRouter;
 assert actual == expected;
 assert !disabledTargetEvaluation.success;
 assert !missingTraefikEvaluation.success;
@@ -194,4 +394,12 @@ assert !missingCloudflareEvaluation.success;
 assert !unknownPolicyEvaluation.success;
 assert !missingRegistryTargetEvaluation.success;
 assert !invalidHostnameEvaluation.success;
+assert !invalidCanonicalDomainEvaluation.success;
+assert !undefinedMiddlewareEvaluation.success;
+assert !removedHostOptionEvaluation.success;
+assert !removedInstanceOptionEvaluation.success;
+assert !(builtins.hasAttr "matrix.zzxyz.no" matrixDisabledTunnel.ingress);
+assert !(builtins.hasAttr "matrix-synapse" matrixDisabledPublicationHttp.routers);
+assert !(builtins.hasAttr "matrix-synapse" matrixDisabledPublicationHttp.services);
+assert !(builtins.hasAttr "matrix-well-known" matrixDisabledHttp.routers);
 pkgs.runCommand "microvm-publication-tests" { } "touch $out"

--- a/tests/microvm-publication.nix
+++ b/tests/microvm-publication.nix
@@ -1,0 +1,197 @@
+{
+  blizzard,
+  pkgs,
+  self,
+}:
+let
+  publishedQbittorrent = blizzard.extendModules {
+    modules = [
+      {
+        sys.virtualisation.microvm.instances.qbittorrent.publication = {
+          enable = true;
+          hostname = "downloads-test";
+        };
+      }
+    ];
+  };
+
+  cfg = publishedQbittorrent.config;
+  tunnel = cfg.services.cloudflared.tunnels.${cfg.sys.services.cloudflared.tunnelId};
+  http = cfg.services.traefik.dynamicConfigOptions.http;
+
+  actual = {
+    tunnelOrigin = tunnel.ingress."downloads-test.zzxyz.no";
+    router = http.routers.qbittorrent;
+    backend = http.services.qbittorrent;
+  };
+
+  expected = {
+    tunnelOrigin = "http://localhost:80";
+    router = {
+      rule = "Host(`downloads-test.zzxyz.no`)";
+      service = "qbittorrent";
+      entryPoints = [ "web" ];
+      middlewares = [
+        "security-headers"
+        "crowdsec"
+      ];
+    };
+    backend.loadBalancer.servers = [
+      { url = "http://10.100.0.30:11030"; }
+    ];
+  };
+
+  disabledTarget = blizzard.extendModules {
+    modules = [
+      {
+        sys.virtualisation.microvm.instances.actual.publication = {
+          enable = true;
+          hostname = "actual-test";
+        };
+      }
+    ];
+  };
+
+  disabledTargetEvaluation = builtins.tryEval disabledTarget.config.system.build.toplevel.drvPath;
+
+  missingTraefik = blizzard.extendModules {
+    modules = [
+      (
+        { lib, ... }:
+        {
+          services.traefik.enable = lib.mkForce false;
+          sys.virtualisation.microvm.instances.qbittorrent.publication = {
+            enable = true;
+            hostname = "downloads-test";
+          };
+        }
+      )
+    ];
+  };
+
+  missingTraefikEvaluation = builtins.tryEval missingTraefik.config.system.build.toplevel.drvPath;
+
+  duplicateHostname = blizzard.extendModules {
+    modules = [
+      {
+        sys.virtualisation.microvm.instances = {
+          qbittorrent.publication = {
+            enable = true;
+            hostname = "duplicate-test";
+          };
+          wireguard.publication = {
+            enable = true;
+            hostname = "duplicate-test";
+          };
+        };
+      }
+    ];
+  };
+
+  duplicateHostnameEvaluation = builtins.tryEval duplicateHostname.config.system.build.toplevel.drvPath;
+
+  compatibleQbittorrent = blizzard.extendModules {
+    modules = [
+      {
+        sys.virtualisation.microvm.instances.qbittorrent.publication = {
+          enable = true;
+          hostname = "downloads-compatible-test";
+          policy = "legacy-app-shell";
+        };
+      }
+    ];
+  };
+
+  compatibleMiddlewares =
+    compatibleQbittorrent.config.services.traefik.dynamicConfigOptions.http.routers.qbittorrent.middlewares;
+
+  overriddenStrictPolicy = blizzard.extendModules {
+    modules = [
+      {
+        services.traefik.publicationPolicyMiddlewares.strict = [
+          "app-compat-headers"
+        ];
+      }
+    ];
+  };
+
+  overriddenStrictPolicyEvaluation = builtins.tryEval overriddenStrictPolicy.config.system.build.toplevel.drvPath;
+
+  missingCloudflare = blizzard.extendModules {
+    modules = [
+      (
+        { lib, ... }:
+        {
+          sys.services.cloudflared.enable = lib.mkForce false;
+        }
+      )
+    ];
+  };
+
+  missingCloudflareEvaluation = builtins.tryEval missingCloudflare.config.system.build.toplevel.drvPath;
+
+  unknownPolicy = blizzard.extendModules {
+    modules = [
+      {
+        sys.virtualisation.microvm.instances.qbittorrent.publication = {
+          enable = true;
+          hostname = "downloads-unknown-policy-test";
+          policy = "does-not-exist";
+        };
+      }
+    ];
+  };
+
+  unknownPolicyEvaluation = builtins.tryEval unknownPolicy.config.system.build.toplevel.drvPath;
+
+  fakeFlake = self // {
+    nixosConfigurations = self.nixosConfigurations // {
+      "unregistered-vm" = self.nixosConfigurations.qbittorrent-vm;
+    };
+  };
+
+  missingRegistryTarget = blizzard.extendModules {
+    modules = [
+      {
+        sys.virtualisation.microvm.instances.unregistered = {
+          enable = true;
+          flake = fakeFlake;
+          publication = {
+            enable = true;
+            hostname = "unregistered-test";
+          };
+        };
+      }
+    ];
+  };
+
+  missingRegistryTargetEvaluation = builtins.tryEval missingRegistryTarget.config.system.build.toplevel.drvPath;
+
+  invalidHostname = blizzard.extendModules {
+    modules = [
+      {
+        sys.virtualisation.microvm.instances.qbittorrent.publication = {
+          enable = true;
+          hostname = "downloads.alt";
+        };
+      }
+    ];
+  };
+
+  invalidHostnameEvaluation = builtins.tryEval invalidHostname.config.system.build.toplevel.drvPath;
+in
+assert actual == expected;
+assert !disabledTargetEvaluation.success;
+assert !missingTraefikEvaluation.success;
+assert !duplicateHostnameEvaluation.success;
+assert
+  compatibleMiddlewares == [
+    "app-compat-headers"
+    "crowdsec"
+  ];
+assert !overriddenStrictPolicyEvaluation.success;
+assert !missingCloudflareEvaluation.success;
+assert !unknownPolicyEvaluation.success;
+assert !missingRegistryTargetEvaluation.success;
+assert !invalidHostnameEvaluation.success;
+pkgs.runCommand "microvm-publication-tests" { } "touch $out"

--- a/vms/README.md
+++ b/vms/README.md
@@ -146,6 +146,10 @@ disabled (for example `adguard`, `actual`, `lidarr`, and `brave`).
 sys.virtualisation.microvm.instances.<name> = {
   enable = true;
 
+  # Defaults to enable; override when the VM should be defined but not
+  # started automatically.
+  autostart = false;
+
   # Optional transport-layer reachability:
   portForward.ports = [ ... ];
 
@@ -158,9 +162,11 @@ sys.virtualisation.microvm.instances.<name> = {
 };
 ```
 
-Enabling an instance never publishes it automatically. A standard publication
-is an independent opt-in that maps one hostname under the canonical public
-domain to the VM's IP and primary port from
+Enabling an instance starts it automatically by default; set `autostart = false`
+to keep the VM defined without starting it on boot. Instance enablement never
+publishes the VM automatically. A standard publication is an independent
+opt-in that maps one hostname under the canonical public domain to the VM's IP
+and primary port from
 [vm-registry.nix](vm-registry.nix). The host module renders both Cloudflare
 Tunnel ingress and the matching Traefik router and service, applies CrowdSec,
 and uses strict security headers unless a registered compatibility policy is
@@ -176,7 +182,7 @@ flowchart LR
     TR["Traefik router + service\npolicy middleware + CrowdSec"]
     VM["Enabled MicroVM\nhttp://registry IP:port"]
     CLIENT["Public HTTP client"]
-    BESPOKE["Host and bespoke routes\nfor example Matrix"]
+    BESPOKE["Supplemental host/path routes\nfor example Matrix discovery"]
 
     DECL --> PUB
     REG --> PUB
@@ -184,14 +190,28 @@ flowchart LR
     PUB --> CF
     PUB --> TR
     CLIENT --> CF --> TR --> VM
-    BESPOKE -.->|configured explicitly| CF
-    BESPOKE -.->|configured explicitly| TR
+    PUB -.->|publication gates supplemental route| BESPOKE
+    BESPOKE -.-> TR
 ```
 
 Compatibility-policy middleware mappings live in
-`hosts/blizzard/security/traefik.nix`. Host-level routes and exceptional
-multi-host or path routing, such as Matrix discovery, remain explicit in the
-Cloudflare and Traefik host configurations.
+`hosts/blizzard/security/traefik.nix`. Matrix's `matrix.<domain>` workload route
+uses the standard publication path. Its root-domain `/.well-known/matrix/`
+discovery route remains explicit in the host Traefik configuration, but is
+enabled only while the Matrix publication is enabled.
+
+Legacy host-wide MicroVM options were removed in favor of instance-local
+intent. Using one of them now fails evaluation with a targeted migration
+message:
+
+| Removed option | Replacement |
+|---|---|
+| `microvm.hypervisor` | Configure the hypervisor in the guest when required |
+| `microvm.autostart` | `instances.<name>.autostart` |
+| `microvm.vms` | `instances.<name>.flake` and `instances.<name>.vmConfig` |
+| `microvm.expose` | `instances.<name>.portForward` and `instances.<name>.publication` |
+| `instances.<name>.cfTunnel` | `instances.<name>.publication` or a bespoke host ingress |
+| `instances.<name>.reverseProxy` | `instances.<name>.publication` or a bespoke host route |
 
 `immich` is published at `https://photos.zzxyz.no` through Cloudflare Tunnel
 and Traefik. Its raw host port is not forwarded; `10.100.0.70:11070` remains

--- a/vms/README.md
+++ b/vms/README.md
@@ -138,23 +138,38 @@ ______________________________________________________________________
 
 ### Host-side enablement
 
-On `blizzard`, VMs are managed via `sys.virtualisation.microvm.instances.<name>` toggles.
-Some instances are currently disabled (e.g. `adguard`, `actual`, `lidarr`, `brave`).
-Enabled instances are exposed via:
+On `blizzard`, VMs are managed via
+`sys.virtualisation.microvm.instances.<name>`. Some instances are currently
+disabled (for example `adguard`, `actual`, `lidarr`, and `brave`).
 
 ```nix
 sys.virtualisation.microvm.instances.<name> = {
   enable = true;
-  # Optional overrides:
-  autostart = true;
-  portForward.enable = true;
-  cfTunnel.enable = true;
-  reverseProxy.enable = true;
+
+  # Optional transport-layer reachability:
+  portForward.ports = [ ... ];
+
+  # Optional standard public HTTP publication:
+  publication = {
+    enable = true;
+    hostname = "service";
+    policy = "strict";
+  };
 };
 ```
 
-Each instance toggle is independent, so a VM can remain active while
-selectively disabling its Cloudflare Tunnel or Traefik routing.
+Enabling an instance never publishes it automatically. A standard publication
+is an independent opt-in that maps one hostname under the canonical public
+domain to the VM's IP and primary port from
+[vm-registry.nix](vm-registry.nix). The host module renders both Cloudflare
+Tunnel ingress and the matching Traefik router and service, applies CrowdSec,
+and uses strict security headers unless a registered compatibility policy is
+selected.
+
+Compatibility-policy middleware mappings live in
+`hosts/blizzard/security/traefik.nix`. Host-level routes and exceptional
+multi-host or path routing, such as Matrix discovery, remain explicit in the
+Cloudflare and Traefik host configurations.
 
 `immich` is published at `https://photos.zzxyz.no` through Cloudflare Tunnel
 and Traefik. Its raw host port is not forwarded; `10.100.0.70:11070` remains
@@ -180,6 +195,9 @@ ______________________________________________________________________
    service-specific NixOS config.
 1. Wire it up in [flake-microvms.nix](flake-microvms.nix) using `mkMicrovm`.
 1. Enable on the host: `sys.virtualisation.microvm.instances.<name>.enable = true`.
+1. If it needs the standard public HTTP path, explicitly enable
+   `instances.<name>.publication` with one hostname and a registered
+   compatibility policy.
 
 ______________________________________________________________________
 

--- a/vms/README.md
+++ b/vms/README.md
@@ -166,6 +166,28 @@ Tunnel ingress and the matching Traefik router and service, applies CrowdSec,
 and uses strict security headers unless a registered compatibility policy is
 selected.
 
+```mermaid
+flowchart LR
+    DECL["instances.<name>.publication\nhostname label + policy"]
+    REG["vm-registry.nix\nVM IP + primary port"]
+    POL["publicationPolicyMiddlewares\nnamed compatibility policies"]
+    PUB["microvm-base.nix\nvalidate + derive publication"]
+    CF["Cloudflare Tunnel ingress\nhostname → localhost:80"]
+    TR["Traefik router + service\npolicy middleware + CrowdSec"]
+    VM["Enabled MicroVM\nhttp://registry IP:port"]
+    CLIENT["Public HTTP client"]
+    BESPOKE["Host and bespoke routes\nfor example Matrix"]
+
+    DECL --> PUB
+    REG --> PUB
+    POL --> PUB
+    PUB --> CF
+    PUB --> TR
+    CLIENT --> CF --> TR --> VM
+    BESPOKE -.->|configured explicitly| CF
+    BESPOKE -.->|configured explicitly| TR
+```
+
 Compatibility-policy middleware mappings live in
 `hosts/blizzard/security/traefik.nix`. Host-level routes and exceptional
 multi-host or path routing, such as Matrix discovery, remain explicit in the
@@ -221,3 +243,5 @@ ______________________________________________________________________
 - [modules/services/README.md](../modules/services/README.md) — Service module catalog
 - [Blizzard host config](../hosts/blizzard/blizzard.nix) — VM host example
 - [vm-registry.nix](vm-registry.nix) — Single source of truth for all VM parameters
+- [Infrastructure context](../CONTEXT.md) — Canonical publication terminology
+- [ADR 0001](../docs/adr/0001-model-public-http-publication-as-instance-intent.md) — Publication interface decision


### PR DESCRIPTION
Refactor and document the MicroVM public HTTP publication process, introducing explicit lifecycle and compatibility policies. Add comprehensive tests and improve the publication policy middlewares for better compatibility with Traefik. Update documentation to clarify configuration options and intent.