### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -646,11 +646,11 @@
     },
     "nixpkgs-stable-small": {
       "locked": {
-        "lastModified": 1786089803,
-        "narHash": "sha256-ZuvZfVW2tB5tXYEcpcfhVXB3N4OhdZLOqOviy4OD4b4=",
+        "lastModified": 1786152057,
+        "narHash": "sha256-bzEqlLh3EpIhdSDEb4zWy6w39QbZz/OHR8xEBeY6ZwA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ee48b147c18c7de1e6ec97dc74792be42724bed1",
+        "rev": "6241c49fffa016352c8e757decbdb20541aa9cb2",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786169450,
-        "narHash": "sha256-NMjSDowGu81totBj54xRmrtCKjrmH42rm77vLmePrRQ=",
+        "lastModified": 1786180317,
+        "narHash": "sha256-c2kdQ1omjWy7JCmPkVF1hNQ79C5pk4g9kcKJe4dCOP4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "00fb17e8607406d699e22c22b6835b7a44f66dfa",
+        "rev": "3c48a79060e90361ded0ed3e5bd43c27e5c87b5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs-stable-small':
    'github:NixOS/nixpkgs/ee48b14' (2026-08-07)
  → 'github:NixOS/nixpkgs/6241c49' (2026-08-08)
• Updated input 'nur':
    'github:nix-community/NUR/00fb17e' (2026-08-08)
  → 'github:nix-community/NUR/3c48a79' (2026-08-08)
```