### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786763190,
-        "narHash": "sha256-Bi6kMlwFvL25n0MgsBb0v/WlXwenW/Ybr5nZymAbBg0=",
+        "lastModified": 1786773673,
+        "narHash": "sha256-Ex9gyRSX3JQlqmJq3MkYk5gE0f7qlLeoa9kweEbTlTc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "29b9882368239b94ab4053f47268d8e52d3c73b9",
+        "rev": "236bc9b265530c437342d1ba8a87989e67ee201c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/29b9882' (2026-08-15)
  → 'github:nix-community/NUR/236bc9b' (2026-08-15)
```