### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -583,11 +583,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1785843289,
-        "narHash": "sha256-H/0YgQ+3BtNbdeSVuqjU7ElneBzPPuIKcuWOi0ZUktQ=",
+        "lastModified": 1786300091,
+        "narHash": "sha256-4UFJOVGpaYtHW5yasSv80MaJxTBYdk2zyf3jhKtt0wA=",
         "owner": "microvm-nix",
         "repo": "microvm.nix",
-        "rev": "e615e23267bf10d483fb44f759d4e61c354cc0f4",
+        "rev": "71beea0076cd46dafcee97a5a2e7d00cbba5bd2f",
         "type": "github"
       },
       "original": {
@@ -638,11 +638,11 @@
     },
     "nix-secrets": {
       "locked": {
-        "lastModified": 1784449690,
-        "narHash": "sha256-6RzEKGpykw4f6OvSn7oe3vquux4B6P1hQrgap8KONoE=",
+        "lastModified": 1786300000,
+        "narHash": "sha256-dSqMpzQMyqOf4b0i0QTN6cV7R7zE2+J6Pxm+rvKyvD0=",
         "ref": "refs/heads/master",
-        "rev": "89f2ffa1093f842e46a3c5e5bdfd7a619ac98c90",
-        "revCount": 128,
+        "rev": "6b01eb686b202fcd9044eecbc7c3facee8f971c0",
+        "revCount": 129,
         "type": "git",
         "url": "ssh://git@github.com/telometto/nix-secrets.git"
       },
@@ -688,11 +688,11 @@
     },
     "nixpkgs-beta": {
       "locked": {
-        "lastModified": 1786089803,
-        "narHash": "sha256-ZuvZfVW2tB5tXYEcpcfhVXB3N4OhdZLOqOviy4OD4b4=",
+        "lastModified": 1786201459,
+        "narHash": "sha256-CiOTEjmwAmG2AWnaIno9YaCJJmpca2FXPhMAsnrolCg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ee48b147c18c7de1e6ec97dc74792be42724bed1",
+        "rev": "8b8c811c7c2541c30382c5de7ed26be055569c60",
         "type": "github"
       },
       "original": {
@@ -826,11 +826,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1786089803,
-        "narHash": "sha256-ZuvZfVW2tB5tXYEcpcfhVXB3N4OhdZLOqOviy4OD4b4=",
+        "lastModified": 1786201459,
+        "narHash": "sha256-CiOTEjmwAmG2AWnaIno9YaCJJmpca2FXPhMAsnrolCg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ee48b147c18c7de1e6ec97dc74792be42724bed1",
+        "rev": "8b8c811c7c2541c30382c5de7ed26be055569c60",
         "type": "github"
       },
       "original": {
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786296971,
-        "narHash": "sha256-i/L0mDpkn+DR77KVniuNfxxEcdk4D/MGfIon3lg3l+Y=",
+        "lastModified": 1786309555,
+        "narHash": "sha256-l4Ng8jS3jzRdYouymJD7YOq9sMzRrxAls0xbMPF7TF8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "be872ed694def544d3e2dd006747431cfbcf00b7",
+        "rev": "bca779015d428962ad1ff89cb27fc60d21994bd6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'microvm':
    'github:microvm-nix/microvm.nix/e615e23' (2026-08-04)
  → 'github:microvm-nix/microvm.nix/71beea0' (2026-08-09)
• Updated input 'nix-secrets':
    'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=89f2ffa1093f842e46a3c5e5bdfd7a619ac98c90' (2026-07-19)
  → 'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=6b01eb686b202fcd9044eecbc7c3facee8f971c0' (2026-08-09)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/ee48b14' (2026-08-07)
  → 'github:NixOS/nixpkgs/8b8c811' (2026-08-08)
• Updated input 'nixpkgs-beta':
    'github:NixOS/nixpkgs/ee48b14' (2026-08-07)
  → 'github:NixOS/nixpkgs/8b8c811' (2026-08-08)
• Updated input 'nur':
    'github:nix-community/NUR/be872ed' (2026-08-09)
  → 'github:nix-community/NUR/bca7790' (2026-08-09)
```