### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -688,11 +688,11 @@
     },
     "nixpkgs-beta": {
       "locked": {
-        "lastModified": 1786711500,
-        "narHash": "sha256-QvnceIGTBeDvDd9oCn+GvdsnkquliuwbVgpiRH68qaQ=",
+        "lastModified": 1786943417,
+        "narHash": "sha256-b4qgjdFtlz5TAZ1Hi7DFJeqX3sjaDUnrwr9OO+O1rM0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "02e08985a27c65ffd33d434eeb2e660a2e4dc84d",
+        "rev": "0dd31db7e6dbf9ce05697c4545f6fe01accec994",
         "type": "github"
       },
       "original": {
@@ -826,11 +826,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1786711500,
-        "narHash": "sha256-QvnceIGTBeDvDd9oCn+GvdsnkquliuwbVgpiRH68qaQ=",
+        "lastModified": 1786943417,
+        "narHash": "sha256-b4qgjdFtlz5TAZ1Hi7DFJeqX3sjaDUnrwr9OO+O1rM0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "02e08985a27c65ffd33d434eeb2e660a2e4dc84d",
+        "rev": "0dd31db7e6dbf9ce05697c4545f6fe01accec994",
         "type": "github"
       },
       "original": {
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786946663,
-        "narHash": "sha256-yWonqzVap0h2cJopqnXenLu+Y0+99leynZRsn2l4rAU=",
+        "lastModified": 1786957694,
+        "narHash": "sha256-k/C9qxzXOiDEtJ1C02OLtnrS3pAc6NIk86WD/7t4ArM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ea9c84b8981b4ef87d16bb203370709a8450463b",
+        "rev": "4067b9b9653074901cb596c554fff72184e7a8d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/02e0898' (2026-08-14)
  → 'github:NixOS/nixpkgs/0dd31db' (2026-08-17)
• Updated input 'nixpkgs-beta':
    'github:NixOS/nixpkgs/02e0898' (2026-08-14)
  → 'github:NixOS/nixpkgs/0dd31db' (2026-08-17)
• Updated input 'nur':
    'github:nix-community/NUR/ea9c84b' (2026-08-17)
  → 'github:nix-community/NUR/4067b9b' (2026-08-17)
```