### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787022528,
-        "narHash": "sha256-UvHI8euixa4JmTdamvuvKmAB94iruqLiD18PfdkSw7k=",
+        "lastModified": 1787032672,
+        "narHash": "sha256-ajlMB/aU9LICqwgkjoIONpDGgnXcDN5/M+xBQYHgWIc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7187c05fcad6a139ccd6242647bc17de80dec581",
+        "rev": "014291a88e25f1dc2f0532680c1345fabf5c53b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nur':
    'github:nix-community/NUR/7187c05' (2026-08-18)
  → 'github:nix-community/NUR/014291a' (2026-08-18)
```