### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -747,6 +747,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-master": {
+      "locked": {
+        "lastModified": 1787562361,
+        "narHash": "sha256-r8xi6VcrbF/kJs7zjHNT+PycjGUrAFYYCeOfBBFAbck=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c1064215f05c3ae7ce4fb7ca71cd6d76f78ac93d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-stable-small": {
       "locked": {
         "lastModified": 1787481426,
@@ -765,11 +781,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1787360063,
-        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
         "type": "github"
       },
       "original": {
@@ -848,11 +864,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787551631,
-        "narHash": "sha256-lwVtvAMxL6j0ekZDShiGq7UJEyDV6LE1Q/d095Urfd0=",
+        "lastModified": 1787562806,
+        "narHash": "sha256-jhMqGzQc237NJ6itBY45WCY1Ll64gY73KaycFpBs/Zo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3c24922ef04b62324087261bae783a3cb6aca2eb",
+        "rev": "e72adbbaab89e6d987b2a8519e9fae605705b64b",
         "type": "github"
       },
       "original": {
@@ -943,6 +959,7 @@
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_4",
         "nixpkgs-beta": "nixpkgs-beta",
+        "nixpkgs-master": "nixpkgs-master",
         "nixpkgs-stable-small": "nixpkgs-stable-small",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nixpkgs-unstable-small": "nixpkgs-unstable-small",


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nix-secrets':
    'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=f32880ee09f0362767d8a14f2ea13743518ed4d6' (2026-08-17)
  → 'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=f32880ee09f0362767d8a14f2ea13743518ed4d6' (2026-08-17)
• Added input 'nixpkgs-master':
    'github:NixOS/nixpkgs/c106421' (2026-08-24)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/2c423e0' (2026-08-22)
  → 'github:NixOS/nixpkgs/56c02bc' (2026-08-23)
• Updated input 'nur':
    'github:nix-community/NUR/3c24922' (2026-08-24)
  → 'github:nix-community/NUR/e72adbb' (2026-08-24)
```