### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786871156,
-        "narHash": "sha256-UURcflogOUScDm7RcuzljqEAFtOPYVrCswOFELunkAI=",
+        "lastModified": 1786881147,
+        "narHash": "sha256-SP3a7a3nENJVeZVyLYo8aJXBoCQPSlH0F4+pcYUVpX0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d1598e263a05d753ad06be26c48744e60424f9bf",
+        "rev": "ae51083f105be0ec4a2ff98ca246a4899bb8fe92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/d1598e2' (2026-08-16)
  → 'github:nix-community/NUR/ae51083' (2026-08-16)
```