### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -656,11 +656,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1785232496,
-        "narHash": "sha256-65EQYIRRpTdpH8lUiB6Mvo5uBkG60aBIzAJuALfx+O0=",
+        "lastModified": 1786437054,
+        "narHash": "sha256-I++HzBBAgQ17UaLVU6aSm1/7LDo6c9xr8rAbpByWywE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "2e790b0a6be8ec2b76174ac0931b8ff11919ec98",
+        "rev": "6ed13b1d888d5cb07dbb0723eb1df86bbacd0b9c",
         "type": "github"
       },
       "original": {
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786428725,
-        "narHash": "sha256-SKQ4bpTQkvxz9spWQAHy5Rnw1EFQIaEmUEKoqNm3CFc=",
+        "lastModified": 1786439692,
+        "narHash": "sha256-tiZQBGSS4Ent2h/ceb4KOFIbgJxZ+bry51R7PxeK730=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a821f94ee108a0cc424c3601d0e35bdff2643609",
+        "rev": "8a2e89bd4ab9173da401b1972a6e0f59c4a03b5f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/2e790b0' (2026-07-28)
  → 'github:NixOS/nixos-hardware/6ed13b1' (2026-08-11)
• Updated input 'nur':
    'github:nix-community/NUR/a821f94' (2026-08-11)
  → 'github:nix-community/NUR/8a2e89b' (2026-08-11)
```