### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -197,11 +197,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786603258,
-        "narHash": "sha256-j1lYPT7YxOQc/G7NcJKqdpQ5/A5yX2aZdhVKkJR6cM4=",
+        "lastModified": 1786630952,
+        "narHash": "sha256-a952+jEQ1I6sMd6yzi2GIsO/EFNtEFvzwbJ+oOG9Cg0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0668fdbc15bd602e463cab37ff64346021193652",
+        "rev": "2d1bac51b2513914ace47797765c3265164de78e",
         "type": "github"
       },
       "original": {
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786622604,
-        "narHash": "sha256-szeEL7z8R9KFM0ZMMOlqZulCpzVkfhbwIvqmGLiDELs=",
+        "lastModified": 1786633793,
+        "narHash": "sha256-rTiYcnaPPuA3hDRR/aWGls/L2GpFvy41/SKiP6OaKpc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bb4ab5a48b93156b2c4c2d10caf52f1ecf4c9833",
+        "rev": "e9ead09300be75c3d6816cf3568bded785283945",
         "type": "github"
       },
       "original": {
@@ -981,11 +981,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786375908,
-        "narHash": "sha256-G7qDAT98nywA4EFmJCwIRO5wKvDlBBN3BWpsOnjAto8=",
+        "lastModified": 1786629091,
+        "narHash": "sha256-gkig4nPi1CWc4Z50GBsjE4ygSE7hMpl/TwID2an2Cck=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "d1337e05ba0a8e88a75d2c0e1595d82f3b3e2ac4",
+        "rev": "a8627b21b9107c5711c96b84f32a9a4b3d45295f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hm-master':
    'github:nix-community/home-manager/0668fdb' (2026-08-13)
  → 'github:nix-community/home-manager/2d1bac5' (2026-08-13)
• Updated input 'nur':
    'github:nix-community/NUR/bb4ab5a' (2026-08-13)
  → 'github:nix-community/NUR/e9ead09' (2026-08-13)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/d1337e0' (2026-08-10)
  → 'github:Mic92/sops-nix/a8627b2' (2026-08-13)
```