### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785584152,
-        "narHash": "sha256-KvBh1d/kLXjjOdrQRasv/bccBlh7+LHs7oV7PdlnAng=",
+        "lastModified": 1785595305,
+        "narHash": "sha256-kpOee/oZfUA7KEnwcXst41CI6vhoKUpWlv6gY7ajU1I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d21fdc75128076e6447ef910d10ff35b4e499e5b",
+        "rev": "fb46d9801c1b387cba3b797d07d1996a30aca528",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/d21fdc7' (2026-08-01)
  → 'github:nix-community/NUR/fb46d98' (2026-08-01)
```