### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787009737,
-        "narHash": "sha256-/ZJjqo+1BRpbcOZAS8t3BazB5KBZt3LkCsZYFk9A9VY=",
+        "lastModified": 1787022528,
+        "narHash": "sha256-UvHI8euixa4JmTdamvuvKmAB94iruqLiD18PfdkSw7k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8c7fcba3fc86b44018a2fbb1e04b743fd68915e4",
+        "rev": "7187c05fcad6a139ccd6242647bc17de80dec581",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/8c7fcba' (2026-08-17)
  → 'github:nix-community/NUR/7187c05' (2026-08-18)
```