### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -197,11 +197,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786719456,
-        "narHash": "sha256-B74DLQs/VjlqyhnnX3tguWwghqJHWSJX30TKZuAljIg=",
+        "lastModified": 1786826571,
+        "narHash": "sha256-nNqmXIFmESRnU91KARtiekSox0+o+E3AS0d1TuUQ/9o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "83b7606dcf44abe3a94b86e8bb2b3355d22e8797",
+        "rev": "c8058ecc1329a71a3c99c4d0353dba4009a66152",
         "type": "github"
       },
       "original": {
@@ -781,11 +781,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1786757182,
-        "narHash": "sha256-6yXdh3FSlYRHUFCL3EUW+42vZ2kIoJuAL28o2xIu9F0=",
+        "lastModified": 1786801259,
+        "narHash": "sha256-dL6Qx1ycmvm+7N/X3a3TrQxcZgyKcsYBF3zjXziFjvE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0639e165b2e207c6f2ae62dd30dc929440846ee0",
+        "rev": "00c2b6e885e1b0c321fdcec025e29c2520abb95e",
         "type": "github"
       },
       "original": {
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786816927,
-        "narHash": "sha256-q8QV8+1dzhX/Nl2UtWYC8RAeUcTsTwmwyw7h36wWTcM=",
+        "lastModified": 1786827102,
+        "narHash": "sha256-TfExy2FBC6peGpxXmKKt+lsim+QG2eMkICOWKfRvtJA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7b837c7162e2df66ad76033528465add96eda6ad",
+        "rev": "41da67f1c25b1ec2a21cd60a73cd07f56d767e84",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hm-master':
    'github:nix-community/home-manager/83b7606' (2026-08-14)
  → 'github:nix-community/home-manager/c8058ec' (2026-08-15)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/0639e16' (2026-08-15)
  → 'github:NixOS/nixpkgs/00c2b6e' (2026-08-15)
• Updated input 'nur':
    'github:nix-community/NUR/7b837c7' (2026-08-15)
  → 'github:nix-community/NUR/41da67f' (2026-08-15)
```