### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -765,11 +765,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1786514691,
-        "narHash": "sha256-9dkt1i5JNbEfPb+EjLcSDNs8zqEHQ/1JlSaKgj0SBAg=",
+        "lastModified": 1786599213,
+        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "867dcbc30bafe3c862ef88620f2e7a109d7d3be5",
+        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
         "type": "github"
       },
       "original": {
@@ -781,11 +781,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1786581322,
-        "narHash": "sha256-w0DkhP01iPdwin6CpMntZxhYLLYoupu0eqwrGAh+Bb8=",
+        "lastModified": 1786614121,
+        "narHash": "sha256-qF9a4PzIXQn/XrvtpJkIdXlsKK6sYTH9yFAejxXvkBQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8f4f7ae8c3c8fddf517782b653903d11f89b5c87",
+        "rev": "592c38b175d0c7bb9ccf1eb3b80872a7bba5f125",
         "type": "github"
       },
       "original": {
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786612668,
-        "narHash": "sha256-drUMW/BXNEKe5wzw2yM7ea/g7CnObPcwRNVp9ap0yQk=",
+        "lastModified": 1786622604,
+        "narHash": "sha256-szeEL7z8R9KFM0ZMMOlqZulCpzVkfhbwIvqmGLiDELs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a5ef785fafbf01c361372d7dc8e0f1591aeeacd3",
+        "rev": "bb4ab5a48b93156b2c4c2d10caf52f1ecf4c9833",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/867dcbc' (2026-08-12)
  → 'github:NixOS/nixpkgs/0e251e2' (2026-08-13)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/8f4f7ae' (2026-08-13)
  → 'github:NixOS/nixpkgs/592c38b' (2026-08-13)
• Updated input 'nur':
    'github:nix-community/NUR/a5ef785' (2026-08-13)
  → 'github:nix-community/NUR/bb4ab5a' (2026-08-13)
```