### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -307,11 +307,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1786193514,
-        "narHash": "sha256-gcNQ3qP/STcZZJ74a9B0qLaNQRokwJgIvHsDBEzUxTk=",
+        "lastModified": 1786221986,
+        "narHash": "sha256-OXy0AdoS3A9pKqnpQ2OzN2fSoWiuMhxsqzrStxkYXVM=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "a2636192b5033ad4cc621f4209322dd69dc251eb",
+        "rev": "5b1c0fda73fe2ae1ada5ce0cecac43aeab8b0a3b",
         "type": "github"
       },
       "original": {
@@ -749,11 +749,11 @@
     },
     "nixpkgs-stable-small": {
       "locked": {
-        "lastModified": 1786152057,
-        "narHash": "sha256-bzEqlLh3EpIhdSDEb4zWy6w39QbZz/OHR8xEBeY6ZwA=",
+        "lastModified": 1786201459,
+        "narHash": "sha256-CiOTEjmwAmG2AWnaIno9YaCJJmpca2FXPhMAsnrolCg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6241c49fffa016352c8e757decbdb20541aa9cb2",
+        "rev": "8b8c811c7c2541c30382c5de7ed26be055569c60",
         "type": "github"
       },
       "original": {
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786212012,
-        "narHash": "sha256-0pIvMWZeieIti6FGZiWV42PmRPvpij27Ema9RMnRAw0=",
+        "lastModified": 1786221489,
+        "narHash": "sha256-cm3e1A7byPry9B5WN8hPZ6AsqWbdbxuyo3E5yj+akrU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5489bad7acf09f9bd796fee9b6891f3792e88463",
+        "rev": "325373d9baa145ea56b8d657fe06354c1dabb0b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hyprland':
    'github:hyprwm/Hyprland/a263619' (2026-08-08)
  → 'github:hyprwm/Hyprland/5b1c0fd' (2026-08-08)
• Updated input 'nixpkgs-stable-small':
    'github:NixOS/nixpkgs/6241c49' (2026-08-08)
  → 'github:NixOS/nixpkgs/8b8c811' (2026-08-08)
• Updated input 'nur':
    'github:nix-community/NUR/5489bad' (2026-08-08)
  → 'github:nix-community/NUR/325373d' (2026-08-08)
```