### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -749,11 +749,11 @@
     },
     "nixpkgs-stable-small": {
       "locked": {
-        "lastModified": 1786659501,
-        "narHash": "sha256-oN+HZDL3oxWU7IOBcPnN+HLlzR2XBbcX/hTUcMtLfEw=",
+        "lastModified": 1786748293,
+        "narHash": "sha256-pyVwd5TfCGgQkn2ZogKLeld+MJMavP3bxXDwWFWSEKs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bf817068f9eb336bfd314cab423f826af5b56a6a",
+        "rev": "1fb71ab2beebb8ff3b99626ce1dbf254cfdc3293",
         "type": "github"
       },
       "original": {
@@ -781,11 +781,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1786723161,
-        "narHash": "sha256-TwOM4sZZMJIU60+rYqCToveUQjti7XSPFcisqIEcVc8=",
+        "lastModified": 1786757182,
+        "narHash": "sha256-6yXdh3FSlYRHUFCL3EUW+42vZ2kIoJuAL28o2xIu9F0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4746f0c303f040b7148947095e3758be86e8e337",
+        "rev": "0639e165b2e207c6f2ae62dd30dc929440846ee0",
         "type": "github"
       },
       "original": {
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786773673,
-        "narHash": "sha256-Ex9gyRSX3JQlqmJq3MkYk5gE0f7qlLeoa9kweEbTlTc=",
+        "lastModified": 1786784357,
+        "narHash": "sha256-3qWKEUZVi3M7IttKhMiKMOlK6+51A0Xhb5I98AjeLVE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "236bc9b265530c437342d1ba8a87989e67ee201c",
+        "rev": "3eda8f9fb3c706e4d0e2506c3ab2061ac86a6bdf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs-stable-small':
    'github:NixOS/nixpkgs/bf81706' (2026-08-13)
  → 'github:NixOS/nixpkgs/1fb71ab' (2026-08-14)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/4746f0c' (2026-08-14)
  → 'github:NixOS/nixpkgs/0639e16' (2026-08-15)
• Updated input 'nur':
    'github:nix-community/NUR/236bc9b' (2026-08-15)
  → 'github:nix-community/NUR/3eda8f9' (2026-08-15)
```