### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -197,11 +197,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786538400,
-        "narHash": "sha256-PH8B1YKxedcWKNw2xsk6cKPVk/rJoLgdlWd5d+Icies=",
+        "lastModified": 1786603258,
+        "narHash": "sha256-j1lYPT7YxOQc/G7NcJKqdpQ5/A5yX2aZdhVKkJR6cM4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e13ba5e5abbd9b912fa8c6979bd119e87ca7fdd9",
+        "rev": "0668fdbc15bd602e463cab37ff64346021193652",
         "type": "github"
       },
       "original": {
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786601925,
-        "narHash": "sha256-ELx8PFHvjhnyy3TNszRlyDsiif52yAqEWuWM2D03580=",
+        "lastModified": 1786612668,
+        "narHash": "sha256-drUMW/BXNEKe5wzw2yM7ea/g7CnObPcwRNVp9ap0yQk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c0014e9f958e28467e4c0f6a50edd67f67bbf321",
+        "rev": "a5ef785fafbf01c361372d7dc8e0f1591aeeacd3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hm-master':
    'github:nix-community/home-manager/e13ba5e' (2026-08-12)
  → 'github:nix-community/home-manager/0668fdb' (2026-08-13)
• Updated input 'nur':
    'github:nix-community/NUR/c0014e9' (2026-08-13)
  → 'github:nix-community/NUR/a5ef785' (2026-08-13)
```