### PR TITLE
Update guest interface for MicroVM networking defaults

### DIFF
--- a/tests/matrix-baseline.nix
+++ b/tests/matrix-baseline.nix
@@ -61,6 +61,7 @@ let
 in
 assert matrixInstance.portForward.ports == [ ];
 assert matrixInstance.portForward.enable == false;
+assert networkDefaults.guestInterface == "ens6";
 assert !(lib.elem 11060 vmCfg.networking.firewall.allowedTCPPorts);
 assert lib.elem expectedFirewallRule firewallCommands;
 assert synapseListeners != [ ];

--- a/vms/README.md
+++ b/vms/README.md
@@ -103,7 +103,7 @@ ______________________________________________________________________
 The Matrix VM's TCP `11060` port is a guest service port, not a host
 port-forward. Nginx listens on `0.0.0.0:11060` inside the VM, while the guest
 firewall accepts that port only from Blizzard's MicroVM gateway
-`10.100.0.1` on the primary `ens3` interface. The public path is the managed
+`10.100.0.1` on the primary `ens6` interface. The public path is the managed
 `matrix` publication through Cloudflare Tunnel and Traefik; no raw host
 forward bypasses those controls.
 

--- a/vms/microvm-network-defaults.nix
+++ b/vms/microvm-network-defaults.nix
@@ -6,10 +6,11 @@ let
     network = "10.100.0.0/24";
   };
 
-  # Cloud Hypervisor exposes the primary virtio NIC as ens3 in guests. Keep
-  # firewall rules that target the VM's primary network boundary on this
-  # shared contract instead of scattering the device name through workloads.
-  guestInterface = "ens3";
+  # The current Cloud Hypervisor guest layout exposes the primary virtio NIC
+  # at PCI slot 6, which systemd names ens6. Keep firewall rules that target
+  # the VM's primary network boundary on this shared contract instead of
+  # scattering the device name through workloads.
+  guestInterface = "ens6";
 in
 {
   inherit sharedBridge guestInterface;


### PR DESCRIPTION
Update the guest interface from `ens3` to `ens6` in the MicroVM networking defaults and add an assertion to verify the change. This ensures consistency in the network configuration for the Matrix VM.