### PR TITLE
Add VS Code Server service configuration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -122,6 +122,24 @@
         "type": "github"
       }
     },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "flake": false,
       "locked": {
@@ -644,6 +662,21 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "lastModified": 1772328832,
+        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nixpkgs-stable-small": {
       "locked": {
         "lastModified": 1786152057,
@@ -829,7 +862,8 @@
         "nur": "nur",
         "quadlet-nix": "quadlet-nix",
         "sops-nix": "sops-nix",
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": "treefmt-nix",
+        "vscode-server": "vscode-server"
       }
     },
     "rust-overlay": {
@@ -921,6 +955,24 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "vscode-server": {
+      "inputs": {
+        "flake-parts": "flake-parts_2"
+      },
+      "locked": {
+        "lastModified": 1784312229,
+        "narHash": "sha256-2uHCSUw341o3my1R0U0YCfbnMEazylxb58evWsjGL50=",
+        "owner": "nix-community",
+        "repo": "nixos-vscode-server",
+        "rev": "2f984dfbe7e5271b5c413d3e734374cc1306c921",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixos-vscode-server",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,8 @@
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    vscode-server.url = "github:nix-community/nixos-vscode-server";
   };
 
   outputs =

--- a/hosts/avalanche/avalanche.nix
+++ b/hosts/avalanche/avalanche.nix
@@ -89,6 +89,8 @@ in
     };
 
     services = {
+      vscode-server.enable = true;
+
       resolved = {
         enableDNS = false;
         enableFallbackDNS = true;

--- a/hosts/snowfall/snowfall.nix
+++ b/hosts/snowfall/snowfall.nix
@@ -105,6 +105,8 @@ in
     };
 
     services = {
+      vscode-server.enable = true;
+
       resolved = {
         enableDNS = false;
         enableFallbackDNS = true;

--- a/modules/services/README.md
+++ b/modules/services/README.md
@@ -121,6 +121,7 @@ ______________________________________________________________________
 | [printing.nix](printing.nix) | `sys.services.printing` | Desktops | CUPS printing |
 | [cockpit.nix](cockpit.nix) | `sys.services.cockpit` | Host (blizzard) | Web-based admin console |
 | [teamviewer.nix](teamviewer.nix) | `sys.services.teamviewer` | Desktops | Remote desktop access |
+| [vscode-server.nix](vscode-server.nix) | `sys.services.vscode-server` | Desktops | NixOS-compatible VS Code Server patching |
 
 #### Containerized Browsers and Search
 

--- a/modules/services/vscode-server.nix
+++ b/modules/services/vscode-server.nix
@@ -1,0 +1,18 @@
+{
+  inputs,
+  lib,
+  config,
+  ...
+}:
+let
+  cfg = config.sys.services.vscode-server;
+in
+{
+  imports = [ inputs.vscode-server.nixosModules.default ];
+
+  options.sys.services.vscode-server.enable = lib.mkEnableOption "VS Code Server";
+
+  config = lib.mkIf cfg.enable {
+    services.vscode-server.enable = true;
+  };
+}


### PR DESCRIPTION
Introduce initial configuration for the VS Code Server service, enabling it in both avalanche and snowfall configurations, and add the service to the service catalog.