### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786309555,
-        "narHash": "sha256-l4Ng8jS3jzRdYouymJD7YOq9sMzRrxAls0xbMPF7TF8=",
+        "lastModified": 1786320258,
+        "narHash": "sha256-hR4Myisuhk/udOtZsXjfJ0wZDm+RfHK2AszieBK9Nn0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bca779015d428962ad1ff89cb27fc60d21994bd6",
+        "rev": "ed09303570f0d40caebd332eacb9d0726492be4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/bca7790' (2026-08-09)
  → 'github:nix-community/NUR/ed09303' (2026-08-10)
```