### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -255,11 +255,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1785836486,
-        "narHash": "sha256-pa2ROfqS4ifXKfnGjPgdgW61tULmZhWahuU/rIFGdxw=",
+        "lastModified": 1785846819,
+        "narHash": "sha256-4tsQ0iDNmPM7UQOqHFUMPQ+g8gJx0yX6Zk1c+M5+sNE=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "275e27704a36d956fbdc28cec6399b8e298b06ca",
+        "rev": "ea95499cd743f9e01c1e6c5d35bfbf9e31971d0f",
         "type": "github"
       },
       "original": {
@@ -531,11 +531,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1785510331,
-        "narHash": "sha256-d/AR1r5guAk52ZWM0sAd3O8Fd2jQbyGwxU+e6flTiUk=",
+        "lastModified": 1785843289,
+        "narHash": "sha256-H/0YgQ+3BtNbdeSVuqjU7ElneBzPPuIKcuWOi0ZUktQ=",
         "owner": "microvm-nix",
         "repo": "microvm.nix",
-        "rev": "06544a68599a0e0721760af442000204e57e3937",
+        "rev": "e615e23267bf10d483fb44f759d4e61c354cc0f4",
         "type": "github"
       },
       "original": {
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable-small": {
       "locked": {
-        "lastModified": 1785795383,
-        "narHash": "sha256-qkuooVouwAcXwOPmLKRnrOPAXTUz/xQQupCWhZDpdTk=",
+        "lastModified": 1785858998,
+        "narHash": "sha256-fKCq5jphd6l/Ms6gc3dptkw/TcKLYub9lQE5g6rbbkc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a7bb645019743570d75466f73ad2cbe399ab6314",
+        "rev": "04607e1165ac22c5fde6dcc54c9e0b3c0487c555",
         "type": "github"
       },
       "original": {
@@ -662,11 +662,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1785692966,
-        "narHash": "sha256-vUfIeBEfpbAfZ5zjgIkYk7eHBeVfCYVjLbWnMkseYnk=",
+        "lastModified": 1785828668,
+        "narHash": "sha256-8fsyqeO+mJqvIzeO4xIpgJe/f7MTbbVTEC6RT6WSXNs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "643809054d65fdd466a63e3155b8c498cb483c04",
+        "rev": "e72e4f299401a3689d4b3d5fc6496b11db7064eb",
         "type": "github"
       },
       "original": {
@@ -678,11 +678,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1785825000,
-        "narHash": "sha256-8IX3ITYddN29r/lENhPnUBVGfSDP7JILfzzh5DPPit4=",
+        "lastModified": 1785859399,
+        "narHash": "sha256-pY4X50au95QrTpAbEm08pURmeU3/Ud2oa0s2XzpDdz8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8b6ce8cca68dd4ced6695be995b5dfb02383c39b",
+        "rev": "85f62611fa3f3eacbcfe3bc7a6d6518b443ca442",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785834239,
-        "narHash": "sha256-1bnRgLt6jVXsc3Qau5sgGAl3OnF/B66YFNQCkWOVMqo=",
+        "lastModified": 1785869730,
+        "narHash": "sha256-AEl8rsH+NrNfzfJ6kdJv+izGSCn8HvzRSNsAfvJ5tp8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "837db2b7f107e3af9d918e9597d2d9825c2bc592",
+        "rev": "344dd4577722bdf97604c89f2239fe8b2cfad301",
         "type": "github"
       },
       "original": {
@@ -876,11 +876,11 @@
     "spectrum": {
       "flake": false,
       "locked": {
-        "lastModified": 1783694892,
-        "narHash": "sha256-xO8f7Qng+18FK2UlB9vcrkxCaQMCt5WjCH24aW/11eg=",
+        "lastModified": 1785761586,
+        "narHash": "sha256-MWOMVqJJERwjQGgRIv8d6rlEBqbLM3VZWxHkNKIIZNw=",
         "ref": "refs/heads/main",
-        "rev": "24c4346e30fdea8d8e80f34aec3554a15a667d24",
-        "revCount": 1410,
+        "rev": "a7762d6f54b40560dd5255ce902e6e6a5d980fe9",
+        "revCount": 1416,
         "type": "git",
         "url": "https://spectrum-os.org/git/spectrum"
       },


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hyprland':
    'github:hyprwm/Hyprland/275e277' (2026-08-04)
  → 'github:hyprwm/Hyprland/ea95499' (2026-08-04)
• Updated input 'microvm':
    'github:microvm-nix/microvm.nix/06544a6' (2026-07-31)
  → 'github:microvm-nix/microvm.nix/e615e23' (2026-08-04)
• Updated input 'microvm/spectrum':
    'git+https://spectrum-os.org/git/spectrum?ref=refs/heads/main&rev=24c4346e30fdea8d8e80f34aec3554a15a667d24' (2026-07-10)
  → 'git+https://spectrum-os.org/git/spectrum?ref=refs/heads/main&rev=a7762d6f54b40560dd5255ce902e6e6a5d980fe9' (2026-08-03)
• Updated input 'nixpkgs-stable-small':
    'github:NixOS/nixpkgs/a7bb645' (2026-08-03)
  → 'github:NixOS/nixpkgs/04607e1' (2026-08-04)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/6438090' (2026-08-02)
  → 'github:NixOS/nixpkgs/e72e4f2' (2026-08-04)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/8b6ce8c' (2026-08-04)
  → 'github:NixOS/nixpkgs/85f6261' (2026-08-04)
• Updated input 'nur':
    'github:nix-community/NUR/837db2b' (2026-08-04)
  → 'github:nix-community/NUR/344dd45' (2026-08-04)
```