### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786147086,
-        "narHash": "sha256-UnCGq+lwz5Xw0iTHMbWafNpLqy+WzQ3CYSZ6ueYhT8g=",
+        "lastModified": 1786159389,
+        "narHash": "sha256-XLJtmp7ghDA2N8NapBbRCsgyCHpdbNoMYjYB263K0K8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5cf2d233546f1e654eb3fdd49763e5a7ad2145f4",
+        "rev": "28ccb3f50a6ef04dd158821d6086d9e9ae852fc1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/5cf2d23' (2026-08-07)
  → 'github:nix-community/NUR/28ccb3f' (2026-08-08)
```