### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -749,11 +749,11 @@
     },
     "nixpkgs-stable-small": {
       "locked": {
-        "lastModified": 1786406179,
-        "narHash": "sha256-G5V+1/X3OUwVdR9epI4QwNhX3wdvdWKfdPjhD5+rPEE=",
+        "lastModified": 1786475971,
+        "narHash": "sha256-2ff+1XMU7f12vBmi0wS8fdP84kqn6CAtw+B5xqH+NpE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b7b64e4e5a21c558b6c9fa149e94a5b99ca87a7f",
+        "rev": "53f9fac44b4058e46a6105d8e0415857ea12f0d7",
         "type": "github"
       },
       "original": {
@@ -781,11 +781,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1786463514,
-        "narHash": "sha256-lDVA1kYvHuXlcwnBss5Ws70qskNSIwaDLhI9+MIEyiM=",
+        "lastModified": 1786476143,
+        "narHash": "sha256-bKD012WTTrR0/I6/Ab0Yx1JwO9OvUdhfzllFlfLE9Aw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5c406c24ab27a146b8321f419a5536e3cf6842a0",
+        "rev": "ef33b28e97233dac04666e34f26027c44f5db08b",
         "type": "github"
       },
       "original": {
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786471893,
-        "narHash": "sha256-tufRDMltVfXaEARt9eYDUK6dymb7GTUm5aASe1c/Xqk=",
+        "lastModified": 1786482499,
+        "narHash": "sha256-dMxvaTLnj5E2Eg9K10PmSCMNrZ7+Rif66eHa6an9AEQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "80da5c335546d6c3992c230c6f4c23a3729487e7",
+        "rev": "b509d66ed8778ee9b36016206c9c3727db13011b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs-stable-small':
    'github:NixOS/nixpkgs/b7b64e4' (2026-08-10)
  → 'github:NixOS/nixpkgs/53f9fac' (2026-08-11)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/5c406c2' (2026-08-11)
  → 'github:NixOS/nixpkgs/ef33b28' (2026-08-11)
• Updated input 'nur':
    'github:nix-community/NUR/80da5c3' (2026-08-11)
  → 'github:nix-community/NUR/b509d66' (2026-08-11)
```