### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -678,11 +678,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1786074909,
-        "narHash": "sha256-RXBE0mNKb5O4g5PR6iV43/A0qkibe2MSZ+DDvRS4ELs=",
+        "lastModified": 1786111980,
+        "narHash": "sha256-pBV6CU1fOHWZFgeG2TRFzlG/MjjcTgnOTz5G3o95cH4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5738b3c785613e0f8e0d94662dd5542188bb4dc2",
+        "rev": "d7d1cfd03c6c2e4919d2ddac4a4e9acd6a3f2462",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786159389,
-        "narHash": "sha256-XLJtmp7ghDA2N8NapBbRCsgyCHpdbNoMYjYB263K0K8=",
+        "lastModified": 1786169450,
+        "narHash": "sha256-NMjSDowGu81totBj54xRmrtCKjrmH42rm77vLmePrRQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "28ccb3f50a6ef04dd158821d6086d9e9ae852fc1",
+        "rev": "00fb17e8607406d699e22c22b6835b7a44f66dfa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/5738b3c' (2026-08-07)
  → 'github:NixOS/nixpkgs/d7d1cfd' (2026-08-07)
• Updated input 'nur':
    'github:nix-community/NUR/28ccb3f' (2026-08-08)
  → 'github:nix-community/NUR/00fb17e' (2026-08-08)
```