### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787000302,
-        "narHash": "sha256-OKACnEyDnNeRladAL8tS3C/W7Mh9M7xY3ckv0sX1cwQ=",
+        "lastModified": 1787009737,
+        "narHash": "sha256-/ZJjqo+1BRpbcOZAS8t3BazB5KBZt3LkCsZYFk9A9VY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "032cc81455ce27b281e5372ccb58ea2108817c21",
+        "rev": "8c7fcba3fc86b44018a2fbb1e04b743fd68915e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/032cc81' (2026-08-17)
  → 'github:nix-community/NUR/8c7fcba' (2026-08-17)
```