### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -218,11 +218,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786924861,
-        "narHash": "sha256-hftabkb+73OcGzvwFAjCiQorAhprs9TnU1+FkGO5CIw=",
+        "lastModified": 1787146702,
+        "narHash": "sha256-YbRcLdU/yK4gWsQg7V8WTKZHfXL33g8+wSFUX3wyevs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "09ae1b85a6db412d841d60f924b23f881f0d0a38",
+        "rev": "173b7e8d40fdc8c296a9c99854314f17a3a1704c",
         "type": "github"
       },
       "original": {
@@ -656,11 +656,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1787126170,
-        "narHash": "sha256-AFZ07P7jdBhPJt0VkZhQPWEx1+JNySEkBA0IjpPAx08=",
+        "lastModified": 1787144466,
+        "narHash": "sha256-HHfv2/HkNSKbbSyU9iD/g8lbP6r4tl33sSw1W4rXCk0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e8a8bfbbfadb96834ec3fa3d17a03807e38f4e63",
+        "rev": "0471accf8d0a8210b31d947497d179ecc99e0021",
         "type": "github"
       },
       "original": {
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787140331,
-        "narHash": "sha256-XL8I5CxxBhkxP30VWs7nsZ4NnE/CJbLNwrp6FkF4X1k=",
+        "lastModified": 1787151508,
+        "narHash": "sha256-d3zspGE+FIm/XGsvaH0Bp7pyfjOOA61VLGRdt4cq4eU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fbf264158b4b8913c41fe7861f4a57b6cad43597",
+        "rev": "6a6f82b8fc56faf1eebaaa0475ebe780a5992924",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hm-stable':
    'github:nix-community/home-manager/09ae1b8' (2026-08-17)
  → 'github:nix-community/home-manager/173b7e8' (2026-08-19)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/e8a8bfb' (2026-08-19)
  → 'github:NixOS/nixos-hardware/0471acc' (2026-08-19)
• Updated input 'nur':
    'github:nix-community/NUR/fbf2641' (2026-08-19)
  → 'github:nix-community/NUR/6a6f82b' (2026-08-19)
```