### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable-small": {
       "locked": {
-        "lastModified": 1784963280,
-        "narHash": "sha256-mXy7mN4wRWYAnXOyKDylTnThiFGRjSqIRUVv44o+I7A=",
+        "lastModified": 1785017440,
+        "narHash": "sha256-ZMBrD+Ca4ocaxEjH1VLUdbB2HygkK5Ny/LCRgTbQ3No=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4d9b14754f8d4fefe57009774c4024acba495666",
+        "rev": "f52f5138416e42b61269d870336a3fe9a1cac4b7",
         "type": "github"
       },
       "original": {
@@ -678,11 +678,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1784999639,
-        "narHash": "sha256-uW/07AfbRX9CSPeR497fgDGNXHJocftLZoDvMyWNu2A=",
+        "lastModified": 1785016531,
+        "narHash": "sha256-eLWTMGB99JJ+t/7YoGKcl9BsRhmZlz0uvZNn+p+SY0Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4d1e3ff59e4cd0c8106a84ea1f4867b2c56b1cfe",
+        "rev": "2f478a0b4a50c38e4bcf17a16e276e2b531debef",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785008326,
-        "narHash": "sha256-nzU/7RiubqKoVCZxJDPS//Fy47Q0vRjqFe5Sb7Fjp20=",
+        "lastModified": 1785018925,
+        "narHash": "sha256-gxWMwgvV6W6V9PhfP1VmjYvzcdBd8Hcdt7LCFNYz7uY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2438b23c73784053a756dae83b2c9c478af74851",
+        "rev": "2e7a3ed8ee1f4f6a73eb697c21a6422317b61f25",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs-stable-small':
    'github:NixOS/nixpkgs/4d9b147' (2026-07-25)
  → 'github:NixOS/nixpkgs/f52f513' (2026-07-25)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/4d1e3ff' (2026-07-25)
  → 'github:NixOS/nixpkgs/2f478a0' (2026-07-25)
• Updated input 'nur':
    'github:nix-community/NUR/2438b23' (2026-07-25)
  → 'github:nix-community/NUR/2e7a3ed' (2026-07-25)
```