### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -749,11 +749,11 @@
     },
     "nixpkgs-stable-small": {
       "locked": {
-        "lastModified": 1787168735,
-        "narHash": "sha256-BHG+bJnRa7ibsbSp6nAEueKoxfkcwLSoPnca7e4IK0c=",
+        "lastModified": 1787184810,
+        "narHash": "sha256-8Z9Q4Wh/nqdpVSsVvSXxpIJ442CFzLDwfKmWMOsJwts=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "01ad4f4c989b5879956fb1661ae43891635d02d1",
+        "rev": "271998520450db38b8c6b40464ea1fdb466db60c",
         "type": "github"
       },
       "original": {
@@ -765,11 +765,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1787070829,
-        "narHash": "sha256-vXNVDVtvfiQuXthP0NHPFdNvvMTkGpx0UP8oddIWbNk=",
+        "lastModified": 1787135253,
+        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0ae2bc1419c3f345984c2629e72e7a631820fa4d",
+        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
         "type": "github"
       },
       "original": {
@@ -781,11 +781,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1787168064,
-        "narHash": "sha256-Vu0B6tZpsFadZRbJwVqCb40A7iHezHMQmTf4N55IJBs=",
+        "lastModified": 1787201333,
+        "narHash": "sha256-YElrViL7Km6jOPcoPJK/OqXnF95nD8Ibc/qAUlcVM3Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fc4cbc58f4ada95ae34b991b9fb9c4a815c8e721",
+        "rev": "ca3853d32223b08a75a5d45a54953d2f93d15de4",
         "type": "github"
       },
       "original": {
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787195710,
-        "narHash": "sha256-oAKatlFtTMjNi37FdqJXelSTVrCGnB6CVBBP4ldqFHE=",
+        "lastModified": 1787205534,
+        "narHash": "sha256-nqhkSNNx9wAjycEai4AgSBGm/mwq3187Icmg0XHhVvE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7da479a60c07679f5c24832ca707073f2e9f5215",
+        "rev": "be9bed823a6985bd9b852ded5c879fd663b04c61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs-stable-small':
    'github:NixOS/nixpkgs/01ad4f4' (2026-08-19)
  → 'github:NixOS/nixpkgs/2719985' (2026-08-20)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/0ae2bc1' (2026-08-18)
  → 'github:NixOS/nixpkgs/ffb3c9b' (2026-08-19)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/fc4cbc5' (2026-08-19)
  → 'github:NixOS/nixpkgs/ca3853d' (2026-08-20)
• Updated input 'nur':
    'github:nix-community/NUR/7da479a' (2026-08-20)
  → 'github:nix-community/NUR/be9bed8' (2026-08-20)
```