### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -615,11 +615,11 @@
     },
     "nixpkgs-beta": {
       "locked": {
-        "lastModified": 1784707089,
-        "narHash": "sha256-2V/6imsUgB7mPZlHY54oeVBRDoZbPKnvzwkAHUSSufk=",
+        "lastModified": 1784856561,
+        "narHash": "sha256-J+Bx1Z6Oeoj2FgnBhRMKyUhhtDoOpTgXYaVLZpDjW4A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3fe9581c9061c749abef42b6d4ee7b7c05c33fa",
+        "rev": "597283ad8aa0b331c788e97c4c262d58877074ef",
         "type": "github"
       },
       "original": {
@@ -707,11 +707,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1784707089,
-        "narHash": "sha256-2V/6imsUgB7mPZlHY54oeVBRDoZbPKnvzwkAHUSSufk=",
+        "lastModified": 1784856561,
+        "narHash": "sha256-J+Bx1Z6Oeoj2FgnBhRMKyUhhtDoOpTgXYaVLZpDjW4A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3fe9581c9061c749abef42b6d4ee7b7c05c33fa",
+        "rev": "597283ad8aa0b331c788e97c4c262d58877074ef",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784960137,
-        "narHash": "sha256-oRlQZ1vTruZqIdxCZ3yc3zj3sYAvjEpZ6Ioggg5phUk=",
+        "lastModified": 1784971149,
+        "narHash": "sha256-0INDo3Fd9tPzKTFtDKj62lfCUqRf23Oh3ndqIfMVoaQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5ef4b45c435d673d89598b9711280adc423b76a4",
+        "rev": "01133c6906c1d3afc7d99b3f43b554003c45b805",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/b3fe958' (2026-07-22)
  → 'github:NixOS/nixpkgs/597283a' (2026-07-24)
• Updated input 'nixpkgs-beta':
    'github:NixOS/nixpkgs/b3fe958' (2026-07-22)
  → 'github:NixOS/nixpkgs/597283a' (2026-07-24)
• Updated input 'nur':
    'github:nix-community/NUR/5ef4b45' (2026-07-25)
  → 'github:nix-community/NUR/01133c6' (2026-07-25)
```