### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786838669,
-        "narHash": "sha256-4OdI4W9n9/3V2s+jbHd2uG645RThRreX9LGBuFmJlzc=",
+        "lastModified": 1786850246,
+        "narHash": "sha256-Edhf02XurM+rtL1evEmGkRtYlAbGxkusJvWXhMU9rLI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e0c84ea68e176ca393f21f351d4bd3700107cba2",
+        "rev": "6d471eb8549d48a5452627aa075d34b9b01b2f91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/e0c84ea' (2026-08-16)
  → 'github:nix-community/NUR/6d471eb' (2026-08-16)
```