### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -255,11 +255,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1785075476,
-        "narHash": "sha256-Pi8uyEDu621eTAjouR8NRVQvgvF50vRVydUs3bkvCCM=",
+        "lastModified": 1785081751,
+        "narHash": "sha256-0vZbjVqutPmzfAQjNv9QJ/GhvTaeCG+Hh6gfyBNU/s8=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "7b8454d21efae4190ec3ae7d547d5088a887cc4d",
+        "rev": "d8dc50309c551cfa44fee70744397311b8b7c5fc",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785075319,
-        "narHash": "sha256-2Bb9s4wvexs1iqvs6uI/p8Wuof0o0JB/w7qQMaUTZwM=",
+        "lastModified": 1785089350,
+        "narHash": "sha256-s979ryuO5xXJSTfU13mEwdRHmboAEppIiTYFG9Z0+3Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3aeb67434e98f7b9e73d7877bda0703fe554280d",
+        "rev": "6e22eaed76bbe33ddb216463bf68c29f9c6a7f54",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hyprland':
    'github:hyprwm/Hyprland/7b8454d' (2026-07-26)
  → 'github:hyprwm/Hyprland/d8dc503' (2026-07-26)
• Updated input 'nur':
    'github:nix-community/NUR/3aeb674' (2026-07-26)
  → 'github:nix-community/NUR/6e22eae' (2026-07-26)
```