### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -197,11 +197,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786826571,
-        "narHash": "sha256-nNqmXIFmESRnU91KARtiekSox0+o+E3AS0d1TuUQ/9o=",
+        "lastModified": 1786887553,
+        "narHash": "sha256-0J8EwNSJ/2OeyuvXgfG+k5uBT1gkg0ww7VEo+14xl50=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c8058ecc1329a71a3c99c4d0353dba4009a66152",
+        "rev": "5bd505963717a894b02a57cdbcc00db28d9b029f",
         "type": "github"
       },
       "original": {
@@ -781,11 +781,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1786801259,
-        "narHash": "sha256-dL6Qx1ycmvm+7N/X3a3TrQxcZgyKcsYBF3zjXziFjvE=",
+        "lastModified": 1786869074,
+        "narHash": "sha256-s1WmhEljVugdJy4WU7SMkoK+j59nmFnaMMCCWEhnAI0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "00c2b6e885e1b0c321fdcec025e29c2520abb95e",
+        "rev": "56e3883079f8f1959e61c0a8293e47e0fa90eaa4",
         "type": "github"
       },
       "original": {
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786881147,
-        "narHash": "sha256-SP3a7a3nENJVeZVyLYo8aJXBoCQPSlH0F4+pcYUVpX0=",
+        "lastModified": 1786892326,
+        "narHash": "sha256-aACJgufWmkh0f9ACtAmgqmX6Kd/kZTpOVmSu9Ffrlmk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ae51083f105be0ec4a2ff98ca246a4899bb8fe92",
+        "rev": "80cd9b6bdb05df53157599d7b3135f2a8650de42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hm-master':
    'github:nix-community/home-manager/c8058ec' (2026-08-15)
  → 'github:nix-community/home-manager/5bd5059' (2026-08-16)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/00c2b6e' (2026-08-15)
  → 'github:NixOS/nixpkgs/56e3883' (2026-08-16)
• Updated input 'nur':
    'github:nix-community/NUR/ae51083' (2026-08-16)
  → 'github:nix-community/NUR/80cd9b6' (2026-08-16)
```