### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -197,11 +197,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786656209,
-        "narHash": "sha256-ybGtuwGKTUCefKYsplzvw4xcCqznto0c7BaiQhgILtA=",
+        "lastModified": 1786719456,
+        "narHash": "sha256-B74DLQs/VjlqyhnnX3tguWwghqJHWSJX30TKZuAljIg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c554d3441f725537854e877519f01cbd60680174",
+        "rev": "83b7606dcf44abe3a94b86e8bb2b3355d22e8797",
         "type": "github"
       },
       "original": {
@@ -656,11 +656,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1786528975,
-        "narHash": "sha256-8KuasCs+mVQ7WbLONUf/QB7NZeQvovyXRyxAj4nOOzY=",
+        "lastModified": 1786717298,
+        "narHash": "sha256-asdPlqtM0AweQ5YNLad6eY4tSYW55YNr1uyayf7mOMQ=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3e7edd9afe17e45521300e041c65de3015f4a302",
+        "rev": "2dda192987ab6815e44df0130f03d6c907b79134",
         "type": "github"
       },
       "original": {
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786709307,
-        "narHash": "sha256-01LykWiWqov7tWxYCYYWqm93cjJ2dPpUvARyjprrplk=",
+        "lastModified": 1786719943,
+        "narHash": "sha256-xhEBkN8OGd4/WIUhtQkvvU94Ruu5Ozezii1MkW1VVVk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "99607ac0de44ee44b1d5432974b2570bdef5cbd6",
+        "rev": "0e2031d86e978faa7f288d16d24ce0218de10903",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hm-master':
    'github:nix-community/home-manager/c554d34' (2026-08-13)
  → 'github:nix-community/home-manager/83b7606' (2026-08-14)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/3e7edd9' (2026-08-12)
  → 'github:NixOS/nixos-hardware/2dda192' (2026-08-14)
• Updated input 'nur':
    'github:nix-community/NUR/99607ac' (2026-08-14)
  → 'github:nix-community/NUR/0e2031d' (2026-08-14)
```