### PR TITLE
Add support for Scrutiny service secrets management

### DIFF
--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -72,3 +72,6 @@ jobs:
 
             - name: Run Sandfly target tests
               run: nix build .#checks.x86_64-linux.sandfly-target --no-link --print-build-logs
+
+            - name: Run Scrutiny tests
+              run: nix build .#checks.x86_64-linux.scrutiny --no-link --print-build-logs

--- a/docs/Project_Architecture_Blueprint.md
+++ b/docs/Project_Architecture_Blueprint.md
@@ -45,6 +45,7 @@ ______________________________________________________________________
 | `checks.x86_64-linux.cloudflare-metrics` | Cloudflare metrics Python unit tests |
 | `checks.x86_64-linux.microvm-publication` | Rendered publication contract and failure-case evaluation tests |
 | `checks.x86_64-linux.sandfly-target` | Sandfly target policy, Tailscale, account, and sudo contract tests |
+| `checks.x86_64-linux.scrutiny` | Scrutiny service, secret, and systemd contract tests |
 | `devShells.x86_64-linux.default` | nil, nixfmt, deadnix, statix, sops, ssh-to-age |
 
 There are no `homeConfigurations`, `packages`, `apps`, or `templates` outputs.
@@ -601,6 +602,7 @@ ______________________________________________________________________
 | Run only the Cloudflare metrics tests | `nix build .#checks.x86_64-linux.cloudflare-metrics --no-link --print-build-logs` |
 | Run only the MicroVM publication tests | `nix build .#checks.x86_64-linux.microvm-publication --no-link --print-build-logs` |
 | Run only the Sandfly target tests | `nix build .#checks.x86_64-linux.sandfly-target --no-link --print-build-logs` |
+| Run only the Scrutiny service tests | `nix build .#checks.x86_64-linux.scrutiny --no-link --print-build-logs` |
 | Build without switching | `nix build .#nixosConfigurations.<host>.config.system.build.toplevel` |
 | Apply to current host | `sudo nixos-rebuild switch --flake .#<hostname>` |
 | Test without switching | `sudo nixos-rebuild test --flake .#<hostname>` |
@@ -608,8 +610,8 @@ ______________________________________________________________________
 
 The `flake-check.yml` CI workflow uses `nix flake check --no-build` for
 evaluation, then explicitly builds the Cloudflare metrics, MicroVM publication,
-and Sandfly target checks so their tests execute. Host evaluations run
-separately in `validate-config.yml`.
+Sandfly target, and Scrutiny service checks so their tests execute. Host
+evaluations run separately in `validate-config.yml`.
 
 Hosts: `snowfall`, `blizzard`, `avalanche`, `kaizer`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -75,6 +75,7 @@ flowchart LR
 #### Operations
 
 - [sops-setup-guide.md](sops-setup-guide.md) — How to set up SOPS secrets and age keys
+- [scrutiny.md](scrutiny.md) — Provision, verify, and rotate the Scrutiny InfluxDB token
 - [immich-backup.md](immich-backup.md) — Provision, operate, and restore the Immich offsite backup
 - [pocket-id.md](pocket-id.md) — Deploy, bootstrap, operate, and recover the Pocket ID provider
 - [immich.md](immich.md) — Provision, migrate, rotate, and recover Immich OAuth
@@ -94,6 +95,7 @@ flowchart LR
 | Review architecture decisions | [Public HTTP Publication ADR](adr/0001-model-public-http-publication-as-instance-intent.md) |
 | Review credential lifecycle | [Credential Lifecycle](credential-lifecycle.md) |
 | Back up or restore Immich | [Immich Backup Operations](immich-backup.md) |
+| Operate Scrutiny | [Scrutiny Operations](scrutiny.md) |
 | Operate Pocket ID | [Pocket ID Operations](pocket-id.md) |
 | Operate Immich OAuth | [Immich OAuth Operations](immich.md) |
 | Operate Sandfly targets | [Sandfly Target Operations](sandfly.md) |

--- a/docs/reference-architecture.md
+++ b/docs/reference-architecture.md
@@ -17,6 +17,7 @@ Information reference for this repo's moving parts, options, and commands.
 | `checks.x86_64-linux.cloudflare-metrics` | Cloudflare metrics Python unit tests |
 | `checks.x86_64-linux.microvm-publication` | Rendered publication contract and failure-case evaluation tests |
 | `checks.x86_64-linux.sandfly-target` | Sandfly target policy, Tailscale, account, and sudo contract tests |
+| `checks.x86_64-linux.scrutiny` | Scrutiny service, secret, and systemd contract tests |
 | `devShells.x86_64-linux.default` | Dev shell with nil, nixfmt, deadnix, statix, sops, ssh-to-age |
 
 ### `mkHost` — what it always injects
@@ -171,9 +172,9 @@ Operational tools used across the repo.
 | auto-upgrade | Monthly NixOS upgrades (server role only) | `modules/services/auto-upgrade.nix` |
 
 Locally, `nix flake check` evaluates and builds the formatting, Cloudflare
-metrics, MicroVM publication, and Sandfly target checks. The `flake-check.yml`
+metrics, MicroVM publication, Sandfly target, and Scrutiny service checks. The `flake-check.yml`
 CI workflow first runs `nix flake check --no-build` to evaluate all flake
-outputs, then explicitly builds all three executable test checks. Full host
+outputs, then explicitly builds all four executable test checks. Full host
 evaluation is handled separately by the `validate-config.yml` CI workflow.
 
 ______________________________________________________________________
@@ -290,6 +291,9 @@ nix build .#checks.x86_64-linux.microvm-publication --no-link --print-build-logs
 
 # Build and run only the Sandfly target contract check
 nix build .#checks.x86_64-linux.sandfly-target --no-link --print-build-logs
+
+# Build and run only the Scrutiny service contract check
+nix build .#checks.x86_64-linux.scrutiny --no-link --print-build-logs
 
 # Dev shell (includes nil, nixfmt, deadnix, statix, sops, ssh-to-age)
 nix develop

--- a/docs/reference-ci.md
+++ b/docs/reference-ci.md
@@ -74,7 +74,7 @@ ______________________________________________________________________
 | Workflow | Trigger | Purpose | Auto-commits? |
 |----------|---------|---------|--------------|
 | `auto-format.yml` | PR / push to main / manual | Runs `nix fmt`, commits formatted changes back to the branch, comments on PR, enables auto-merge | Yes — formats in-place |
-| `flake-check.yml` | PR / push to main / manual (filtered to its workflow file, Nix/flake inputs, and Cloudflare collector, test, and dashboard files) | Runs `nix flake check --no-build`, redacts secrets in failure output, and builds the Cloudflare metrics, MicroVM publication, and Sandfly target checks | No |
+| `flake-check.yml` | PR / push to main / manual (filtered to its workflow file, Nix/flake inputs, and Cloudflare collector, test, and dashboard files) | Runs `nix flake check --no-build`, redacts secrets in failure output, and builds the Cloudflare metrics, MicroVM publication, Sandfly target, and Scrutiny service checks | No |
 | `validate-config.yml` | PR / push to main / manual | Discovers hosts via `mkHost` grep, evaluates each host's `config.system.build.toplevel` with `nix eval` in a matrix, and evaluates the Home Manager users attrset | No |
 | `change-impact-analysis.yml` | PR | Diffs changed files under `hosts/`, `modules/`, `home/`, `vms/`, `lib/`, `flake.*`, posts impact report as a PR comment | No |
 | `compliance-check.yml` | PR / push / cron Mon 09:00 | Runs `deadnix` and other Nix linters, comments results | No |
@@ -135,7 +135,7 @@ These run on every pull request:
 | Workflow | What it checks |
 |----------|---------------|
 | `auto-format.yml` | Formats all files and commits back; if this commits, the PR diff is automatically clean |
-| `flake-check.yml` | Evaluates the flake for Nix errors and runs the Cloudflare metrics, MicroVM publication, and Sandfly target checks when Nix/flake inputs or the collector, tests, and dashboard contract change |
+| `flake-check.yml` | Evaluates the flake for Nix errors and runs the Cloudflare metrics, MicroVM publication, Sandfly target, and Scrutiny service checks when Nix/flake inputs or the collector, tests, and dashboard contract change |
 | `validate-config.yml` | Evaluates each host's `config.system.build.toplevel` with `nix eval` in a matrix (does not perform a full build) |
 | `change-impact-analysis.yml` | Posts a comment summarising which layer (hosts, modules, home, vms, lib, flake) is affected |
 | `compliance-check.yml` | Dead-code linting and other Nix hygiene checks |

--- a/docs/scrutiny.md
+++ b/docs/scrutiny.md
@@ -1,0 +1,56 @@
+# Scrutiny Operations
+
+Scrutiny runs on `blizzard`. Its web interface listens on `127.0.0.1:11001`
+and is published through the host's existing reverse-proxy and Cloudflare
+Tunnel configuration. The collector uses the same local endpoint.
+
+## Configure the InfluxDB token
+
+The token is intentionally kept in the private `nix-secrets` flake:
+
+1. Create an InfluxDB API token with the minimum read/write permissions needed
+   for Scrutiny's metrics bucket and organization.
+1. Add the token value under the exact SOPS key `scrutiny/token` in the private
+   secrets repository.
+1. Deploy Blizzard so sops-nix can decrypt the secret. Do not copy the token
+   into this repository or into a host module.
+
+When Scrutiny is enabled, sops-nix creates the root-only secret and a root-only
+systemd EnvironmentFile containing `SCRUTINY_WEB_INFLUXDB_TOKEN`. The Scrutiny
+unit starts after `sops-install-secrets.service` and is restarted when the
+token changes.
+
+## Provision and verify
+
+From a checkout with access to the private secrets flake, deploy the host:
+
+```console
+sudo nixos-rebuild switch --flake .#blizzard
+```
+
+Verify the service without printing the token:
+
+```console
+systemctl is-active scrutiny.service
+systemctl show scrutiny.service --property=EnvironmentFiles
+journalctl -u scrutiny.service -n 50 --no-pager
+```
+
+Open the published Scrutiny hostname and confirm that the collector produces
+current disk data. The service log should not contain InfluxDB authentication
+errors. Use the InfluxDB token audit or usage view, when available, to confirm
+that the replacement token is being used.
+
+## Rotate the token
+
+1. Create a replacement InfluxDB token with the same least-privilege access.
+1. Replace the value at `scrutiny/token` in the private secrets repository.
+1. Deploy Blizzard with the command above. sops-nix queues the Scrutiny unit
+   restart before switching the rendered secret, so the running process gets
+   the new token.
+1. Repeat the service, log, and UI checks above.
+1. Revoke the old InfluxDB token after the new token is confirmed healthy.
+
+If the service was stopped during rotation, inspect its logs first. A manual
+`systemctl restart scrutiny.service` is only a recovery step after the updated
+secret has been deployed; it is not a substitute for updating `scrutiny/token`.

--- a/flake.nix
+++ b/flake.nix
@@ -177,6 +177,11 @@
           inherit (self.nixosConfigurations) snowfall;
           pkgs = nixpkgs.legacyPackages.${system};
         };
+
+        scrutiny = import ./tests/scrutiny.nix {
+          inherit (self.nixosConfigurations) blizzard;
+          pkgs = nixpkgs.legacyPackages.${system};
+        };
       };
 
       devShells.${system}.default = nixpkgs.legacyPackages.${system}.mkShell {

--- a/modules/core/sops.nix
+++ b/modules/core/sops.nix
@@ -28,6 +28,7 @@ let
   hasFirefox = config.sys.services.firefox.enable or false;
   hasBrave = config.sys.services.brave.enable or false;
   hasPushover = config.sys.services.grafanaPushover.enable or false;
+  hasScrutiny = config.sys.services.scrutiny.enable or false;
 
   # Host-specific checks
   isKaizer = config.networking.hostName == "kaizer";
@@ -169,6 +170,13 @@ in
           group = "grafana";
           mode = "0440";
         };
+      }
+      // whenEnabled hasScrutiny {
+        "scrutiny/token" = {
+          owner = "root";
+          group = "root";
+          mode = "0400";
+        };
       };
 
     # Templates for combining secrets (only created when needed)
@@ -277,6 +285,9 @@ in
     // whenEnabled hasPushover {
       pushoverApiTokenFile = toString config.sops.secrets."pushover/api_token".path;
       pushoverUserKeyFile = toString config.sops.secrets."pushover/user_key".path;
+    }
+    // whenEnabled hasScrutiny {
+      scrutinyTokenFile = toString config.sops.secrets."scrutiny/token".path;
     };
 
   environment.systemPackages = [

--- a/modules/core/sops.nix
+++ b/modules/core/sops.nix
@@ -176,6 +176,7 @@ in
           owner = "root";
           group = "root";
           mode = "0400";
+          restartUnits = [ "scrutiny.service" ];
         };
       };
 
@@ -188,6 +189,16 @@ in
           config.sops.placeholder."tokens/gitlab-fa"
         }"
       '';
+    }
+    // whenEnabled hasScrutiny {
+      "scrutiny-environment" = {
+        content = ''
+          SCRUTINY_WEB_INFLUXDB_TOKEN=${config.sops.placeholder."scrutiny/token"}
+        '';
+        owner = "root";
+        group = "root";
+        mode = "0400";
+      };
     }
     // whenEnabled hasGrafanaCloud {
       "grafana-cloud-config".content = ''
@@ -288,6 +299,7 @@ in
     }
     // whenEnabled hasScrutiny {
       scrutinyTokenFile = toString config.sops.secrets."scrutiny/token".path;
+      scrutinyTokenEnvironmentFile = toString config.sops.templates."scrutiny-environment".path;
     };
 
   environment.systemPackages = [

--- a/modules/security/secrets.nix
+++ b/modules/security/secrets.nix
@@ -236,6 +236,12 @@
       description = "Path to a file containing the WireGuard private key. Mapped from SOPS in core/sops.nix.";
     };
 
+    scrutinyTokenFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Path to the InfluxDB API token used by Scrutiny. Mapped from SOPS in core/sops.nix.";
+    };
+
     paperlessSecretKeyFile = lib.mkOption {
       type = lib.types.nullOr lib.types.str;
       default = null;

--- a/modules/security/secrets.nix
+++ b/modules/security/secrets.nix
@@ -242,6 +242,12 @@
       description = "Path to the InfluxDB API token used by Scrutiny. Mapped from SOPS in core/sops.nix.";
     };
 
+    scrutinyTokenEnvironmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Path to the SOPS-rendered EnvironmentFile containing the Scrutiny InfluxDB token. Mapped from core/sops.nix.";
+    };
+
     paperlessSecretKeyFile = lib.mkOption {
       type = lib.types.nullOr lib.types.str;
       default = null;

--- a/modules/services/README.md
+++ b/modules/services/README.md
@@ -71,7 +71,7 @@ ______________________________________________________________________
 | [victoriametrics-remote-write.nix](victoriametrics-remote-write.nix) | `sys.services.victoriametricsRemoteWrite` | Host | Remote-write forwarding |
 | [arr-exporter.nix](arr-exporter.nix) | `sys.services.arrExporter` | MicroVM | Prometheus exporter for Arr stack |
 | [electricity-price-exporter.nix](electricity-price-exporter.nix) | `sys.services.electricityPriceExporter` | Host | Nord Pool electricity price exporter |
-| [scrutiny.nix](scrutiny.nix) | `sys.services.scrutiny` | Host (blizzard) | Disk health monitoring (S.M.A.R.T.) |
+| [scrutiny.nix](scrutiny.nix) | `sys.services.scrutiny` | Host (blizzard) | Disk health monitoring; consumes the root-only `scrutiny/token` SOPS secret as a service credential for local InfluxDB |
 
 #### Infrastructure and Reverse Proxy
 

--- a/modules/services/README.md
+++ b/modules/services/README.md
@@ -71,7 +71,7 @@ ______________________________________________________________________
 | [victoriametrics-remote-write.nix](victoriametrics-remote-write.nix) | `sys.services.victoriametricsRemoteWrite` | Host | Remote-write forwarding |
 | [arr-exporter.nix](arr-exporter.nix) | `sys.services.arrExporter` | MicroVM | Prometheus exporter for Arr stack |
 | [electricity-price-exporter.nix](electricity-price-exporter.nix) | `sys.services.electricityPriceExporter` | Host | Nord Pool electricity price exporter |
-| [scrutiny.nix](scrutiny.nix) | `sys.services.scrutiny` | Host (blizzard) | Disk health monitoring; consumes the root-only `scrutiny/token` SOPS secret as a service credential for local InfluxDB |
+| [scrutiny.nix](scrutiny.nix) | `sys.services.scrutiny` | Host (blizzard) | Disk health monitoring; consumes the root-only `scrutiny/token` SOPS secret as a service credential for local InfluxDB ([runbook](../../docs/scrutiny.md)) |
 
 #### Infrastructure and Reverse Proxy
 

--- a/modules/services/scrutiny.nix
+++ b/modules/services/scrutiny.nix
@@ -1,7 +1,19 @@
-{ lib, config, ... }:
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
 let
   cfg = config.sys.services.scrutiny or { };
   traefikLib = import ../../lib/traefik.nix { inherit lib; };
+  tokenCredential = "scrutiny-token";
+  scrutinyWithToken = pkgs.writeShellScript "scrutiny-with-token" ''
+    set -euo pipefail
+
+    export SCRUTINY_WEB_INFLUXDB_TOKEN="$(<"$CREDENTIALS_DIRECTORY/${tokenCredential}")"
+    exec ${lib.getExe config.services.scrutiny.package} start --config /run/scrutiny/config.yaml
+  '';
 in
 {
   options.sys.services.scrutiny = {
@@ -47,7 +59,10 @@ in
 
       inherit (cfg) openFirewall;
 
-      settings.web.listen.port = cfg.port;
+      settings.web = {
+        listen.port = cfg.port;
+        influxdb.host = "127.0.0.1";
+      };
 
       # The upstream default derives the collector destination from the web
       # listen address.  A wildcard bind address is valid for listening but
@@ -60,6 +75,15 @@ in
       ];
     };
 
+    systemd.services.scrutiny = {
+      after = [ "sops-install-secrets.service" ];
+      requires = [ "sops-install-secrets.service" ];
+      serviceConfig = {
+        ExecStart = lib.mkForce scrutinyWithToken;
+        LoadCredential = "${tokenCredential}:${config.sys.secrets.scrutinyTokenFile}";
+      };
+    };
+
     services.traefik.dynamic.files.scrutiny = traefikLib.mkTraefikDynamicConfig {
       name = "scrutiny";
       inherit cfg config;
@@ -67,6 +91,10 @@ in
     };
 
     assertions = [
+      {
+        assertion = config.sys.secrets.scrutinyTokenFile != null;
+        message = "sys.services.scrutiny requires sys.secrets.scrutinyTokenFile.";
+      }
       (traefikLib.mkCfTunnelAssertion {
         name = "scrutiny";
         inherit cfg;

--- a/modules/services/scrutiny.nix
+++ b/modules/services/scrutiny.nix
@@ -1,19 +1,11 @@
 {
   lib,
   config,
-  pkgs,
   ...
 }:
 let
   cfg = config.sys.services.scrutiny or { };
   traefikLib = import ../../lib/traefik.nix { inherit lib; };
-  tokenCredential = "scrutiny-token";
-  scrutinyWithToken = pkgs.writeShellScript "scrutiny-with-token" ''
-    set -euo pipefail
-
-    export SCRUTINY_WEB_INFLUXDB_TOKEN="$(<"$CREDENTIALS_DIRECTORY/${tokenCredential}")"
-    exec ${lib.getExe config.services.scrutiny.package} start --config /run/scrutiny/config.yaml
-  '';
 in
 {
   options.sys.services.scrutiny = {
@@ -78,9 +70,8 @@ in
     systemd.services.scrutiny = {
       after = [ "sops-install-secrets.service" ];
       requires = [ "sops-install-secrets.service" ];
-      serviceConfig = {
-        ExecStart = lib.mkForce scrutinyWithToken;
-        LoadCredential = "${tokenCredential}:${config.sys.secrets.scrutinyTokenFile}";
+      serviceConfig = lib.mkIf (config.sys.secrets.scrutinyTokenEnvironmentFile != null) {
+        EnvironmentFile = [ config.sys.secrets.scrutinyTokenEnvironmentFile ];
       };
     };
 
@@ -92,8 +83,8 @@ in
 
     assertions = [
       {
-        assertion = config.sys.secrets.scrutinyTokenFile != null;
-        message = "sys.services.scrutiny requires sys.secrets.scrutinyTokenFile.";
+        assertion = config.sys.secrets.scrutinyTokenEnvironmentFile != null;
+        message = "sys.services.scrutiny requires sys.secrets.scrutinyTokenEnvironmentFile.";
       }
       (traefikLib.mkCfTunnelAssertion {
         name = "scrutiny";

--- a/tests/scrutiny.nix
+++ b/tests/scrutiny.nix
@@ -41,9 +41,8 @@ assert !(disabled.config.sops.templates ? "scrutiny-environment");
 assert lib.hasInfix "SCRUTINY_WEB_INFLUXDB_TOKEN=" tokenEnvironmentContent;
 assert lib.any (
   assertion:
-  assertion.message != null
+  !assertion.assertion
   && assertion.message == "sys.services.scrutiny requires sys.secrets.scrutinyTokenEnvironmentFile."
-  && !assertion.assertion
 ) missingToken.config.assertions;
 pkgs.runCommand "scrutiny-tests" { nativeBuildInputs = [ pkgs.gnugrep ]; } ''
   printf '%s\n' ${lib.escapeShellArg tokenEnvironmentContent} | grep -Fq 'SCRUTINY_WEB_INFLUXDB_TOKEN='

--- a/tests/scrutiny.nix
+++ b/tests/scrutiny.nix
@@ -29,7 +29,8 @@ assert cfg.sops.templates."scrutiny-environment".mode == "0400";
 assert cfg.sops.templates."scrutiny-environment".owner == "root";
 assert lib.elem "scrutiny.service" cfg.sops.secrets."scrutiny/token".restartUnits;
 assert cfg.services.scrutiny.settings.web.influxdb.host == "127.0.0.1";
-assert cfg.services.scrutiny.collector.settings.api.endpoint
+assert
+  cfg.services.scrutiny.collector.settings.api.endpoint
   == "http://127.0.0.1:${toString cfg.sys.services.scrutiny.port}";
 assert scrutinyService.serviceConfig.EnvironmentFile == [ tokenEnvironmentPath ];
 assert lib.elem "sops-install-secrets.service" scrutinyService.requires;
@@ -40,8 +41,8 @@ assert !(disabled.config.sops.templates ? "scrutiny-environment");
 assert lib.hasInfix "SCRUTINY_WEB_INFLUXDB_TOKEN=" tokenEnvironmentContent;
 assert lib.any (
   assertion:
-    assertion.message == "sys.services.scrutiny requires sys.secrets.scrutinyTokenEnvironmentFile."
-    && !assertion.assertion
+  assertion.message == "sys.services.scrutiny requires sys.secrets.scrutinyTokenEnvironmentFile."
+  && !assertion.assertion
 ) missingToken.config.assertions;
 pkgs.runCommand "scrutiny-tests" { nativeBuildInputs = [ pkgs.gnugrep ]; } ''
   printf '%s\n' ${lib.escapeShellArg tokenEnvironmentContent} | grep -Fq 'SCRUTINY_WEB_INFLUXDB_TOKEN='

--- a/tests/scrutiny.nix
+++ b/tests/scrutiny.nix
@@ -41,7 +41,8 @@ assert !(disabled.config.sops.templates ? "scrutiny-environment");
 assert lib.hasInfix "SCRUTINY_WEB_INFLUXDB_TOKEN=" tokenEnvironmentContent;
 assert lib.any (
   assertion:
-  assertion.message == "sys.services.scrutiny requires sys.secrets.scrutinyTokenEnvironmentFile."
+  assertion.message != null
+  && assertion.message == "sys.services.scrutiny requires sys.secrets.scrutinyTokenEnvironmentFile."
   && !assertion.assertion
 ) missingToken.config.assertions;
 pkgs.runCommand "scrutiny-tests" { nativeBuildInputs = [ pkgs.gnugrep ]; } ''

--- a/tests/scrutiny.nix
+++ b/tests/scrutiny.nix
@@ -3,6 +3,8 @@ let
   inherit (pkgs) lib;
   cfg = blizzard.config;
   tokenPath = cfg.sops.secrets."scrutiny/token".path;
+  tokenEnvironmentPath = cfg.sops.templates."scrutiny-environment".path;
+  tokenEnvironmentContent = cfg.sops.templates."scrutiny-environment".content;
   scrutinyService = cfg.systemd.services.scrutiny;
   disabled = blizzard.extendModules {
     modules = [
@@ -11,20 +13,37 @@ let
       }
     ];
   };
+  missingToken = blizzard.extendModules {
+    modules = [
+      {
+        sys.secrets.scrutinyTokenEnvironmentFile = lib.mkForce null;
+      }
+    ];
+  };
 in
 assert cfg.sys.secrets.scrutinyTokenFile == tokenPath;
+assert cfg.sys.secrets.scrutinyTokenEnvironmentFile == tokenEnvironmentPath;
 assert cfg.sops.secrets."scrutiny/token".mode == "0400";
 assert cfg.sops.secrets."scrutiny/token".owner == "root";
+assert cfg.sops.templates."scrutiny-environment".mode == "0400";
+assert cfg.sops.templates."scrutiny-environment".owner == "root";
+assert lib.elem "scrutiny.service" cfg.sops.secrets."scrutiny/token".restartUnits;
 assert cfg.services.scrutiny.settings.web.influxdb.host == "127.0.0.1";
-assert cfg.services.scrutiny.collector.settings.api.endpoint == "http://127.0.0.1:11001";
-assert scrutinyService.serviceConfig.LoadCredential == "scrutiny-token:${tokenPath}";
+assert cfg.services.scrutiny.collector.settings.api.endpoint
+  == "http://127.0.0.1:${toString cfg.sys.services.scrutiny.port}";
+assert scrutinyService.serviceConfig.EnvironmentFile == [ tokenEnvironmentPath ];
 assert lib.elem "sops-install-secrets.service" scrutinyService.requires;
 assert lib.elem "sops-install-secrets.service" scrutinyService.after;
-assert lib.hasInfix "scrutiny-with-token" scrutinyService.serviceConfig.ExecStart;
 assert cfg.services.scrutiny.settings.web.influxdb.token == null;
 assert !(disabled.config.sops.secrets ? "scrutiny/token");
+assert !(disabled.config.sops.templates ? "scrutiny-environment");
+assert lib.hasInfix "SCRUTINY_WEB_INFLUXDB_TOKEN=" tokenEnvironmentContent;
+assert lib.any (
+  assertion:
+    assertion.message == "sys.services.scrutiny requires sys.secrets.scrutinyTokenEnvironmentFile."
+    && !assertion.assertion
+) missingToken.config.assertions;
 pkgs.runCommand "scrutiny-tests" { nativeBuildInputs = [ pkgs.gnugrep ]; } ''
-  grep -Fq '$CREDENTIALS_DIRECTORY/scrutiny-token' ${scrutinyService.serviceConfig.ExecStart}
-  grep -Fq 'SCRUTINY_WEB_INFLUXDB_TOKEN' ${scrutinyService.serviceConfig.ExecStart}
+  printf '%s\n' ${lib.escapeShellArg tokenEnvironmentContent} | grep -Fq 'SCRUTINY_WEB_INFLUXDB_TOKEN='
   touch "$out"
 ''

--- a/tests/scrutiny.nix
+++ b/tests/scrutiny.nix
@@ -1,0 +1,30 @@
+{ blizzard, pkgs }:
+let
+  inherit (pkgs) lib;
+  cfg = blizzard.config;
+  tokenPath = cfg.sops.secrets."scrutiny/token".path;
+  scrutinyService = cfg.systemd.services.scrutiny;
+  disabled = blizzard.extendModules {
+    modules = [
+      {
+        sys.services.scrutiny.enable = lib.mkForce false;
+      }
+    ];
+  };
+in
+assert cfg.sys.secrets.scrutinyTokenFile == tokenPath;
+assert cfg.sops.secrets."scrutiny/token".mode == "0400";
+assert cfg.sops.secrets."scrutiny/token".owner == "root";
+assert cfg.services.scrutiny.settings.web.influxdb.host == "127.0.0.1";
+assert cfg.services.scrutiny.collector.settings.api.endpoint == "http://127.0.0.1:11001";
+assert scrutinyService.serviceConfig.LoadCredential == "scrutiny-token:${tokenPath}";
+assert lib.elem "sops-install-secrets.service" scrutinyService.requires;
+assert lib.elem "sops-install-secrets.service" scrutinyService.after;
+assert lib.hasInfix "scrutiny-with-token" scrutinyService.serviceConfig.ExecStart;
+assert cfg.services.scrutiny.settings.web.influxdb.token == null;
+assert !(disabled.config.sops.secrets ? "scrutiny/token");
+pkgs.runCommand "scrutiny-tests" { nativeBuildInputs = [ pkgs.gnugrep ]; } ''
+  grep -Fq '$CREDENTIALS_DIRECTORY/scrutiny-token' ${scrutinyService.serviceConfig.ExecStart}
+  grep -Fq 'SCRUTINY_WEB_INFLUXDB_TOKEN' ${scrutinyService.serviceConfig.ExecStart}
+  touch "$out"
+''


### PR DESCRIPTION
Introduce SOPS-based secrets management for the Scrutiny service, including a new option for the InfluxDB API token. Update documentation to reflect these changes and enhance service configuration with systemd integration. Add tests to ensure proper functionality of the new features.