### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -781,11 +781,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1787201333,
-        "narHash": "sha256-YElrViL7Km6jOPcoPJK/OqXnF95nD8Ibc/qAUlcVM3Q=",
+        "lastModified": 1787234702,
+        "narHash": "sha256-kvsnFCG4T5dmUj7BMcmpuPZjZNSjOZfhXUdjiBQG2xk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ca3853d32223b08a75a5d45a54953d2f93d15de4",
+        "rev": "5cca3a89405eb65d2adb43754c2af8dac7b6f2e1",
         "type": "github"
       },
       "original": {
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787226318,
-        "narHash": "sha256-cAPoqRPYZXd2BJVZ56qk9MD82Z63L7wCH0HDyw7fmRQ=",
+        "lastModified": 1787238513,
+        "narHash": "sha256-vvpIdjvE+uejWdyl8W7KEtv9RhIIoQt5Wc0WTLGO2x0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "72e1fa84eb1f0006daeba705b2a81591e7e9f5a8",
+        "rev": "be47adbe5078c604db9bad439c37e09edd1a5f3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nix-secrets':
    'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=f32880ee09f0362767d8a14f2ea13743518ed4d6' (2026-08-17)
  → 'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=f32880ee09f0362767d8a14f2ea13743518ed4d6' (2026-08-17)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/ca3853d' (2026-08-20)
  → 'github:NixOS/nixpkgs/5cca3a8' (2026-08-20)
• Updated input 'nur':
    'github:nix-community/NUR/72e1fa8' (2026-08-20)
  → 'github:nix-community/NUR/be47adb' (2026-08-20)
```