### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -583,11 +583,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1787524185,
-        "narHash": "sha256-8c6dFnJpFLa/LdQx/+6Ae+GF5eTMzJ07gzjmssUR0Nk=",
+        "lastModified": 1787551247,
+        "narHash": "sha256-ogq7JBsR2aJko074/LQOIPcectSXnq2YshD2TG0PP5A=",
         "owner": "microvm-nix",
         "repo": "microvm.nix",
-        "rev": "238f6d2884aec6aafb72442b9d8d10086d06accc",
+        "rev": "ad098ef4658203b3bbc39523ca3f72ece1553e24",
         "type": "github"
       },
       "original": {
@@ -749,11 +749,11 @@
     },
     "nixpkgs-stable-small": {
       "locked": {
-        "lastModified": 1787457369,
-        "narHash": "sha256-4r1TqYC5uVPLWSJcN3zHeUOYz1RCgCAC38j88+BALag=",
+        "lastModified": 1787481426,
+        "narHash": "sha256-CqYuI+GDjlWLcLRWDEVVvATUOVZigBmzKolfqtQRApI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "095b629f2eecc83f0f27373093e336600e886674",
+        "rev": "9854f5e5a66dc5e42acd8ad482cdb05d7ef0431a",
         "type": "github"
       },
       "original": {
@@ -848,11 +848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787540677,
-        "narHash": "sha256-oWeHPTIOObD9tpBWa9IV6M11QmqfNt4zCpBv7Ybzzxc=",
+        "lastModified": 1787551631,
+        "narHash": "sha256-lwVtvAMxL6j0ekZDShiGq7UJEyDV6LE1Q/d095Urfd0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "04aafdf393ec51f243ed99fd356cd9107f51edfb",
+        "rev": "3c24922ef04b62324087261bae783a3cb6aca2eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'microvm':
    'github:microvm-nix/microvm.nix/238f6d2' (2026-08-23)
  → 'github:microvm-nix/microvm.nix/ad098ef' (2026-08-24)
• Updated input 'nix-secrets':
    'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=f32880ee09f0362767d8a14f2ea13743518ed4d6' (2026-08-17)
  → 'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=f32880ee09f0362767d8a14f2ea13743518ed4d6' (2026-08-17)
• Updated input 'nixpkgs-stable-small':
    'github:NixOS/nixpkgs/095b629' (2026-08-23)
  → 'github:NixOS/nixpkgs/9854f5e' (2026-08-23)
• Updated input 'nur':
    'github:nix-community/NUR/04aafdf' (2026-08-24)
  → 'github:nix-community/NUR/3c24922' (2026-08-24)
```