### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -615,11 +615,11 @@
     },
     "nixpkgs-beta": {
       "locked": {
-        "lastModified": 1785386831,
-        "narHash": "sha256-sPS3CaXH8RAT3FZRuy4VcV47iuYIWMMfa0GbyJKC3o4=",
+        "lastModified": 1785491804,
+        "narHash": "sha256-p00vplVOyfKGlhju0+eGGPAxyYYKaY0lpyuoHLFIx2Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21ea275a7c46aef9d4d6ddc962e6d562e9d94183",
+        "rev": "5b4f72e1705a63aace42900610c4db82cb4af0ec",
         "type": "github"
       },
       "original": {
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable-small": {
       "locked": {
-        "lastModified": 1785486920,
-        "narHash": "sha256-y3GCnHcuVB0fx7vezSA8ycPiwH4XpE+NFKkwGuUg/KI=",
+        "lastModified": 1785541090,
+        "narHash": "sha256-KpfCHcis76oTTfJq7x/DRXmliCfUPbWizSqaxCnnQxE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b67d224138bbf26567087bf5567ce69c53a031fc",
+        "rev": "d08455725c2a6db3543d51aa66b7f5e3bb1838da",
         "type": "github"
       },
       "original": {
@@ -678,11 +678,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1785501464,
-        "narHash": "sha256-TOU5zN4qZzi8Fd4FOPaO5liKYo+RHlleHDasnyI3S78=",
+        "lastModified": 1785533494,
+        "narHash": "sha256-8yQQSHFpNuzEPYsGQDPZpJcHPt236gtqAiVPJoxBJs4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7e2391fc6abe0c200affe8e8a4efd2cc891fcffb",
+        "rev": "63f0192dda2d7886919057e1c2ff8b613de838e9",
         "type": "github"
       },
       "original": {
@@ -707,11 +707,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1785386831,
-        "narHash": "sha256-sPS3CaXH8RAT3FZRuy4VcV47iuYIWMMfa0GbyJKC3o4=",
+        "lastModified": 1785491804,
+        "narHash": "sha256-p00vplVOyfKGlhju0+eGGPAxyYYKaY0lpyuoHLFIx2Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21ea275a7c46aef9d4d6ddc962e6d562e9d94183",
+        "rev": "5b4f72e1705a63aace42900610c4db82cb4af0ec",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785541122,
-        "narHash": "sha256-+977ybTIFOFYHK9xMBsgXHQmVR8EgjQSzkloBdgMJsU=",
+        "lastModified": 1785556105,
+        "narHash": "sha256-mM7PNfNgvj83TW/Ttrq+7xTd8dr8Kc2U0/VFiO6FSLE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "64e74ace88f3101a283d364ca73ee16ae0aa992a",
+        "rev": "4f79d3a488fee0517e36bd66fb2c5a1be5d98769",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/21ea275' (2026-07-30)
  → 'github:NixOS/nixpkgs/5b4f72e' (2026-07-31)
• Updated input 'nixpkgs-beta':
    'github:NixOS/nixpkgs/21ea275' (2026-07-30)
  → 'github:NixOS/nixpkgs/5b4f72e' (2026-07-31)
• Updated input 'nixpkgs-stable-small':
    'github:NixOS/nixpkgs/b67d224' (2026-07-31)
  → 'github:NixOS/nixpkgs/d084557' (2026-07-31)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/7e2391f' (2026-07-31)
  → 'github:NixOS/nixpkgs/63f0192' (2026-07-31)
• Updated input 'nur':
    'github:nix-community/NUR/64e74ac' (2026-07-31)
  → 'github:nix-community/NUR/4f79d3a' (2026-08-01)
```