### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -749,11 +749,11 @@
     },
     "nixpkgs-stable-small": {
       "locked": {
-        "lastModified": 1786564866,
-        "narHash": "sha256-euwYmpnTqQQ7fWEMRyUjkGNZ0rvdk1kOcJnmuqn4mBA=",
+        "lastModified": 1786659501,
+        "narHash": "sha256-oN+HZDL3oxWU7IOBcPnN+HLlzR2XBbcX/hTUcMtLfEw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "abbffaf878d77842cf72336df1b342466319c214",
+        "rev": "bf817068f9eb336bfd314cab423f826af5b56a6a",
         "type": "github"
       },
       "original": {
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786677088,
-        "narHash": "sha256-vgkQZWnmhqiK2w66yAmMLGnfZtiVP9UPGtcgP+yQNnQ=",
+        "lastModified": 1786687404,
+        "narHash": "sha256-/8JSCGyTORZBOdWlVz0D137bL5WsTZ7ZARcmkn8q3d0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1a0a59d9c72e0ac08980e905050dc414cebcd97f",
+        "rev": "9cac9f2d81473428b0cc63e202b67e5c4530fa16",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs-stable-small':
    'github:NixOS/nixpkgs/abbffaf' (2026-08-12)
  → 'github:NixOS/nixpkgs/bf81706' (2026-08-13)
• Updated input 'nur':
    'github:nix-community/NUR/1a0a59d' (2026-08-14)
  → 'github:nix-community/NUR/9cac9f2' (2026-08-14)
```