### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786083389,
-        "narHash": "sha256-UwV40moUkW3auGrsH0TUINoZ+WnucvHD74svTGOlXHk=",
+        "lastModified": 1786093190,
+        "narHash": "sha256-ZD36Yhj7vzHCU3PqECkVugH6u0YPSHEmC/zhfB0fGQc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6afe7506ab71693328e4331e3390d1421667ec38",
+        "rev": "026c8c044ba1cce784c643e3ca994c3b01ffb60f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/6afe750' (2026-08-07)
  → 'github:nix-community/NUR/026c8c0' (2026-08-07)
```