### PR TITLE
Add service availability dashboard and monitoring configuration

### DIFF
--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -9,7 +9,8 @@ dashboards/
 ├── shared/              # Dashboards usable across hosts
 │   ├── arr-services.json
 │   ├── electricity-prices.json
-│   └── power-consumption.json
+│   ├── power-consumption.json
+│   └── service-availability.json
 └── host/
     └── blizzard/        # Host-specific dashboards
         ├── zfs-overview.json
@@ -25,6 +26,7 @@ dashboards/
 | [arr-services.json](shared/arr-services.json) | \*arr stack service metrics (Sonarr/Radarr/Prowlarr/etc.) | arr-exporter |
 | [electricity-prices.json](shared/electricity-prices.json) | Energy pricing visualization | Electricity price exporter |
 | [power-consumption.json](shared/power-consumption.json) | Real-time power usage | Smart plug metrics |
+| [service-availability.json](shared/service-availability.json) | Public HTTP/TLS blackbox probe health | Prometheus blackbox exporter |
 
 ### Host-Specific Dashboards
 

--- a/dashboards/shared/service-availability.json
+++ b/dashboards/shared/service-availability.json
@@ -1,0 +1,340 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": false,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "Down"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "Up"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "color": "gray",
+                  "text": "No data"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "probe_success{job=\"blackbox\"}",
+          "legendFormat": "{{service}} / {{probe}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Public probe success",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "probe_duration_seconds{job=\"blackbox\"}",
+          "legendFormat": "{{service}} / {{probe}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Probe duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "probe_http_status_code{job=\"blackbox\"}",
+          "legendFormat": "{{service}} / {{probe}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 30
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "d"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(probe_ssl_earliest_cert_expiry{job=\"blackbox\"} - time()) / 86400",
+          "legendFormat": "{{service}} / {{probe}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "TLS certificate days remaining",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "availability",
+    "blackbox"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Public Service Availability",
+  "uid": "service-availability",
+  "version": 1,
+  "weekStart": ""
+}

--- a/flake.nix
+++ b/flake.nix
@@ -179,6 +179,11 @@
           blizzard = self.nixosConfigurations.blizzard;
         };
 
+        blackbox-observability = import ./tests/blackbox-observability.nix {
+          blizzard = self.nixosConfigurations.blizzard;
+          pkgs = nixpkgs.legacyPackages.${system};
+        };
+
         microvm-network-policy = import ./tests/microvm-network-policy.nix {
           inherit (nixpkgs) lib;
           inherit (self.nixosConfigurations) blizzard;

--- a/hosts/blizzard/monitoring/blackbox.nix
+++ b/hosts/blizzard/monitoring/blackbox.nix
@@ -1,0 +1,38 @@
+{ VARS, ... }:
+let
+  matrixBaseUrl = "https://matrix.${VARS.domains.public}";
+in
+{
+  sys.services.blackbox = {
+    enable = true;
+
+    # These targets deliberately use public URLs. They exercise DNS,
+    # Cloudflare Tunnel, Traefik/CrowdSec, Nginx, and the Matrix services.
+    targets = [
+      {
+        service = "matrix";
+        name = "client-api";
+        url = "${matrixBaseUrl}/_matrix/client/versions";
+        requiredJsonFields = [ "versions" ];
+      }
+      {
+        service = "matrix";
+        name = "oidc-discovery";
+        url = "${matrixBaseUrl}/.well-known/openid-configuration";
+        expectedJsonFields.issuer = "${matrixBaseUrl}/";
+      }
+      {
+        service = "matrix";
+        name = "federation-discovery";
+        url = "https://${VARS.domains.public}/.well-known/matrix/server";
+        expectedJsonFields."m.server" = "matrix.${VARS.domains.public}:443";
+      }
+      {
+        service = "matrix";
+        name = "federation-endpoint";
+        url = "${matrixBaseUrl}/_matrix/federation/v1/version";
+        requiredJsonFields = [ "server" ];
+      }
+    ];
+  };
+}

--- a/hosts/blizzard/monitoring/grafana.nix
+++ b/hosts/blizzard/monitoring/grafana.nix
@@ -25,6 +25,7 @@ in
       "power-consumption-historical" = grafanaDashboards.custom.power-consumption-historical;
       "ups-monitoring" = grafanaDashboards.custom.ups-monitoring;
       "electricity-prices" = grafanaDashboards.custom.electricity-prices;
+      "service-availability" = grafanaDashboards.custom.service-availability;
     };
 
     reverseProxy = {

--- a/lib/grafana-dashboards.nix
+++ b/lib/grafana-dashboards.nix
@@ -38,6 +38,7 @@ rec {
     power-consumption-historical = ../dashboards/host/blizzard/power-consumption-historical.json;
     ups-monitoring = ../dashboards/host/blizzard/ups-monitoring.json;
     electricity-prices = ../dashboards/shared/electricity-prices.json;
+    service-availability = ../dashboards/shared/service-availability.json;
   };
 
   all = community // custom;

--- a/modules/services/README.md
+++ b/modules/services/README.md
@@ -64,6 +64,7 @@ ______________________________________________________________________
 | [grafana.nix](grafana.nix) | `sys.services.grafana` | Host (blizzard) | Dashboards and alerting |
 | [grafana-cloud.nix](grafana-cloud.nix) | `sys.services.grafanaCloud` | Host | Grafana Cloud remote-write config |
 | [grafana-pushover.nix](grafana-pushover.nix) | `sys.services.grafanaPushover` | Host | Pushover alert contact point |
+| [blackbox.nix](blackbox.nix) | `sys.services.blackbox` | Host | Public HTTP/TLS availability probes |
 | [cloudflare-metrics.nix](cloudflare-metrics.nix) | `sys.services.cloudflareMetrics` | Host (blizzard) | Cloudflare HTTP analytics and Access authentication Prometheus collector ([runbook](../../docs/cloudflare-metrics.md)) |
 | [prometheus.nix](prometheus.nix) | `sys.services.prometheus` | Host (blizzard) | Metrics collection |
 | [prometheus-exporters.nix](prometheus-exporters.nix) | `sys.services.prometheusExporters` | Host + VMs | System metrics exporters |

--- a/modules/services/blackbox.nix
+++ b/modules/services/blackbox.nix
@@ -1,0 +1,244 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.sys.services.blackbox;
+  blackboxPort = 9115;
+  scrapeInterval = "30s";
+  failureWindow = "5m";
+
+  targetType = lib.types.submodule {
+    options = {
+      service = lib.mkOption {
+        type = lib.types.strMatching "[a-z][a-z0-9_-]*";
+        description = "Stable service label used by availability metrics and alerts.";
+      };
+
+      name = lib.mkOption {
+        type = lib.types.strMatching "[a-z][a-z0-9_-]*";
+        description = "Stable name for the public probe.";
+      };
+
+      url = lib.mkOption {
+        type = lib.types.str;
+        description = "Public URL to probe.";
+      };
+
+      requiredJsonFields = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        description = "JSON object fields that must be present in a successful response.";
+      };
+
+      expectedJsonFields = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+        description = "JSON object fields whose string values must match exactly.";
+      };
+    };
+  };
+
+  moduleName = target: "http_${target.service}_${target.name}";
+
+  bodyPatterns =
+    target:
+    (map (field: ''"${lib.escapeRegex field}"[[:space:]]*:'') target.requiredJsonFields)
+    ++ (lib.mapAttrsToList (
+      field: value: ''"${lib.escapeRegex field}"[[:space:]]*:[[:space:]]*"${lib.escapeRegex value}"''
+    ) target.expectedJsonFields);
+
+  blackboxModule = target: {
+    prober = "http";
+    timeout = "10s";
+    http = {
+      method = "GET";
+      preferred_ip_protocol = "ip4";
+      valid_http_versions = [
+        "HTTP/1.1"
+        "HTTP/2.0"
+      ];
+      valid_status_codes = [ 200 ];
+    }
+    // lib.optionalAttrs (bodyPatterns target != [ ]) {
+      fail_if_body_not_matches_regexp = bodyPatterns target;
+    };
+  };
+
+  blackboxConfig = {
+    modules = lib.listToAttrs (
+      map (target: {
+        name = moduleName target;
+        value = blackboxModule target;
+      }) cfg.targets
+    );
+  };
+
+  scrapeConfig = {
+    job_name = "blackbox";
+    scrape_interval = scrapeInterval;
+    scrape_timeout = "15s";
+    metrics_path = "/probe";
+    static_configs = map (target: {
+      targets = [ target.url ];
+      labels = {
+        blackbox_module = moduleName target;
+        probe = target.name;
+        inherit (target) service;
+      };
+    }) cfg.targets;
+    relabel_configs = [
+      {
+        source_labels = [ "__address__" ];
+        target_label = "__param_target";
+      }
+      {
+        source_labels = [ "blackbox_module" ];
+        target_label = "__param_module";
+      }
+      {
+        source_labels = [ "__param_target" ];
+        target_label = "instance";
+      }
+      {
+        target_label = "__address__";
+        replacement = "127.0.0.1:${toString blackboxPort}";
+      }
+      {
+        action = "labeldrop";
+        regex = "blackbox_module";
+      }
+    ];
+  };
+
+  prometheusDatasource = {
+    type = "prometheus";
+    uid = "prometheus";
+  };
+
+  availabilityRuleGroup = {
+    orgId = 1;
+    name = "public-service-availability";
+    folder = "Service Availability";
+    interval = scrapeInterval;
+    rules = [
+      {
+        uid = "public-service-probe-failed";
+        title = "Public service probe failed";
+        condition = "A";
+        execErrState = "Error";
+        for = failureWindow;
+        isPaused = false;
+        noDataState = "OK";
+        data = [
+          {
+            refId = "A";
+            relativeTimeRange = {
+              from = 300;
+              to = 0;
+            };
+            datasourceUid = prometheusDatasource.uid;
+            model = {
+              datasource = prometheusDatasource;
+              editorMode = "code";
+              expr = ''min by (service, probe) (probe_success{job="blackbox"}) < 1'';
+              instant = true;
+              interval = "";
+              intervalMs = 30000;
+              maxDataPoints = 43200;
+              range = false;
+              refId = "A";
+            };
+          }
+        ];
+        annotations = {
+          summary = "Public {{ $labels.service }} probe failed: {{ $labels.probe }}";
+          description = "The public probe has failed continuously for five minutes. Check the public route, Cloudflare Tunnel, Traefik/CrowdSec, and the target service.";
+        };
+        labels = {
+          alert_group = "public-service-availability";
+          severity = "critical";
+        };
+      }
+    ];
+  };
+
+  targetKeys = map (target: "${target.service}/${target.name}") cfg.targets;
+in
+{
+  options.sys.services.blackbox = {
+    enable = lib.mkEnableOption "Prometheus blackbox public availability probes";
+
+    targets = lib.mkOption {
+      type = lib.types.listOf targetType;
+      default = [ ];
+      description = ''
+        Public endpoints to probe. The module owns the exporter modules,
+        Prometheus relabeling, common alert, and availability labels.
+      '';
+      example = lib.literalExpression ''
+        [
+          {
+            service = "example";
+            name = "homepage";
+            url = "https://example.com/";
+          }
+        ]
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.targets != [ ];
+        message = "sys.services.blackbox.targets must not be empty when blackbox probes are enabled";
+      }
+      {
+        assertion = builtins.length targetKeys == builtins.length (lib.unique targetKeys);
+        message = "sys.services.blackbox target service/name pairs must be unique";
+      }
+      {
+        assertion = config.sys.services.prometheus.enable or false;
+        message = "sys.services.blackbox requires sys.services.prometheus.enable";
+      }
+    ];
+
+    services.prometheus.exporters.blackbox = {
+      enable = true;
+      listenAddress = "127.0.0.1";
+      port = blackboxPort;
+      configFile = pkgs.writeText "blackbox-exporter.json" (builtins.toJSON blackboxConfig);
+      enableConfigCheck = true;
+    };
+
+    sys.services.prometheus.extraScrapeConfigs = [ scrapeConfig ];
+
+    # HTTP/TLS probes do not use ICMP. Remove the upstream module's default
+    # CAP_NET_RAW and keep the exporter read-only apart from its runtime state.
+    systemd.services.prometheus-blackbox-exporter.serviceConfig = {
+      AmbientCapabilities = lib.mkForce [ ];
+      CapabilityBoundingSet = lib.mkForce [ ];
+      LockPersonality = true;
+      NoNewPrivileges = true;
+      PrivateDevices = true;
+      PrivateTmp = true;
+      ProtectHome = true;
+      ProtectSystem = "strict";
+      RestrictAddressFamilies = lib.mkForce [
+        "AF_INET"
+        "AF_INET6"
+      ];
+      RestrictNamespaces = true;
+      RestrictRealtime = true;
+      RestrictSUIDSGID = true;
+      SystemCallArchitectures = "native";
+    };
+
+    services.grafana.provision.alerting.rules.settings.groups =
+      lib.mkIf (config.sys.services.grafana.enable or false)
+        (lib.mkAfter [ availabilityRuleGroup ]);
+  };
+}

--- a/tests/blackbox-observability.nix
+++ b/tests/blackbox-observability.nix
@@ -1,0 +1,91 @@
+{
+  blizzard,
+  pkgs,
+}:
+let
+  inherit (pkgs) lib;
+  cfg = blizzard.config;
+  blackbox = cfg.sys.services.blackbox;
+  exporter = cfg.services.prometheus.exporters.blackbox;
+  exporterUnit = cfg.systemd.services.prometheus-blackbox-exporter;
+  scrape = lib.findFirst (
+    item: item.job_name == "blackbox"
+  ) null cfg.services.prometheus.scrapeConfigs;
+  alertGroups = cfg.services.grafana.provision.alerting.rules.settings.groups;
+  availabilityGroup = lib.findFirst (
+    group: group.name == "public-service-availability"
+  ) null alertGroups;
+  availabilityRule = lib.findFirst (
+    rule: rule.uid == "public-service-probe-failed"
+  ) null availabilityGroup.rules;
+  dashboard = builtins.fromJSON (
+    builtins.readFile cfg.sys.services.grafana.provision.dashboards.service-availability
+  );
+  blackboxConfig = builtins.fromJSON (builtins.readFile exporter.configFile);
+  expectedTargets = [
+    "matrix/client-api"
+    "matrix/oidc-discovery"
+    "matrix/federation-discovery"
+    "matrix/federation-endpoint"
+  ];
+in
+assert blackbox.enable;
+assert map (target: "${target.service}/${target.name}") blackbox.targets == expectedTargets;
+assert exporter.enable;
+assert exporter.listenAddress == "127.0.0.1";
+assert exporter.port == 9115;
+assert exporterUnit.serviceConfig.AmbientCapabilities == [ ];
+assert exporterUnit.serviceConfig.CapabilityBoundingSet == [ ];
+assert
+  exporterUnit.serviceConfig.RestrictAddressFamilies == [
+    "AF_INET"
+    "AF_INET6"
+  ];
+assert builtins.length (builtins.attrNames blackboxConfig.modules) == 4;
+assert lib.all (
+  module:
+  module.prober == "http"
+  && module.timeout == "10s"
+  && module.http.method == "GET"
+  && module.http.valid_status_codes == [ 200 ]
+) (builtins.attrValues blackboxConfig.modules);
+assert lib.any (pattern: lib.hasInfix "issuer" pattern) (
+  blackboxConfig.modules."http_matrix_oidc-discovery".http.fail_if_body_not_matches_regexp
+);
+assert lib.any (pattern: lib.hasInfix "m\\.server" pattern) (
+  blackboxConfig.modules."http_matrix_federation-discovery".http.fail_if_body_not_matches_regexp
+);
+assert scrape != null;
+assert scrape.scrape_interval == "30s";
+assert scrape.scrape_timeout == "15s";
+assert scrape.metrics_path == "/probe";
+assert builtins.length scrape.static_configs == 4;
+assert lib.hasPrefix "https://" (builtins.head (builtins.head scrape.static_configs).targets);
+assert lib.any (relabel: relabel.target_label or null == "__param_target") scrape.relabel_configs;
+assert lib.any (relabel: relabel.target_label or null == "__param_module") scrape.relabel_configs;
+assert lib.any (relabel: relabel.target_label or null == "instance") scrape.relabel_configs;
+assert lib.any (relabel: relabel.replacement or null == "127.0.0.1:9115") scrape.relabel_configs;
+assert availabilityGroup != null;
+assert availabilityGroup.interval == "30s";
+assert availabilityRule != null;
+assert availabilityRule.for == "5m";
+assert availabilityRule.noDataState == "OK";
+assert lib.hasInfix "probe_success" (builtins.head availabilityRule.data).model.expr;
+assert lib.hasInfix ''job="blackbox"'' (builtins.head availabilityRule.data).model.expr;
+assert lib.hasInfix "five minutes" availabilityRule.annotations.description;
+assert dashboard.uid == "service-availability";
+assert dashboard.title == "Public Service Availability";
+assert dashboard.refresh == "30s";
+assert lib.any (
+  panel:
+  lib.any (target: lib.hasInfix "probe_success{job=\"blackbox\"}" (target.expr or "")) (
+    panel.targets or [ ]
+  )
+) dashboard.panels;
+assert lib.any (
+  panel:
+  lib.any (target: lib.hasInfix "probe_ssl_earliest_cert_expiry" (target.expr or "")) (
+    panel.targets or [ ]
+  )
+) dashboard.panels;
+pkgs.runCommand "blackbox-observability-tests" { } "touch $out"


### PR DESCRIPTION
Introduce a new dashboard for monitoring public service availability, along with necessary configurations for blackbox probes and observability tests. Update documentation to reflect these changes and ensure integration with Grafana.