### PR TITLE
Refactor to use constants for service ports and addresses

### DIFF
--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -79,3 +79,6 @@ jobs:
 
             - name: Run Scrutiny tests
               run: nix build .#checks.x86_64-linux.scrutiny --no-link --print-build-logs
+
+            - name: Run VictoriaMetrics tests
+              run: nix build .#checks.x86_64-linux.victoriametrics --no-link --print-build-logs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,9 @@ Enable in a host file: `sys.role.desktop.enable = true;`
 ### Lib helpers
 
 - `lib/traefik.nix` — `mkSecurityHeaders`, `mkRoutes`, `mkReverseProxyOptions`, `mkTraefikDynamicConfig`, `mkCfTunnelAssertion`
-- `lib/constants.nix` — shared strings: `tailscale.suffix` (loaded as `consts` in flake.nix)
+- `lib/constants.nix` — shared Tailscale endpoints and namespaced ports
+  (`ports.host`, `ports.vm`, `ports.secondary`, `ports.network`), loaded as
+  `consts` in NixOS, VM, and Home Manager modules
 - `lib/grafana-dashboards.nix` — `fetchGrafanaDashboard`, pre-configured community and custom dashboard sets
 - `lib/grafana.nix` — panel-builder DSL: `mkDashboard`, `mkTimeseries`, `mkGauge`, `mkStat`, `mkBargauge`, `mkRow`, `mkTarget`
 

--- a/containers/README.md
+++ b/containers/README.md
@@ -51,7 +51,7 @@ ______________________________________________________________________
 | Option | File | Port(s) | Purpose |
 |--------|------|---------|---------|
 | `services.ollama-container.enable` | [ollama.nix](ollama.nix) | 11434 | Standalone LLM server (ROCm/AMD or CPU image) |
-| `services.immich-machine-learning-container.enable` | [immich-machine-learning.nix](immich-machine-learning.nix) | 3003 | Standalone Immich ML worker (CUDA/NVIDIA or CPU image) |
+| `services.immich-machine-learning-container.enable` | [immich-machine-learning.nix](immich-machine-learning.nix) | 3003 host/container defaults from [`lib/constants.nix`](../lib/constants.nix) | Standalone Immich ML worker (CUDA/NVIDIA or CPU image) |
 | `services.subgen-container.enable` | [subgen.nix](subgen.nix) | 11027 | Whisper-based subtitle generator (CPU or AMD GPU) |
 | `services.lingarr.enable` | [subtitle-stack.nix](subtitle-stack.nix) | 11025 | Full subtitle translation pipeline (lingarr + libretranslate + ollama + subgen as a pod) |
 | `services.subgen.enable` | [subtitle-stack.nix](subtitle-stack.nix) | 11027 | Subgen as part of the subtitle-stack pod |

--- a/containers/immich-machine-learning.nix
+++ b/containers/immich-machine-learning.nix
@@ -4,10 +4,12 @@
   lib,
   config,
   pkgs,
+  consts,
   ...
 }:
 let
   cfg = config.services.immich-machine-learning-container;
+  containerPort = consts.ports.secondary.immichMachineLearning.containerPort;
 
   imageSuffix = lib.optionalString (cfg.acceleration != "cpu") "-${cfg.acceleration}";
   defaultImage = "ghcr.io/immich-app/immich-machine-learning:v${pkgs.immich.version}${imageSuffix}";
@@ -18,7 +20,7 @@ in
 
     port = lib.mkOption {
       type = lib.types.port;
-      default = 3003;
+      default = consts.ports.secondary.immichMachineLearning.hostPort;
       description = "Host port to expose the Immich machine-learning API on.";
     };
 
@@ -84,14 +86,14 @@ in
       containerConfig = {
         image = if cfg.image != null then cfg.image else defaultImage;
         publishPorts = [
-          "${cfg.listenAddress}:${toString cfg.port}:3003"
+          "${cfg.listenAddress}:${toString cfg.port}:${toString containerPort}"
         ];
         volumes = [
           "${cfg.cacheDir}:/cache:U"
         ];
         environments = {
           IMMICH_HOST = "0.0.0.0";
-          IMMICH_PORT = "3003";
+          IMMICH_PORT = toString containerPort;
           MACHINE_LEARNING_CACHE_FOLDER = "/cache";
           MACHINE_LEARNING_MODEL_TTL = cfg.modelTtl;
           HF_HOME = "/cache/huggingface";

--- a/docs/2026-08-18-blizzard-microvm-enforce-audit.md
+++ b/docs/2026-08-18-blizzard-microvm-enforce-audit.md
@@ -226,12 +226,12 @@ the earlier read-only guest probes and journal telemetry.
 ## Recommendations
 
 1. Keep Blizzard in `enforce` mode. No source fix is indicated.
-2. Record the supplied counter snapshot with the deployment evidence. For any
+1. Record the supplied counter snapshot with the deployment evidence. For any
    future ruleset reload, record the reload time and counter reset explicitly.
-3. Record the deployed flake commit and lock revision at the next deployment
+1. Record the deployed flake commit and lock revision at the next deployment
    or audit handoff so the full system generation can be reconciled with the
    evaluated checkout.
-4. Preserve the existing focused test as the acceptance gate for future policy
+1. Preserve the existing focused test as the acceptance gate for future policy
    changes. Do not run live spoofing or bypass traffic against production just
    to fill this report's evidence matrix.
 

--- a/docs/Project_Architecture_Blueprint.md
+++ b/docs/Project_Architecture_Blueprint.md
@@ -49,6 +49,7 @@ ______________________________________________________________________
 | `checks.x86_64-linux.microvm-network-policy` | NixOS integration test for MicroVM identity, lateral, gateway, and bridge isolation |
 | `checks.x86_64-linux.sandfly-target` | Sandfly target policy, Tailscale, account, and sudo contract tests |
 | `checks.x86_64-linux.scrutiny` | Scrutiny service, secret, and systemd contract tests |
+| `checks.x86_64-linux.victoriametrics` | VictoriaMetrics listener, firewall, authentication, client credentials, and startup-order contract tests |
 | `devShells.x86_64-linux.default` | nil, nixfmt, deadnix, statix, sops, ssh-to-age |
 
 There are no `homeConfigurations`, `packages`, `apps`, or `templates` outputs.
@@ -524,7 +525,7 @@ ______________________________________________________________________
 
 | File | Exports | Purpose |
 |------|---------|---------|
-| `lib/constants.nix` | `{ tailscale.suffix = "mole-delta.ts.net"; }` | Loaded once as `consts` in `flake.nix`; shared strings across all modules |
+| `lib/constants.nix` | Tailscale endpoints, namespaced host/VM/secondary/network ports, and monitoring identifiers | Loaded once as `consts` in `flake.nix`; the same value is passed to NixOS, VM, and Home Manager modules |
 | `lib/traefik.nix` | `mkSecurityHeaders`, `mkRoutes`, `mkReverseProxyOptions`, `mkTraefikDynamicConfig`, `mkCfTunnelAssertion`, `defaultPermissionsPolicy`, `defaultCsp` | Generates shared headers and host-service or bespoke route config; standard MicroVM publication is rendered by `microvm-base.nix` |
 | `lib/grafana-dashboards.nix` | `fetchGrafanaDashboard`, `community.*`, `custom.*`, `all` | Fetches Grafana.com dashboards by ID; bundles community (node-exporter-full, kubernetes-cluster) and custom (arr-services, cloudflare-overview, zfs-overview, power-consumption, ups-monitoring, electricity-prices) sets |
 | `lib/grafana.nix` | `prometheusDatasource`, `mkRow`, `mkGauge`, `mkStat`, `mkTimeseries`, `mkBargauge`, `mkTarget`, `mkDashboard`, default field configs | Nix-native Grafana panel/dashboard builders |
@@ -645,9 +646,11 @@ ______________________________________________________________________
 | Run only the Cloudflare metrics tests | `nix build .#checks.x86_64-linux.cloudflare-metrics --no-link --print-build-logs` |
 | Run only the Matrix baseline tests | `nix build .#checks.x86_64-linux.matrix-baseline --no-link --print-build-logs` |
 | Run only the MicroVM publication tests | `nix build .#checks.x86_64-linux.microvm-publication --no-link --print-build-logs` |
+| Run only the blackbox observability tests | `nix build .#checks.x86_64-linux.blackbox-observability --no-link --print-build-logs` |
 | Run only the MicroVM network-policy test | `nix build .#checks.x86_64-linux.microvm-network-policy --no-link --print-build-logs` |
 | Run only the Sandfly target tests | `nix build .#checks.x86_64-linux.sandfly-target --no-link --print-build-logs` |
 | Run only the Scrutiny service tests | `nix build .#checks.x86_64-linux.scrutiny --no-link --print-build-logs` |
+| Run only the VictoriaMetrics contract tests | `nix build .#checks.x86_64-linux.victoriametrics --no-link --print-build-logs` |
 | Build without switching | `nix build .#nixosConfigurations.<host>.config.system.build.toplevel` |
 | Apply to current host | `sudo nixos-rebuild switch --flake .#<hostname>` |
 | Test without switching | `sudo nixos-rebuild test --flake .#<hostname>` |
@@ -657,8 +660,9 @@ The `flake-check.yml` CI workflow uses
 `.github/scripts/evaluate-flake-outputs.sh` to evaluate configurations,
 formatters, checks, and development shells in separate Nix processes, then
 explicitly builds the Cloudflare metrics, MicroVM publication, Matrix baseline,
-network-policy, Sandfly target, and Scrutiny service checks so their tests
-execute. Host evaluations run separately in `validate-config.yml`.
+blackbox observability, network-policy, Sandfly target, Scrutiny service, and
+VictoriaMetrics checks so their tests execute. Host evaluations run separately
+in `validate-config.yml`.
 
 Hosts: `snowfall`, `blizzard`, `avalanche`, `kaizer`.
 
@@ -717,6 +721,8 @@ ______________________________________________________________________
 
 ### Add a service VM
 
+1. Add or reuse the service port in `lib/constants.nix` under the appropriate
+   `ports.*` namespace (`ports.vm` for a MicroVM primary service).
 1. Add an entry to `vms/vm-registry.nix` (CID, MAC, IP, port, mem, vcpu, gateway).
 1. Create `vms/<name>.nix` with the service NixOS config.
 1. Register the VM in `vms/flake-microvms.nix`.

--- a/docs/cloudflare-metrics.md
+++ b/docs/cloudflare-metrics.md
@@ -21,6 +21,24 @@ flowchart LR
     ALERTS --> NOTIFY["Configured Grafana contact point"]
 ```
 
+VictoriaMetrics is the long-term store for the local and remote Prometheus
+writers. On Blizzard it listens at
+`100.86.227.97:11008` (the Blizzard Tailscale address) and the firewall opens
+that port only on `tailscale0`; it is not a general host-firewall opening.
+VictoriaMetrics HTTP Basic Authentication protects the complete API, including
+remote-write, query, and administrative endpoints. The username is a stable
+configuration constant; the password is the SOPS secret
+`victoriametrics/remote_write_password` in the private `nix-secrets` flake.
+Add or rotate that key in the private flake before activating this configuration;
+this repository intentionally does not contain its value.
+
+Snowfall's remote writer and Blizzard's local Prometheus and Grafana datasource
+read that password from their SOPS-rendered file. Remote writes use HTTP inside
+the encrypted Tailscale transport, not an unprotected LAN or public route. A
+password rotation requires updating the private secret and restarting the
+VictoriaMetrics, Prometheus, and Grafana services together; never put the value
+in this repository or in a Nix command-line argument.
+
 The collector reads:
 
 - the active zone inventory and HTTP adaptive analytics

--- a/docs/reference-architecture.md
+++ b/docs/reference-architecture.md
@@ -21,6 +21,7 @@ Information reference for this repo's moving parts, options, and commands.
 | `checks.x86_64-linux.microvm-publication` | Rendered publication contract and failure-case evaluation tests |
 | `checks.x86_64-linux.sandfly-target` | Sandfly target policy, Tailscale, account, and sudo contract tests |
 | `checks.x86_64-linux.scrutiny` | Scrutiny service, secret, and systemd contract tests |
+| `checks.x86_64-linux.victoriametrics` | VictoriaMetrics listener, firewall, authentication, client credentials, and startup-order contract tests |
 | `devShells.x86_64-linux.default` | Dev shell with nil, nixfmt, deadnix, statix, sops, ssh-to-age |
 
 ### `mkHost` — what it always injects
@@ -175,11 +176,12 @@ Operational tools used across the repo.
 | auto-upgrade | Monthly NixOS upgrades (server role only) | `modules/services/auto-upgrade.nix` |
 
 Locally, `nix flake check` evaluates and builds the formatting, Cloudflare
-metrics, Matrix baseline, MicroVM publication, MicroVM network-policy, Sandfly
-target, and Scrutiny service checks. The `flake-check.yml` CI workflow first runs
+metrics, Matrix baseline, MicroVM publication, blackbox observability, MicroVM
+network-policy, Sandfly target, Scrutiny service, and VictoriaMetrics checks. The
+`flake-check.yml` CI workflow first runs
 `.github/scripts/evaluate-flake-outputs.sh`, which evaluates configurations,
 formatters, checks, and development shells in separate Nix processes, then
-explicitly builds all six executable test checks. Full host evaluation is
+explicitly builds all eight executable test checks. Full host evaluation is
 handled separately by the `validate-config.yml` CI workflow.
 
 ______________________________________________________________________
@@ -275,11 +277,11 @@ ______________________________________________________________________
 ## Constants (`lib/constants.nix`)
 
 Centralises shared magic strings and service endpoints: the Tailscale domain
-suffix, the shared Blizzard Tailscale address, Cloudflare account/policy IDs,
-and reusable service-port constants. Imported once in `flake.nix` and passed
-into modules as `consts` via `specialArgs` (and similarly for MicroVMs in
-`vms/flake-microvms.nix`). Prefer the injected `consts` argument over ad-hoc
-direct imports.
+suffix, the shared Blizzard Tailscale address, namespaced host/VM/secondary and
+network ports, and monitoring identifiers. Cloudflare account and policy IDs
+remain SOPS secrets, not constants. Imported once in `flake.nix` and passed
+into NixOS, MicroVM, and Home Manager modules as `consts` via `specialArgs`.
+Prefer the injected `consts` argument over ad-hoc direct imports.
 
 ______________________________________________________________________
 
@@ -316,6 +318,9 @@ nix build .#checks.x86_64-linux.microvm-publication --no-link --print-build-logs
 # Build and run the Matrix baseline contract check
 nix build .#checks.x86_64-linux.matrix-baseline --no-link --print-build-logs
 
+# Build and run the blackbox observability contract check
+nix build .#checks.x86_64-linux.blackbox-observability --no-link --print-build-logs
+
 # Build and run the MicroVM network-policy integration test
 nix build .#checks.x86_64-linux.microvm-network-policy --no-link --print-build-logs
 
@@ -324,6 +329,9 @@ nix build .#checks.x86_64-linux.sandfly-target --no-link --print-build-logs
 
 # Build and run only the Scrutiny service contract check
 nix build .#checks.x86_64-linux.scrutiny --no-link --print-build-logs
+
+# Build and run only the VictoriaMetrics contract check
+nix build .#checks.x86_64-linux.victoriametrics --no-link --print-build-logs
 
 # Dev shell (includes nil, nixfmt, deadnix, statix, sops, ssh-to-age)
 nix develop

--- a/docs/reference-architecture.md
+++ b/docs/reference-architecture.md
@@ -274,7 +274,12 @@ ______________________________________________________________________
 
 ## Constants (`lib/constants.nix`)
 
-Centralises shared magic strings: Tailscale domain suffix, Cloudflare account/policy IDs. Imported once in `flake.nix` and passed into modules as `consts` via `specialArgs` (and similarly for MicroVMs in `vms/flake-microvms.nix`). Prefer the injected `consts` argument over ad-hoc direct imports.
+Centralises shared magic strings and service endpoints: the Tailscale domain
+suffix, the shared Blizzard Tailscale address, Cloudflare account/policy IDs,
+and reusable service-port constants. Imported once in `flake.nix` and passed
+into modules as `consts` via `specialArgs` (and similarly for MicroVMs in
+`vms/flake-microvms.nix`). Prefer the injected `consts` argument over ad-hoc
+direct imports.
 
 ______________________________________________________________________
 

--- a/docs/reference-ci.md
+++ b/docs/reference-ci.md
@@ -74,7 +74,7 @@ ______________________________________________________________________
 | Workflow | Trigger | Purpose | Auto-commits? |
 |----------|---------|---------|--------------|
 | `auto-format.yml` | PR / push to main / manual | Runs `nix fmt`, commits formatted changes back to the branch, comments on PR, enables auto-merge | Yes — formats in-place |
-| `flake-check.yml` | PR / push to main / manual (filtered to its workflow file, Nix/flake inputs, Cloudflare collector/tests/dashboard, the VM README, and ADRs) | Runs `.github/scripts/evaluate-flake-outputs.sh` to evaluate each flake output sequentially, redacts secrets in failure output, and builds the Cloudflare metrics, MicroVM publication, Matrix baseline, blackbox observability, MicroVM network-policy, Sandfly target, and Scrutiny service checks | No |
+| `flake-check.yml` | PR / push to main / manual (filtered to its workflow file, Nix/flake inputs, Cloudflare collector/tests/dashboard, the VM README, and ADRs) | Runs `.github/scripts/evaluate-flake-outputs.sh` to evaluate each flake output sequentially, redacts secrets in failure output, and builds the Cloudflare metrics, MicroVM publication, Matrix baseline, blackbox observability, MicroVM network-policy, Sandfly target, Scrutiny service, and VictoriaMetrics contract checks | No |
 | `validate-config.yml` | PR / push to main / manual | Discovers hosts via `mkHost` grep, evaluates each host's `config.system.build.toplevel` with `nix eval` in a matrix, and evaluates the Home Manager users attrset | No |
 | `change-impact-analysis.yml` | PR | Diffs changed files under `hosts/`, `modules/`, `home/`, `vms/`, `lib/`, `flake.*`, posts impact report as a PR comment | No |
 | `compliance-check.yml` | PR / push / cron Mon 09:00 | Runs `deadnix` and other Nix linters, comments results | No |
@@ -135,7 +135,7 @@ These run on every pull request:
 | Workflow | What it checks |
 |----------|---------------|
 | `auto-format.yml` | Formats all files and commits back; if this commits, the PR diff is automatically clean |
-| `flake-check.yml` | Evaluates the flake for Nix errors and runs the Cloudflare metrics, MicroVM publication, Matrix baseline, MicroVM network-policy, Sandfly target, and Scrutiny service checks when Nix/flake inputs or their scoped test, dashboard, VM README, or ADR contracts change |
+| `flake-check.yml` | Evaluates the flake for Nix errors and runs the Cloudflare metrics, MicroVM publication, Matrix baseline, blackbox observability, MicroVM network-policy, Sandfly target, Scrutiny service, and VictoriaMetrics contract checks when Nix/flake inputs or their scoped test, dashboard, VM README, or ADR contracts change |
 | `validate-config.yml` | Evaluates each host's `config.system.build.toplevel` with `nix eval` in a matrix (does not perform a full build) |
 | `change-impact-analysis.yml` | Posts a comment summarising which layer (hosts, modules, home, vms, lib, flake) is affected |
 | `compliance-check.yml` | Dead-code linting and other Nix hygiene checks |

--- a/flake.nix
+++ b/flake.nix
@@ -104,7 +104,12 @@
       consts = import ./lib/constants.nix;
       treefmtEval = inputs.treefmt-nix.lib.evalModule nixpkgs.legacyPackages.${system} ./treefmt.nix;
       microvmConfigurations = import ./vms/flake-microvms.nix {
-        inherit inputs system VARS consts;
+        inherit
+          inputs
+          system
+          VARS
+          consts
+          ;
       };
       mkHost =
         hostname: extraModules:

--- a/flake.nix
+++ b/flake.nix
@@ -104,7 +104,7 @@
       consts = import ./lib/constants.nix;
       treefmtEval = inputs.treefmt-nix.lib.evalModule nixpkgs.legacyPackages.${system} ./treefmt.nix;
       microvmConfigurations = import ./vms/flake-microvms.nix {
-        inherit inputs system VARS;
+        inherit inputs system VARS consts;
       };
       mkHost =
         hostname: extraModules:
@@ -186,6 +186,11 @@
           blizzard = self.nixosConfigurations.blizzard;
           pkgs = nixpkgs.legacyPackages.${system};
           publicDomain = VARS.domains.public;
+        };
+
+        victoriametrics = import ./tests/victoriametrics.nix {
+          inherit (self.nixosConfigurations) blizzard snowfall;
+          pkgs = nixpkgs.legacyPackages.${system};
         };
 
         microvm-network-policy = import ./tests/microvm-network-policy.nix {

--- a/hosts/avalanche/avalanche.nix
+++ b/hosts/avalanche/avalanche.nix
@@ -125,14 +125,14 @@ in
       prometheusExporters.node = {
         enable = false;
         enableRapl = true;
-        port = 11011;
+        port = consts.nodeExporterPort;
       };
 
       prometheus = {
         # Avalanche no longer collects local metrics; keep the stack disabled
         # to avoid its services contributing to shutdown latency.
         enable = false;
-        port = 11009;
+        port = consts.prometheusPort;
         listenAddress = "127.0.0.1";
         openFirewall = false;
         scrapeInterval = "15s";
@@ -140,7 +140,7 @@ in
 
       grafana = {
         enable = false;
-        port = 11010;
+        port = consts.grafanaPort;
         addr = "127.0.0.1";
         openFirewall = false;
 
@@ -154,6 +154,7 @@ in
       victoriametricsRemoteWrite = {
         enable = false;
         vmHost = "blizzard"; # Tailscale hostname
+        vmPort = consts.victoriametricsPort;
       };
 
       # nfs = {
@@ -194,7 +195,7 @@ in
 
   fileSystems = {
     "/mnt/backups" = {
-      device = "100.86.227.97:/rpool/enc/transfers";
+      device = "${consts.tailscale.hosts.blizzard.ipv4}:/rpool/enc/transfers";
       fsType = "nfs";
       options = [
         "nofail"

--- a/hosts/avalanche/avalanche.nix
+++ b/hosts/avalanche/avalanche.nix
@@ -125,14 +125,14 @@ in
       prometheusExporters.node = {
         enable = false;
         enableRapl = true;
-        port = consts.nodeExporterPort;
+        port = consts.ports.host.nodeExporter;
       };
 
       prometheus = {
         # Avalanche no longer collects local metrics; keep the stack disabled
         # to avoid its services contributing to shutdown latency.
         enable = false;
-        port = consts.prometheusPort;
+        port = consts.ports.host.prometheus;
         listenAddress = "127.0.0.1";
         openFirewall = false;
         scrapeInterval = "15s";
@@ -140,7 +140,7 @@ in
 
       grafana = {
         enable = false;
-        port = consts.grafanaPort;
+        port = consts.ports.host.grafana;
         addr = "127.0.0.1";
         openFirewall = false;
 
@@ -154,7 +154,7 @@ in
       victoriametricsRemoteWrite = {
         enable = false;
         vmHost = "blizzard"; # Tailscale hostname
-        vmPort = consts.victoriametricsPort;
+        vmPort = consts.ports.host.victoriametrics;
       };
 
       # nfs = {

--- a/hosts/blizzard/monitoring/exporters.nix
+++ b/hosts/blizzard/monitoring/exporters.nix
@@ -65,7 +65,7 @@
       prometheusExporter = {
         enable = true;
 
-      port = consts.ports.host.upsExporter;
+        port = consts.ports.host.upsExporter;
         variables = [
           "battery.charge"
           "battery.charge.low"

--- a/hosts/blizzard/monitoring/exporters.nix
+++ b/hosts/blizzard/monitoring/exporters.nix
@@ -4,27 +4,27 @@
     prometheusExporters = {
       node = {
         enableRapl = true;
-        port = consts.nodeExporterPort;
+        port = consts.ports.host.nodeExporter;
       };
 
       zfs = {
         enable = true;
 
-        port = consts.zfsExporterPort;
+        port = consts.ports.host.zfsExporter;
       };
     };
 
     electricityPriceExporter = {
       enable = true;
 
-      port = consts.electricityPriceExporterPort;
+      port = consts.ports.host.electricityPriceExporter;
       priceArea = "NO2";
     };
 
     cloudflareMetrics = {
       enable = true;
 
-      port = consts.cloudflareMetricsPort;
+      port = consts.ports.host.cloudflareMetrics;
       apiTokenFile = config.sys.secrets.cloudflareMetricsApiTokenFile;
       accountIdFile = config.sys.secrets.cloudflareAccountIdFile;
       ownerEmailsFile = config.sys.secrets.cloudflareAccessOwnerEmailsFile;
@@ -65,7 +65,7 @@
       prometheusExporter = {
         enable = true;
 
-        port = consts.upsExporterPort;
+      port = consts.ports.host.upsExporter;
         variables = [
           "battery.charge"
           "battery.charge.low"

--- a/hosts/blizzard/monitoring/exporters.nix
+++ b/hosts/blizzard/monitoring/exporters.nix
@@ -1,30 +1,30 @@
-{ config, ... }:
+{ config, consts, ... }:
 {
   sys.services = {
     prometheusExporters = {
       node = {
         enableRapl = true;
-        port = 11011;
+        port = consts.nodeExporterPort;
       };
 
       zfs = {
         enable = true;
 
-        port = 11013;
+        port = consts.zfsExporterPort;
       };
     };
 
     electricityPriceExporter = {
       enable = true;
 
-      port = 11012;
+      port = consts.electricityPriceExporterPort;
       priceArea = "NO2";
     };
 
     cloudflareMetrics = {
       enable = true;
 
-      port = 11015;
+      port = consts.cloudflareMetricsPort;
       apiTokenFile = config.sys.secrets.cloudflareMetricsApiTokenFile;
       accountIdFile = config.sys.secrets.cloudflareAccountIdFile;
       ownerEmailsFile = config.sys.secrets.cloudflareAccessOwnerEmailsFile;
@@ -65,7 +65,7 @@
       prometheusExporter = {
         enable = true;
 
-        port = 11014;
+        port = consts.upsExporterPort;
         variables = [
           "battery.charge"
           "battery.charge.low"

--- a/hosts/blizzard/monitoring/grafana.nix
+++ b/hosts/blizzard/monitoring/grafana.nix
@@ -2,6 +2,7 @@
   lib,
   pkgs,
   VARS,
+  consts,
   ...
 }:
 let
@@ -11,7 +12,7 @@ in
   sys.services.grafana = {
     enable = true;
 
-    port = 11010;
+    port = consts.grafanaPort;
     addr = "127.0.0.1";
     openFirewall = false;
     domain = "metrics.${VARS.domains.public}";

--- a/hosts/blizzard/monitoring/grafana.nix
+++ b/hosts/blizzard/monitoring/grafana.nix
@@ -12,7 +12,7 @@ in
   sys.services.grafana = {
     enable = true;
 
-    port = consts.grafanaPort;
+    port = consts.ports.host.grafana;
     addr = "127.0.0.1";
     openFirewall = false;
     domain = "metrics.${VARS.domains.public}";

--- a/hosts/blizzard/monitoring/prometheus.nix
+++ b/hosts/blizzard/monitoring/prometheus.nix
@@ -1,4 +1,9 @@
-{ config, consts, lib, ... }:
+{
+  config,
+  consts,
+  lib,
+  ...
+}:
 {
   sys.services.prometheus = {
     enable = true;

--- a/hosts/blizzard/monitoring/prometheus.nix
+++ b/hosts/blizzard/monitoring/prometheus.nix
@@ -1,9 +1,9 @@
-{ config, lib, ... }:
+{ config, consts, lib, ... }:
 {
   sys.services.prometheus = {
     enable = true;
 
-    port = 11009;
+    port = consts.prometheusPort;
     listenAddress = "127.0.0.1";
     openFirewall = false;
     scrapeInterval = "5s";

--- a/hosts/blizzard/monitoring/prometheus.nix
+++ b/hosts/blizzard/monitoring/prometheus.nix
@@ -8,7 +8,7 @@
   sys.services.prometheus = {
     enable = true;
 
-    port = consts.prometheusPort;
+    port = consts.ports.host.prometheus;
     listenAddress = "127.0.0.1";
     openFirewall = false;
     scrapeInterval = "5s";

--- a/hosts/blizzard/monitoring/victoriametrics.nix
+++ b/hosts/blizzard/monitoring/victoriametrics.nix
@@ -1,11 +1,15 @@
-{ consts, ... }:
+{ config, consts, ... }:
 {
   sys.services.victoriametrics = {
     enable = true;
 
-    port = consts.victoriametricsPort;
+    port = consts.ports.host.victoriametrics;
     listenAddress = consts.tailscale.hosts.blizzard.ipv4;
     localAddress = consts.tailscale.hosts.blizzard.ipv4;
+    httpAuth = {
+      username = consts.victoriametrics.username;
+      passwordFile = config.sops.secrets."victoriametrics/remote_write_password".path;
+    };
     openFirewall = false;
     retentionPeriod = "10y";
     prometheusRemoteWrite = {
@@ -30,10 +34,16 @@
     };
   };
 
-  networking.firewall.interfaces.tailscale0.allowedTCPPorts = [ consts.victoriametricsPort ];
+  # VictoriaMetrics is reachable only through the encrypted Tailscale
+  # interface and still requires HTTP Basic Authentication for every API.
+  networking.firewall.interfaces.tailscale0.allowedTCPPorts = [ consts.ports.host.victoriametrics ];
 
   systemd.services.victoriametrics = {
-    after = [ "tailscaled-autoconnect.service" ];
+    after = [
+      "tailscaled-autoconnect.service"
+      "sops-install-secrets.service"
+    ];
     wants = [ "tailscaled-autoconnect.service" ];
+    requires = [ "sops-install-secrets.service" ];
   };
 }

--- a/hosts/blizzard/monitoring/victoriametrics.nix
+++ b/hosts/blizzard/monitoring/victoriametrics.nix
@@ -1,8 +1,11 @@
-_: {
+{ consts, ... }:
+{
   sys.services.victoriametrics = {
     enable = true;
 
-    listenAddress = "127.0.0.1";
+    port = consts.victoriametricsPort;
+    listenAddress = consts.tailscale.hosts.blizzard.ipv4;
+    localAddress = consts.tailscale.hosts.blizzard.ipv4;
     openFirewall = false;
     retentionPeriod = "10y";
     prometheusRemoteWrite = {
@@ -25,5 +28,12 @@ _: {
       uid = null;
       isDefault = true;
     };
+  };
+
+  networking.firewall.interfaces.tailscale0.allowedTCPPorts = [ consts.victoriametricsPort ];
+
+  systemd.services.victoriametrics = {
+    after = [ "tailscaled-autoconnect.service" ];
+    wants = [ "tailscaled-autoconnect.service" ];
   };
 }

--- a/hosts/blizzard/services/backup.nix
+++ b/hosts/blizzard/services/backup.nix
@@ -2,10 +2,11 @@
   config,
   lib,
   pkgs,
+  consts,
   ...
 }:
 let
-  immichReg = (import ../../../vms/vm-registry.nix).immich;
+  immichReg = (import ../../../vms/vm-registry.nix { inherit consts; }).immich;
   immichStorage = import ../../../vms/immich-storage.nix;
   immichBackupVolumes = immichStorage.backupVolumes;
   immichVmName = "${immichReg.name}-vm";

--- a/hosts/blizzard/services/media.nix
+++ b/hosts/blizzard/services/media.nix
@@ -22,7 +22,7 @@
     ombi = {
       enable = false;
 
-      port = consts.ombiHostPort;
+      port = consts.ports.host.ombi;
       openFirewall = true;
       dataDir = "/rpool/unenc/apps/nixos/ombi";
 
@@ -36,7 +36,7 @@
     tautulli = {
       enable = false;
 
-      port = consts.tautulliHostPort;
+      port = consts.ports.host.tautulli;
       openFirewall = true;
       dataDir = "/rpool/unenc/apps/nixos/tautulli";
 

--- a/hosts/blizzard/services/media.nix
+++ b/hosts/blizzard/services/media.nix
@@ -1,4 +1,4 @@
-{ VARS, ... }:
+{ VARS, consts, ... }:
 {
   sys.services = {
     plex = {
@@ -22,7 +22,7 @@
     ombi = {
       enable = false;
 
-      port = 11003;
+      port = consts.ombiHostPort;
       openFirewall = true;
       dataDir = "/rpool/unenc/apps/nixos/ombi";
 
@@ -36,7 +36,7 @@
     tautulli = {
       enable = false;
 
-      port = 11004;
+      port = consts.tautulliHostPort;
       openFirewall = true;
       dataDir = "/rpool/unenc/apps/nixos/tautulli";
 

--- a/hosts/blizzard/services/productivity.nix
+++ b/hosts/blizzard/services/productivity.nix
@@ -1,11 +1,11 @@
-{ VARS, ... }:
+{ VARS, consts, ... }:
 {
   sys.services = {
     paperless.enable = false;
 
     glance = {
       enable = true;
-      port = 11064;
+      port = consts.glancePort;
 
       reverseProxy = {
         enable = true;
@@ -17,7 +17,7 @@
     actual = {
       enable = false;
 
-      port = 11005;
+      port = consts.actualHostPort;
       dataDir = "/rpool/unenc/apps/nixos/actual";
     };
 

--- a/hosts/blizzard/services/productivity.nix
+++ b/hosts/blizzard/services/productivity.nix
@@ -5,7 +5,7 @@
 
     glance = {
       enable = true;
-      port = consts.glancePort;
+      port = consts.ports.host.glance;
 
       reverseProxy = {
         enable = true;
@@ -17,7 +17,7 @@
     actual = {
       enable = false;
 
-      port = consts.actualHostPort;
+      port = consts.ports.host.actual;
       dataDir = "/rpool/unenc/apps/nixos/actual";
     };
 

--- a/hosts/blizzard/services/seaweedfs.nix
+++ b/hosts/blizzard/services/seaweedfs.nix
@@ -13,21 +13,21 @@
     configDir = "/rpool/unenc/apps/nixos/seaweedfs/config";
 
     master.dataDir = "/rpool/unenc/apps/nixos/seaweedfs/master";
-    master.port = consts.seaweedfsMasterPort;
+    master.port = consts.ports.host.seaweedfsMaster;
 
     volume = {
       dataDir = "/rpool/unenc/apps/nixos/seaweedfs/volume";
-      port = consts.seaweedfsVolumePort;
-      grpcPort = consts.seaweedfsGrpcPort;
+      port = consts.ports.host.seaweedfsVolume;
+      grpcPort = consts.ports.host.seaweedfsGrpc;
     };
 
     filer = {
       dataDir = "/rpool/unenc/apps/nixos/seaweedfs/filer";
-      port = consts.seaweedfsFilerPort;
+      port = consts.ports.host.seaweedfsFiler;
     };
 
     s3 = {
-      port = consts.seaweedfsS3Port;
+      port = consts.ports.host.seaweedfsS3;
       auth = {
         enable = true;
         accessKeyFile = config.sys.secrets.seaweedfsAccessKeyFile;
@@ -35,6 +35,6 @@
       };
     };
 
-    metrics.port = consts.seaweedfsMetricsPort;
+    metrics.port = consts.ports.host.seaweedfsMetrics;
   };
 }

--- a/hosts/blizzard/services/seaweedfs.nix
+++ b/hosts/blizzard/services/seaweedfs.nix
@@ -13,21 +13,21 @@
     configDir = "/rpool/unenc/apps/nixos/seaweedfs/config";
 
     master.dataDir = "/rpool/unenc/apps/nixos/seaweedfs/master";
-    master.port = 11017;
+    master.port = consts.seaweedfsMasterPort;
 
     volume = {
       dataDir = "/rpool/unenc/apps/nixos/seaweedfs/volume";
-      port = 11018;
-      grpcPort = 11019;
+      port = consts.seaweedfsVolumePort;
+      grpcPort = consts.seaweedfsGrpcPort;
     };
 
     filer = {
       dataDir = "/rpool/unenc/apps/nixos/seaweedfs/filer";
-      port = 11020;
+      port = consts.seaweedfsFilerPort;
     };
 
     s3 = {
-      port = 11021;
+      port = consts.seaweedfsS3Port;
       auth = {
         enable = true;
         accessKeyFile = config.sys.secrets.seaweedfsAccessKeyFile;
@@ -35,6 +35,6 @@
       };
     };
 
-    metrics.port = 11022;
+    metrics.port = consts.seaweedfsMetricsPort;
   };
 }

--- a/hosts/blizzard/services/system.nix
+++ b/hosts/blizzard/services/system.nix
@@ -4,7 +4,7 @@
     scrutiny = {
       enable = true;
 
-      port = consts.scrutinyPort;
+      port = consts.ports.host.scrutiny;
       openFirewall = true;
 
       reverseProxy = {
@@ -16,7 +16,7 @@
 
     cockpit = {
       enable = false;
-      port = consts.cockpitPort;
+      port = consts.ports.host.cockpit;
       openFirewall = true;
     };
   };

--- a/hosts/blizzard/services/system.nix
+++ b/hosts/blizzard/services/system.nix
@@ -1,10 +1,10 @@
-{ VARS, ... }:
+{ VARS, consts, ... }:
 {
   sys.services = {
     scrutiny = {
       enable = true;
 
-      port = 11001;
+      port = consts.scrutinyPort;
       openFirewall = true;
 
       reverseProxy = {
@@ -16,7 +16,7 @@
 
     cockpit = {
       enable = false;
-      port = 11006;
+      port = consts.cockpitPort;
       openFirewall = true;
     };
   };

--- a/hosts/blizzard/virtualisation/microvms.nix
+++ b/hosts/blizzard/virtualisation/microvms.nix
@@ -8,7 +8,6 @@
 }:
 let
   reg = import ../../../vms/vm-registry.nix;
-  immichMlProxyPort = 3003;
 
   mkPortForward =
     proto: sourcePort: destPort:
@@ -45,7 +44,7 @@ let
         (mkPortForward "both" 53 null)
         (mkPortForward "tcp" 443 null)
         (mkPortForward "tcp" 853 null)
-        (mkPortForward "tcp" 11010 null)
+        (mkPortForward "tcp" consts.adguardPort null)
       ];
       publication.hostname = "adguard";
     };
@@ -178,12 +177,12 @@ let
 
     qbittorrent = {
       enable = true;
-      portForwards = [ (mkPortForward "tcp" 11030 null) ];
+      portForwards = [ (mkPortForward "tcp" consts.qbittorrentPort null) ];
     };
 
     sabnzbd = {
       enable = true;
-      portForwards = [ (mkPortForward "tcp" 11031 null) ];
+      portForwards = [ (mkPortForward "tcp" consts.sabnzbdPort null) ];
       publication = {
         enable = true;
         hostname = "sab";
@@ -193,14 +192,14 @@ let
 
     wireguard = {
       enable = true;
-      portForwards = [ (mkPortForward "udp" 51820 56943) ];
+      portForwards = [ (mkPortForward "udp" 51820 consts.wireguardPort) ];
     };
 
     firefox = {
       enable = true;
       portForwards = [
-        (mkPortForward "tcp" 11052 null)
-        (mkPortForward "tcp" 11053 null)
+        (mkPortForward "tcp" consts.firefoxPort null)
+        (mkPortForward "tcp" consts.firefoxHttpsPort null)
       ];
       publication = {
         enable = true;
@@ -212,8 +211,8 @@ let
     brave = {
       enable = false;
       portForwards = [
-        (mkPortForward "tcp" 11054 null)
-        (mkPortForward "tcp" 11055 null)
+        (mkPortForward "tcp" consts.bravePort null)
+        (mkPortForward "tcp" consts.braveHttpsPort null)
       ];
       publication = {
         hostname = "brave";
@@ -232,7 +231,7 @@ let
 
     paperless = {
       enable = false;
-      portForwards = [ (mkPortForward "tcp" 11061 null) ];
+      portForwards = [ (mkPortForward "tcp" consts.paperlessPort null) ];
       publication = {
         hostname = "docs";
         policy = "csrf-compatible";
@@ -241,7 +240,7 @@ let
 
     firefly = {
       enable = false;
-      portForwards = [ (mkPortForward "tcp" 11062 null) ];
+      portForwards = [ (mkPortForward "tcp" consts.fireflyPort null) ];
       publication = {
         hostname = "finance";
         policy = "firefly-proxy";
@@ -250,7 +249,7 @@ let
 
     "firefly-importer" = {
       enable = false;
-      portForwards = [ (mkPortForward "tcp" 11063 null) ];
+      portForwards = [ (mkPortForward "tcp" consts.fireflyImporterPort null) ];
       publication = {
         hostname = "finimport";
         policy = "firefly-proxy";
@@ -261,7 +260,7 @@ let
       enable = true;
       # Keep the managed Cloudflare publication while also allowing direct
       # home-LAN access through Blizzard at TCP 11070.
-      portForwards = [ (mkPortForward "tcp" 11070 null) ];
+      portForwards = [ (mkPortForward "tcp" consts.immichPort null) ];
       publication = {
         enable = true;
         hostname = "photos";
@@ -271,7 +270,7 @@ let
 
     mealie = {
       enable = false;
-      portForwards = [ (mkPortForward "tcp" 11071 null) ];
+      portForwards = [ (mkPortForward "tcp" consts.mealiePort null) ];
       publication.hostname = "recipes";
     };
 
@@ -295,7 +294,7 @@ let
   };
 in
 {
-  networking.firewall.interfaces."microvm-br0".allowedTCPPorts = [ immichMlProxyPort ];
+  networking.firewall.interfaces."microvm-br0".allowedTCPPorts = [ consts.immichMachineLearningPort ];
 
   systemd.services.immich-ml-proxy = {
     description = "Proxy Immich MicroVM machine-learning requests to Kaizer";
@@ -308,7 +307,7 @@ in
     wantedBy = [ "multi-user.target" ];
 
     serviceConfig = {
-      ExecStart = "${lib.getExe pkgs.socat} TCP-LISTEN:${toString immichMlProxyPort},bind=10.100.0.1,reuseaddr,fork TCP:kaizer.boreal-ruler.ts.net:${toString immichMlProxyPort}";
+      ExecStart = "${lib.getExe pkgs.socat} TCP-LISTEN:${toString consts.immichMachineLearningPort},bind=10.100.0.1,reuseaddr,fork TCP:kaizer.boreal-ruler.ts.net:${toString consts.immichMachineLearningPort}";
       Restart = "always";
       RestartSec = "5s";
       DynamicUser = true;

--- a/hosts/blizzard/virtualisation/microvms.nix
+++ b/hosts/blizzard/virtualisation/microvms.nix
@@ -7,7 +7,7 @@
   ...
 }:
 let
-  reg = import ../../../vms/vm-registry.nix;
+  reg = import ../../../vms/vm-registry.nix { inherit consts; };
 
   mkPortForward =
     proto: sourcePort: destPort:
@@ -44,7 +44,7 @@ let
         (mkPortForward "both" 53 null)
         (mkPortForward "tcp" 443 null)
         (mkPortForward "tcp" 853 null)
-        (mkPortForward "tcp" consts.adguardPort null)
+        (mkPortForward "tcp" consts.ports.vm.adguard null)
       ];
       publication.hostname = "adguard";
     };
@@ -177,12 +177,12 @@ let
 
     qbittorrent = {
       enable = true;
-      portForwards = [ (mkPortForward "tcp" consts.qbittorrentPort null) ];
+      portForwards = [ (mkPortForward "tcp" consts.ports.vm.qbittorrent null) ];
     };
 
     sabnzbd = {
       enable = true;
-      portForwards = [ (mkPortForward "tcp" consts.sabnzbdPort null) ];
+      portForwards = [ (mkPortForward "tcp" consts.ports.vm.sabnzbd null) ];
       publication = {
         enable = true;
         hostname = "sab";
@@ -192,14 +192,14 @@ let
 
     wireguard = {
       enable = true;
-      portForwards = [ (mkPortForward "udp" 51820 consts.wireguardPort) ];
+      portForwards = [ (mkPortForward "udp" 51820 consts.ports.vm.wireguard) ];
     };
 
     firefox = {
       enable = true;
       portForwards = [
-        (mkPortForward "tcp" consts.firefoxPort null)
-        (mkPortForward "tcp" consts.firefoxHttpsPort null)
+        (mkPortForward "tcp" consts.ports.vm.firefox null)
+        (mkPortForward "tcp" consts.ports.secondary.firefoxHttps null)
       ];
       publication = {
         enable = true;
@@ -211,8 +211,8 @@ let
     brave = {
       enable = false;
       portForwards = [
-        (mkPortForward "tcp" consts.bravePort null)
-        (mkPortForward "tcp" consts.braveHttpsPort null)
+        (mkPortForward "tcp" consts.ports.vm.brave null)
+        (mkPortForward "tcp" consts.ports.secondary.braveHttps null)
       ];
       publication = {
         hostname = "brave";
@@ -231,7 +231,7 @@ let
 
     paperless = {
       enable = false;
-      portForwards = [ (mkPortForward "tcp" consts.paperlessPort null) ];
+      portForwards = [ (mkPortForward "tcp" consts.ports.vm.paperless null) ];
       publication = {
         hostname = "docs";
         policy = "csrf-compatible";
@@ -240,7 +240,7 @@ let
 
     firefly = {
       enable = false;
-      portForwards = [ (mkPortForward "tcp" consts.fireflyPort null) ];
+      portForwards = [ (mkPortForward "tcp" consts.ports.vm.firefly null) ];
       publication = {
         hostname = "finance";
         policy = "firefly-proxy";
@@ -249,7 +249,7 @@ let
 
     "firefly-importer" = {
       enable = false;
-      portForwards = [ (mkPortForward "tcp" consts.fireflyImporterPort null) ];
+      portForwards = [ (mkPortForward "tcp" consts.ports.vm.fireflyImporter null) ];
       publication = {
         hostname = "finimport";
         policy = "firefly-proxy";
@@ -260,7 +260,7 @@ let
       enable = true;
       # Keep the managed Cloudflare publication while also allowing direct
       # home-LAN access through Blizzard at TCP 11070.
-      portForwards = [ (mkPortForward "tcp" consts.immichPort null) ];
+      portForwards = [ (mkPortForward "tcp" consts.ports.vm.immich null) ];
       publication = {
         enable = true;
         hostname = "photos";
@@ -270,7 +270,7 @@ let
 
     mealie = {
       enable = false;
-      portForwards = [ (mkPortForward "tcp" consts.mealiePort null) ];
+      portForwards = [ (mkPortForward "tcp" consts.ports.vm.mealie null) ];
       publication.hostname = "recipes";
     };
 
@@ -294,7 +294,7 @@ let
   };
 in
 {
-  networking.firewall.interfaces."microvm-br0".allowedTCPPorts = [ consts.immichMachineLearningPort ];
+  networking.firewall.interfaces."microvm-br0".allowedTCPPorts = [ consts.ports.secondary.immichMachineLearning.hostPort ];
 
   systemd.services.immich-ml-proxy = {
     description = "Proxy Immich MicroVM machine-learning requests to Kaizer";
@@ -307,7 +307,7 @@ in
     wantedBy = [ "multi-user.target" ];
 
     serviceConfig = {
-      ExecStart = "${lib.getExe pkgs.socat} TCP-LISTEN:${toString consts.immichMachineLearningPort},bind=10.100.0.1,reuseaddr,fork TCP:kaizer.boreal-ruler.ts.net:${toString consts.immichMachineLearningPort}";
+      ExecStart = "${lib.getExe pkgs.socat} TCP-LISTEN:${toString consts.ports.secondary.immichMachineLearning.hostPort},bind=10.100.0.1,reuseaddr,fork TCP:kaizer.boreal-ruler.ts.net:${toString consts.ports.secondary.immichMachineLearning.hostPort}";
       Restart = "always";
       RestartSec = "5s";
       DynamicUser = true;

--- a/hosts/blizzard/virtualisation/microvms.nix
+++ b/hosts/blizzard/virtualisation/microvms.nix
@@ -294,7 +294,9 @@ let
   };
 in
 {
-  networking.firewall.interfaces."microvm-br0".allowedTCPPorts = [ consts.ports.secondary.immichMachineLearning.hostPort ];
+  networking.firewall.interfaces."microvm-br0".allowedTCPPorts = [
+    consts.ports.secondary.immichMachineLearning.hostPort
+  ];
 
   systemd.services.immich-ml-proxy = {
     description = "Proxy Immich MicroVM machine-learning requests to Kaizer";

--- a/hosts/kaizer/containers.nix
+++ b/hosts/kaizer/containers.nix
@@ -4,7 +4,9 @@ let
   username = VARS.users.luke.user;
 in
 {
-  networking.firewall.interfaces.tailscale0.allowedTCPPorts = [ consts.ports.secondary.immichMachineLearning.hostPort ];
+  networking.firewall.interfaces.tailscale0.allowedTCPPorts = [
+    consts.ports.secondary.immichMachineLearning.hostPort
+  ];
 
   users.users.${username} = {
     linger = true;

--- a/hosts/kaizer/containers.nix
+++ b/hosts/kaizer/containers.nix
@@ -4,7 +4,7 @@ let
   username = VARS.users.luke.user;
 in
 {
-  networking.firewall.interfaces.tailscale0.allowedTCPPorts = [ consts.immichMachineLearningPort ];
+  networking.firewall.interfaces.tailscale0.allowedTCPPorts = [ consts.ports.secondary.immichMachineLearning.hostPort ];
 
   users.users.${username} = {
     linger = true;
@@ -22,7 +22,7 @@ in
 
     services.immich-machine-learning-container = {
       enable = true;
-      port = consts.immichMachineLearningPort;
+      port = consts.ports.secondary.immichMachineLearning.hostPort;
       acceleration = "cuda";
     };
   };

--- a/hosts/kaizer/containers.nix
+++ b/hosts/kaizer/containers.nix
@@ -1,11 +1,10 @@
 # Rootless Podman containers on kaizer (managed via quadlet-nix + Home Manager)
-{ VARS, ... }:
+{ VARS, consts, ... }:
 let
   username = VARS.users.luke.user;
-  immichMlPort = 3003;
 in
 {
-  networking.firewall.interfaces.tailscale0.allowedTCPPorts = [ immichMlPort ];
+  networking.firewall.interfaces.tailscale0.allowedTCPPorts = [ consts.immichMachineLearningPort ];
 
   users.users.${username} = {
     linger = true;
@@ -23,7 +22,7 @@ in
 
     services.immich-machine-learning-container = {
       enable = true;
-      port = immichMlPort;
+      port = consts.immichMachineLearningPort;
       acceleration = "cuda";
     };
   };

--- a/hosts/snowfall/snowfall.nix
+++ b/hosts/snowfall/snowfall.nix
@@ -128,13 +128,13 @@ in
       # Enable RAPL power monitoring for CPU
       prometheusExporters.node = {
         enableRapl = true;
-        port = consts.nodeExporterPort;
+        port = consts.ports.host.nodeExporter;
       };
 
       # Norwegian electricity price exporter (NO2 = Sør-Norge)
       electricityPriceExporter = {
         enable = true;
-        port = consts.electricityPriceExporterPort;
+        port = consts.ports.host.electricityPriceExporter;
         priceArea = "NO2";
       };
 
@@ -154,7 +154,7 @@ in
 
       prometheus = {
         enable = lib.mkDefault true;
-        port = consts.prometheusPort;
+        port = consts.ports.host.prometheus;
         listenAddress = "127.0.0.1";
         openFirewall = lib.mkDefault false;
         scrapeInterval = "15s";
@@ -182,7 +182,7 @@ in
 
       grafana = {
         enable = lib.mkDefault true;
-        port = consts.grafanaPort;
+        port = consts.ports.host.grafana;
 
         addr = "127.0.0.1";
         openFirewall = lib.mkDefault false;
@@ -223,7 +223,11 @@ in
       victoriametricsRemoteWrite = {
         enable = true;
         vmHost = "blizzard"; # Tailscale hostname
-        vmPort = consts.victoriametricsPort;
+        vmPort = consts.ports.host.victoriametrics;
+        basicAuth = {
+          username = consts.victoriametrics.username;
+          passwordFile = config.sops.secrets."victoriametrics/remote_write_password".path;
+        };
       };
 
       traefik = {

--- a/hosts/snowfall/snowfall.nix
+++ b/hosts/snowfall/snowfall.nix
@@ -128,13 +128,13 @@ in
       # Enable RAPL power monitoring for CPU
       prometheusExporters.node = {
         enableRapl = true;
-        port = 11011;
+        port = consts.nodeExporterPort;
       };
 
       # Norwegian electricity price exporter (NO2 = Sør-Norge)
       electricityPriceExporter = {
         enable = true;
-        port = 11012;
+        port = consts.electricityPriceExporterPort;
         priceArea = "NO2";
       };
 
@@ -154,7 +154,7 @@ in
 
       prometheus = {
         enable = lib.mkDefault true;
-        port = 11009;
+        port = consts.prometheusPort;
         listenAddress = "127.0.0.1";
         openFirewall = lib.mkDefault false;
         scrapeInterval = "15s";
@@ -182,7 +182,7 @@ in
 
       grafana = {
         enable = lib.mkDefault true;
-        port = 11010;
+        port = consts.grafanaPort;
 
         addr = "127.0.0.1";
         openFirewall = lib.mkDefault false;
@@ -223,6 +223,7 @@ in
       victoriametricsRemoteWrite = {
         enable = true;
         vmHost = "blizzard"; # Tailscale hostname
+        vmPort = consts.victoriametricsPort;
       };
 
       traefik = {
@@ -271,7 +272,7 @@ in
 
   fileSystems = {
     "/mnt/backups" = {
-      device = "100.86.227.97:/rpool/enc/transfers";
+      device = "${consts.tailscale.hosts.blizzard.ipv4}:/rpool/enc/transfers";
       fsType = "nfs";
       options = [
         "nofail"
@@ -281,7 +282,7 @@ in
     };
 
     "/mnt/media" = {
-      device = "100.86.227.97:/rpool/unenc/media/data/media";
+      device = "${consts.tailscale.hosts.blizzard.ipv4}:/rpool/unenc/media/data/media";
       fsType = "nfs";
       options = [
         "nofail"

--- a/lib/README.md
+++ b/lib/README.md
@@ -40,6 +40,13 @@ places.
 | Key | Value | Purpose |
 |-----|-------|---------|
 | `tailscale.suffix` | `"mole-delta.ts.net"` | Tailscale network domain suffix for building service FQDNs |
+| `tailscale.hosts.blizzard.ipv4` | `"100.86.227.97"` | Shared Blizzard Tailscale endpoint |
+| `<service>Port` | service-specific integer | Shared host, MicroVM, and secondary service ports |
+
+The port constants include names such as `immichPort`, `victoriametricsPort`,
+`prometheusPort`, and `immichMachineLearningPort`. MicroVM primary ports in
+`vms/vm-registry.nix` are sourced from these constants so the registry remains
+the assembled VM contract without duplicating the numeric assignments.
 
 ______________________________________________________________________
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -17,9 +17,9 @@ ______________________________________________________________________
 
 ### constants.nix
 
-Shared string constants used throughout the configuration. Loaded once in
-`flake.nix` as `consts` and threaded through all hosts and VMs via
-`specialArgs`.
+Shared string, endpoint, and port constants used throughout the configuration.
+Loaded once in `flake.nix` as `consts` and threaded through all hosts, VMs, and
+Home Manager modules via `specialArgs`.
 
 **Purpose:** Avoid repeating magic strings (domain suffixes, IDs) in multiple
 places.
@@ -41,12 +41,16 @@ places.
 |-----|-------|---------|
 | `tailscale.suffix` | `"mole-delta.ts.net"` | Tailscale network domain suffix for building service FQDNs |
 | `tailscale.hosts.blizzard.ipv4` | `"100.86.227.97"` | Shared Blizzard Tailscale endpoint |
-| `<service>Port` | service-specific integer | Shared host, MicroVM, and secondary service ports |
+| `ports.host.<service>` | service-specific integer | Physical-host service ports |
+| `ports.vm.<service>` | service-specific integer | MicroVM primary service ports |
+| `ports.secondary.<service>` | service-specific integer or `{ hostPort, containerPort }` | Secondary service endpoints and container contracts |
+| `ports.network.<service>` | service-specific integer | Network-only ports such as the qBittorrent torrent port |
+| `victoriametrics.username` | `"metrics-writer"` | Shared Basic Authentication username for the protected metrics endpoint |
 
-The port constants include names such as `immichPort`, `victoriametricsPort`,
-`prometheusPort`, and `immichMachineLearningPort`. MicroVM primary ports in
-`vms/vm-registry.nix` are sourced from these constants so the registry remains
-the assembled VM contract without duplicating the numeric assignments.
+MicroVM primary ports in `vms/vm-registry.nix` are sourced from
+`consts.ports.vm`, so the registry remains the assembled VM contract without
+duplicating numeric assignments. The registry receives the same injected
+`consts` value as the rest of the NixOS configuration.
 
 ______________________________________________________________________
 

--- a/lib/constants.nix
+++ b/lib/constants.nix
@@ -1,10 +1,75 @@
 # Centralized constants shared across hosts, VMs, and services.
-# For secrets use sops-nix; for per-host data use host configs.
+# For secrets use sops-nix; host-local data should remain in host configs.
+let
+  blackboxPortValue = 9115;
+in
 {
-  tailscale.suffix = "mole-delta.ts.net";
+  tailscale = {
+    suffix = "mole-delta.ts.net";
+    # Shared endpoint consumed by multiple hosts and the Blizzard services.
+    hosts.blizzard.ipv4 = "100.86.227.97";
+  };
 
+  # Blizzard host service ports.
+  scrutinyPort = 11001;
+  ombiHostPort = 11003;
+  tautulliHostPort = 11004;
+  actualHostPort = 11005;
+  cockpitPort = 11006;
+  victoriametricsPort = 11008;
+  prometheusPort = 11009;
+  grafanaPort = 11010;
+  nodeExporterPort = 11011;
+  electricityPriceExporterPort = 11012;
+  zfsExporterPort = 11013;
+  upsExporterPort = 11014;
+  cloudflareMetricsPort = 11015;
+  seaweedfsMasterPort = 11017;
+  seaweedfsVolumePort = 11018;
+  seaweedfsGrpcPort = 11019;
+  seaweedfsFilerPort = 11020;
+  seaweedfsS3Port = 11021;
+  seaweedfsMetricsPort = 11022;
+  glancePort = 11064;
+
+  # MicroVM primary service ports.
+  adguardPort = 11010;
+  actualPort = 11051;
+  searxPort = 11012;
+  ombiPort = 11041;
+  tautulliPort = 11042;
+  giteaPort = 11050;
+  sonarrPort = 11021;
+  radarrPort = 11022;
+  prowlarrPort = 11020;
+  bazarrPort = 11023;
+  readarrPort = 11024;
+  lidarrPort = 11028;
+  qbittorrentPort = 11030;
+  qbittorrentTorrentPort = 50820;
+  overseerrPort = 11040;
+  firefoxPort = 11052;
+  wireguardPort = 56943;
+  sabnzbdPort = 11031;
+  flaresolverrPort = 11013;
+  matrixSynapsePort = 11060;
+  paperlessPort = 11061;
+  fireflyPort = 11062;
+  bravePort = 11054;
+  fireflyImporterPort = 11063;
+  immichPort = 11070;
+  mealiePort = 11071;
+  triggerPort = 11080;
+  pocketIdPort = 11081;
+
+  # Secondary service endpoints.
+  immichMachineLearningPort = 3003;
+  firefoxHttpsPort = 11053;
+  braveHttpsPort = 11055;
+
+  blackboxPort = blackboxPortValue;
   blackbox = {
-    port = 9115;
+    port = blackboxPortValue;
     jobName = "blackbox";
     probeTimeout = "10s";
     scrapeInterval = "30s";

--- a/lib/constants.nix
+++ b/lib/constants.nix
@@ -1,8 +1,5 @@
 # Centralized constants shared across hosts, VMs, and services.
 # For secrets use sops-nix; host-local data should remain in host configs.
-let
-  blackboxPortValue = 9115;
-in
 {
   tailscale = {
     suffix = "mole-delta.ts.net";
@@ -10,66 +7,77 @@ in
     hosts.blizzard.ipv4 = "100.86.227.97";
   };
 
-  # Blizzard host service ports.
-  scrutinyPort = 11001;
-  ombiHostPort = 11003;
-  tautulliHostPort = 11004;
-  actualHostPort = 11005;
-  cockpitPort = 11006;
-  victoriametricsPort = 11008;
-  prometheusPort = 11009;
-  grafanaPort = 11010;
-  nodeExporterPort = 11011;
-  electricityPriceExporterPort = 11012;
-  zfsExporterPort = 11013;
-  upsExporterPort = 11014;
-  cloudflareMetricsPort = 11015;
-  seaweedfsMasterPort = 11017;
-  seaweedfsVolumePort = 11018;
-  seaweedfsGrpcPort = 11019;
-  seaweedfsFilerPort = 11020;
-  seaweedfsS3Port = 11021;
-  seaweedfsMetricsPort = 11022;
-  glancePort = 11064;
+  # Keep host, MicroVM, secondary-service, and network ports in separate
+  # namespaces so service ownership is explicit at call sites.
+  ports = {
+    host = {
+      scrutiny = 11001;
+      ombi = 11003;
+      tautulli = 11004;
+      actual = 11005;
+      cockpit = 11006;
+      victoriametrics = 11008;
+      prometheus = 11009;
+      grafana = 11010;
+      nodeExporter = 11011;
+      electricityPriceExporter = 11012;
+      zfsExporter = 11013;
+      upsExporter = 11014;
+      cloudflareMetrics = 11015;
+      seaweedfsMaster = 11017;
+      seaweedfsVolume = 11018;
+      seaweedfsGrpc = 11019;
+      seaweedfsFiler = 11020;
+      seaweedfsS3 = 11021;
+      seaweedfsMetrics = 11022;
+      glance = 11064;
+    };
 
-  # MicroVM primary service ports.
-  adguardPort = 11010;
-  actualPort = 11051;
-  searxPort = 11012;
-  ombiPort = 11041;
-  tautulliPort = 11042;
-  giteaPort = 11050;
-  sonarrPort = 11021;
-  radarrPort = 11022;
-  prowlarrPort = 11020;
-  bazarrPort = 11023;
-  readarrPort = 11024;
-  lidarrPort = 11028;
-  qbittorrentPort = 11030;
-  qbittorrentTorrentPort = 50820;
-  overseerrPort = 11040;
-  firefoxPort = 11052;
-  wireguardPort = 56943;
-  sabnzbdPort = 11031;
-  flaresolverrPort = 11013;
-  matrixSynapsePort = 11060;
-  paperlessPort = 11061;
-  fireflyPort = 11062;
-  bravePort = 11054;
-  fireflyImporterPort = 11063;
-  immichPort = 11070;
-  mealiePort = 11071;
-  triggerPort = 11080;
-  pocketIdPort = 11081;
+    vm = {
+      adguard = 11010;
+      actual = 11051;
+      searx = 11012;
+      ombi = 11041;
+      tautulli = 11042;
+      gitea = 11050;
+      sonarr = 11021;
+      radarr = 11022;
+      prowlarr = 11020;
+      bazarr = 11023;
+      readarr = 11024;
+      lidarr = 11028;
+      qbittorrent = 11030;
+      overseerr = 11040;
+      firefox = 11052;
+      wireguard = 56943;
+      sabnzbd = 11031;
+      flaresolverr = 11013;
+      matrixSynapse = 11060;
+      paperless = 11061;
+      firefly = 11062;
+      brave = 11054;
+      fireflyImporter = 11063;
+      immich = 11070;
+      mealie = 11071;
+      trigger = 11080;
+      pocketId = 11081;
+    };
 
-  # Secondary service endpoints.
-  immichMachineLearningPort = 3003;
-  firefoxHttpsPort = 11053;
-  braveHttpsPort = 11055;
+    secondary = {
+      immichMachineLearning = rec {
+        hostPort = 3003;
+        containerPort = hostPort;
+      };
+      firefoxHttps = 11053;
+      braveHttps = 11055;
+    };
 
-  blackboxPort = blackboxPortValue;
+    network.qbittorrentTorrent = 50820;
+  };
+
+  victoriametrics.username = "metrics-writer";
   blackbox = {
-    port = blackboxPortValue;
+    port = 9115;
     jobName = "blackbox";
     probeTimeout = "10s";
     scrapeInterval = "30s";

--- a/modules/core/sops.nix
+++ b/modules/core/sops.nix
@@ -17,6 +17,8 @@ let
   hasSearx = config.services.searx.enable or false;
   hasGrafana = config.sys.services.grafana.enable or false;
   hasGrafanaCloud = config.sys.services.grafanaCloud.enable or false;
+  hasVictoriaMetrics = config.sys.services.victoriametrics.enable or false;
+  hasVictoriaMetricsRemoteWrite = config.sys.services.victoriametricsRemoteWrite.enable or false;
   hasCloudflared = config.sys.services.cloudflared.enable or false;
   hasCrowdsec = config.services.crowdsec.enable or false;
   hasCloudflareAccessIpUpdater = config.sys.services.cloudflareAccessIpUpdater.enable or false;
@@ -77,6 +79,15 @@ in
         "grafana/secret_key" = {
           owner = "grafana";
           group = "grafana";
+          mode = "0440";
+        };
+      }
+      // whenEnabled (hasVictoriaMetrics || hasVictoriaMetricsRemoteWrite) {
+        # Shared by the protected Blizzard endpoint and its Prometheus writers.
+        # The value itself lives in the private nix-secrets flake.
+        "victoriametrics/remote_write_password" = {
+          owner = "root";
+          group = "monitoring-credentials";
           mode = "0440";
         };
       }

--- a/modules/home-manager-integration.nix
+++ b/modules/home-manager-integration.nix
@@ -4,6 +4,7 @@
   inputs,
   self,
   VARS,
+  consts,
   ...
 }:
 let
@@ -24,7 +25,7 @@ in
       ];
 
       extraSpecialArgs = {
-        inherit inputs VARS;
+        inherit inputs VARS consts;
         inherit (config.networking) hostName;
       };
     };

--- a/modules/services/README.md
+++ b/modules/services/README.md
@@ -68,8 +68,8 @@ ______________________________________________________________________
 | [cloudflare-metrics.nix](cloudflare-metrics.nix) | `sys.services.cloudflareMetrics` | Host (blizzard) | Cloudflare HTTP analytics and Access authentication Prometheus collector ([runbook](../../docs/cloudflare-metrics.md)) |
 | [prometheus.nix](prometheus.nix) | `sys.services.prometheus` | Host (blizzard) | Metrics collection |
 | [prometheus-exporters.nix](prometheus-exporters.nix) | `sys.services.prometheusExporters` | Host + VMs | System metrics exporters |
-| [victoriametrics.nix](victoriametrics.nix) | `sys.services.victoriametrics` | Host (blizzard) | Long-term time-series storage |
-| [victoriametrics-remote-write.nix](victoriametrics-remote-write.nix) | `sys.services.victoriametricsRemoteWrite` | Host | Remote-write forwarding |
+| [victoriametrics.nix](victoriametrics.nix) | `sys.services.victoriametrics` | Host (blizzard) | Long-term time-series storage with optional SOPS-backed HTTP Basic Authentication |
+| [victoriametrics-remote-write.nix](victoriametrics-remote-write.nix) | `sys.services.victoriametricsRemoteWrite` | Host | Authenticated remote-write forwarding |
 | [arr-exporter.nix](arr-exporter.nix) | `sys.services.arrExporter` | MicroVM | Prometheus exporter for Arr stack |
 | [electricity-price-exporter.nix](electricity-price-exporter.nix) | `sys.services.electricityPriceExporter` | Host | Nord Pool electricity price exporter |
 | [scrutiny.nix](scrutiny.nix) | `sys.services.scrutiny` | Host (blizzard) | Disk health monitoring; consumes the root-only `scrutiny/token` SOPS secret as a service credential for local InfluxDB ([runbook](../../docs/scrutiny.md)) |

--- a/modules/services/blackbox.nix
+++ b/modules/services/blackbox.nix
@@ -2,12 +2,13 @@
   config,
   lib,
   pkgs,
+  consts,
   ...
 }:
 let
   cfg = config.sys.services.blackbox;
-  blackboxConstants = (import ../../lib/constants.nix).blackbox;
-  blackboxPort = blackboxConstants.port;
+  blackboxConstants = consts.blackbox;
+  blackboxPort = consts.blackboxPort;
 
   targetType = lib.types.submodule {
     options = {

--- a/modules/services/blackbox.nix
+++ b/modules/services/blackbox.nix
@@ -8,7 +8,7 @@
 let
   cfg = config.sys.services.blackbox;
   blackboxConstants = consts.blackbox;
-  blackboxPort = consts.blackboxPort;
+  blackboxPort = blackboxConstants.port;
 
   targetType = lib.types.submodule {
     options = {

--- a/modules/services/cloudflare-metrics.nix
+++ b/modules/services/cloudflare-metrics.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  consts,
   ...
 }:
 let
@@ -35,7 +36,7 @@ in
 
     port = lib.mkOption {
       type = lib.types.port;
-      default = 11015;
+      default = consts.cloudflareMetricsPort;
       description = "Loopback port on which the collector exposes Prometheus metrics.";
     };
 

--- a/modules/services/cloudflare-metrics.nix
+++ b/modules/services/cloudflare-metrics.nix
@@ -36,7 +36,7 @@ in
 
     port = lib.mkOption {
       type = lib.types.port;
-      default = consts.cloudflareMetricsPort;
+      default = consts.ports.host.cloudflareMetrics;
       description = "Loopback port on which the collector exposes Prometheus metrics.";
     };
 

--- a/modules/services/qbittorrent.nix
+++ b/modules/services/qbittorrent.nix
@@ -26,7 +26,7 @@ in
 
     torrentPort = lib.mkOption {
       type = lib.types.nullOr lib.types.port;
-      default = consts.qbittorrentTorrentPort;
+      default = consts.ports.network.qbittorrentTorrent;
       description = "Incoming torrent port (TCP/UDP).";
     };
 

--- a/modules/services/qbittorrent.nix
+++ b/modules/services/qbittorrent.nix
@@ -2,6 +2,7 @@
   lib,
   config,
   pkgs,
+  consts,
   ...
 }:
 let
@@ -25,7 +26,7 @@ in
 
     torrentPort = lib.mkOption {
       type = lib.types.nullOr lib.types.port;
-      default = 50820;
+      default = consts.qbittorrentTorrentPort;
       description = "Incoming torrent port (TCP/UDP).";
     };
 

--- a/modules/services/victoriametrics-remote-write.nix
+++ b/modules/services/victoriametrics-remote-write.nix
@@ -3,6 +3,7 @@
 {
   lib,
   config,
+  consts,
   ...
 }:
 let
@@ -24,7 +25,7 @@ in
 
     vmPort = lib.mkOption {
       type = lib.types.port;
-      default = 11008;
+      default = consts.victoriametricsPort;
       description = "Port on which the remote VictoriaMetrics listens";
     };
 

--- a/modules/services/victoriametrics-remote-write.nix
+++ b/modules/services/victoriametrics-remote-write.nix
@@ -8,6 +8,8 @@
 }:
 let
   cfg = config.sys.services.victoriametricsRemoteWrite;
+  hasBasicAuth = cfg.basicAuth.username != null;
+  credentialGroup = "monitoring-credentials";
 in
 {
   options.sys.services.victoriametricsRemoteWrite = {
@@ -25,8 +27,25 @@ in
 
     vmPort = lib.mkOption {
       type = lib.types.port;
-      default = consts.victoriametricsPort;
+      default = consts.ports.host.victoriametrics;
       description = "Port on which the remote VictoriaMetrics listens";
+    };
+
+    basicAuth = {
+      username = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "Basic Authentication username for the remote VictoriaMetrics instance";
+      };
+
+      passwordFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = ''
+          SOPS-managed file containing the Basic Authentication password for
+          the remote VictoriaMetrics instance.
+        '';
+      };
     };
 
     path = lib.mkOption {
@@ -77,6 +96,10 @@ in
   config = lib.mkIf cfg.enable {
     assertions = [
       {
+        assertion = (cfg.basicAuth.username == null) == (cfg.basicAuth.passwordFile == null);
+        message = "sys.services.victoriametricsRemoteWrite.basicAuth.username and passwordFile must both be set or both be null";
+      }
+      {
         assertion = config.services.prometheus.enable or config.sys.services.prometheus.enable or false;
         message = "victoriametricsRemoteWrite requires Prometheus to be enabled";
       }
@@ -90,33 +113,49 @@ in
     ];
 
     services.prometheus.remoteWrite = [
-      {
-        url =
-          let
-            protocol = if cfg.useHttps then "https" else "http";
-          in
-          "${protocol}://${cfg.vmHost}:${toString cfg.vmPort}${cfg.path}";
+      (
+        {
+          url =
+            let
+              protocol = if cfg.useHttps then "https" else "http";
+            in
+            "${protocol}://${cfg.vmHost}:${toString cfg.vmPort}${cfg.path}";
 
-        queue_config = {
-          inherit (cfg.queueConfig) capacity;
+          queue_config = {
+            inherit (cfg.queueConfig) capacity;
 
-          max_shards = cfg.queueConfig.maxShards;
-          min_shards = cfg.queueConfig.minShards;
-          max_samples_per_send = cfg.queueConfig.maxSamplesPerSend;
-          batch_send_deadline = cfg.queueConfig.batchSendDeadline;
-          min_backoff = "30ms";
-          max_backoff = "5s";
-        };
+            max_shards = cfg.queueConfig.maxShards;
+            min_shards = cfg.queueConfig.minShards;
+            max_samples_per_send = cfg.queueConfig.maxSamplesPerSend;
+            batch_send_deadline = cfg.queueConfig.batchSendDeadline;
+            min_backoff = "30ms";
+            max_backoff = "5s";
+          };
 
-        # Add hostname label to all metrics for identification
-        write_relabel_configs = [
-          {
-            source_labels = [ "__address__" ];
-            target_label = "source_host";
-            replacement = config.networking.hostName;
-          }
-        ];
-      }
+          # Add hostname label to all metrics for identification
+          write_relabel_configs = [
+            {
+              source_labels = [ "__address__" ];
+              target_label = "source_host";
+              replacement = config.networking.hostName;
+            }
+          ];
+        }
+        // lib.optionalAttrs hasBasicAuth {
+          basic_auth = {
+            username = cfg.basicAuth.username;
+            password_file = cfg.basicAuth.passwordFile;
+          };
+        }
+      )
     ];
+
+    users.groups.${credentialGroup} = lib.mkIf hasBasicAuth { };
+    users.users.prometheus.extraGroups = lib.mkIf hasBasicAuth (lib.mkAfter [ credentialGroup ]);
+
+    systemd.services.prometheus = lib.mkIf hasBasicAuth {
+      after = [ "sops-install-secrets.service" ];
+      requires = [ "sops-install-secrets.service" ];
+    };
   };
 }

--- a/modules/services/victoriametrics.nix
+++ b/modules/services/victoriametrics.nix
@@ -10,6 +10,8 @@
 }:
 let
   cfg = config.sys.services.victoriametrics;
+  hasHttpAuth = cfg.httpAuth.username != null;
+  credentialGroup = "monitoring-credentials";
 in
 {
   options.sys.services.victoriametrics = {
@@ -19,8 +21,29 @@ in
 
     port = lib.mkOption {
       type = lib.types.port;
-      default = consts.victoriametricsPort;
+      default = consts.ports.host.victoriametrics;
       description = "Port on which VictoriaMetrics listens for HTTP requests";
+    };
+
+    httpAuth = {
+      username = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          Username for VictoriaMetrics HTTP Basic Authentication. Set this
+          together with passwordFile to protect every HTTP endpoint.
+        '';
+      };
+
+      passwordFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = ''
+          SOPS-managed file containing the VictoriaMetrics HTTP Basic
+          Authentication password. The password is loaded through systemd
+          credentials and is never placed in the unit command line.
+        '';
+      };
     };
 
     listenAddress = lib.mkOption {
@@ -28,9 +51,10 @@ in
       default = "127.0.0.1";
       description = ''
         Address on which VictoriaMetrics listens.
-        Set to "0.0.0.0" to listen on all interfaces (required for remote write from other hosts).
+        Remote clients require a reachable non-loopback address. Bind to the
+        narrowest interface that serves the intended clients.
       '';
-      example = "0.0.0.0";
+      example = "100.86.227.97";
     };
 
     localAddress = lib.mkOption {
@@ -170,6 +194,9 @@ in
       enable = true;
       inherit (cfg) package retentionPeriod;
 
+      basicAuthUsername = cfg.httpAuth.username;
+      basicAuthPasswordFile = cfg.httpAuth.passwordFile;
+
       listenAddress = "${cfg.listenAddress}:${toString cfg.port}";
 
       extraOptions =
@@ -186,35 +213,43 @@ in
     services.prometheus.remoteWrite =
       lib.mkIf (cfg.prometheusRemoteWrite.enable && config.services.prometheus.enable or false)
         [
-          {
-            url = "http://${cfg.localAddress}:${toString cfg.port}${cfg.prometheusRemoteWrite.path}";
+          (
+            {
+              url = "http://${cfg.localAddress}:${toString cfg.port}${cfg.prometheusRemoteWrite.path}";
 
-            queue_config = {
-              capacity = 10000;
-              max_shards = 3;
-              min_shards = 1;
-              max_samples_per_send = 1000;
-              batch_send_deadline = "5s";
-              min_backoff = "30ms";
-              max_backoff = "5s";
-            };
+              queue_config = {
+                capacity = 10000;
+                max_shards = 3;
+                min_shards = 1;
+                max_samples_per_send = 1000;
+                batch_send_deadline = "5s";
+                min_backoff = "30ms";
+                max_backoff = "5s";
+              };
 
-            write_relabel_configs =
-              lib.optionals (cfg.prometheusRemoteWrite.excludedMetricNames != [ ]) [
-                {
-                  source_labels = [ "__name__" ];
-                  regex = lib.concatStringsSep "|" cfg.prometheusRemoteWrite.excludedMetricNames;
-                  action = "drop";
-                }
-              ]
-              ++ [
-                {
-                  source_labels = [ "__address__" ];
-                  target_label = "source_host";
-                  replacement = config.networking.hostName;
-                }
-              ];
-          }
+              write_relabel_configs =
+                lib.optionals (cfg.prometheusRemoteWrite.excludedMetricNames != [ ]) [
+                  {
+                    source_labels = [ "__name__" ];
+                    regex = lib.concatStringsSep "|" cfg.prometheusRemoteWrite.excludedMetricNames;
+                    action = "drop";
+                  }
+                ]
+                ++ [
+                  {
+                    source_labels = [ "__address__" ];
+                    target_label = "source_host";
+                    replacement = config.networking.hostName;
+                  }
+                ];
+            }
+            // lib.optionalAttrs hasHttpAuth {
+              basic_auth = {
+                username = cfg.httpAuth.username;
+                password_file = cfg.httpAuth.passwordFile;
+              };
+            }
+          )
         ];
 
     # Add VictoriaMetrics as Grafana datasource
@@ -245,6 +280,11 @@ in
                 manageAlerts = false;
               };
             }
+            // lib.optionalAttrs hasHttpAuth {
+              basicAuth = true;
+              basicAuthUser = cfg.httpAuth.username;
+              secureJsonData.basicAuthPassword = "$__file{${cfg.httpAuth.passwordFile}}";
+            }
             // lib.optionalAttrs (cfg.grafanaDatasource.uid != null) {
               inherit (cfg.grafanaDatasource) uid;
             }
@@ -253,5 +293,43 @@ in
 
     # Open firewall if requested
     networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];
+
+    users.groups.${credentialGroup} = lib.mkIf hasHttpAuth { };
+    users.users.prometheus.extraGroups = lib.mkIf (
+      hasHttpAuth && (config.services.prometheus.enable or false)
+    ) (lib.mkAfter [ credentialGroup ]);
+    users.users.grafana.extraGroups = lib.mkIf (
+      hasHttpAuth && (config.sys.services.grafana.enable or false)
+    ) (lib.mkAfter [ credentialGroup ]);
+
+    systemd.services.victoriametrics = lib.mkIf hasHttpAuth {
+      after = [ "sops-install-secrets.service" ];
+      requires = [ "sops-install-secrets.service" ];
+    };
+
+    systemd.services.prometheus = lib.mkIf (
+      hasHttpAuth && (config.services.prometheus.enable or false)
+    ) {
+      after = [ "sops-install-secrets.service" ];
+      requires = [ "sops-install-secrets.service" ];
+    };
+
+    systemd.services.grafana = lib.mkIf (
+      hasHttpAuth && (config.sys.services.grafana.enable or false)
+    ) {
+      after = [ "sops-install-secrets.service" ];
+      requires = [ "sops-install-secrets.service" ];
+    };
+
+    assertions = [
+      {
+        assertion = (cfg.httpAuth.username == null) == (cfg.httpAuth.passwordFile == null);
+        message = "sys.services.victoriametrics.httpAuth.username and passwordFile must both be set or both be null";
+      }
+      {
+        assertion = lib.elem cfg.listenAddress [ "127.0.0.1" "::1" "localhost" ] || hasHttpAuth;
+        message = "sys.services.victoriametrics requires HTTP Basic Authentication when listenAddress is not loopback";
+      }
+    ];
   };
 }

--- a/modules/services/victoriametrics.nix
+++ b/modules/services/victoriametrics.nix
@@ -5,6 +5,7 @@
   lib,
   config,
   pkgs,
+  consts,
   ...
 }:
 let
@@ -18,7 +19,7 @@ in
 
     port = lib.mkOption {
       type = lib.types.port;
-      default = 11008;
+      default = consts.victoriametricsPort;
       description = "Port on which VictoriaMetrics listens for HTTP requests";
     };
 
@@ -30,6 +31,16 @@ in
         Set to "0.0.0.0" to listen on all interfaces (required for remote write from other hosts).
       '';
       example = "0.0.0.0";
+    };
+
+    localAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = ''
+        Address used by local Prometheus and Grafana clients to reach VictoriaMetrics.
+        Set this when listenAddress does not include the loopback interface.
+      '';
+      example = "127.0.0.1";
     };
 
     openFirewall = lib.mkOption {
@@ -176,7 +187,7 @@ in
       lib.mkIf (cfg.prometheusRemoteWrite.enable && config.services.prometheus.enable or false)
         [
           {
-            url = "http://127.0.0.1:${toString cfg.port}${cfg.prometheusRemoteWrite.path}";
+            url = "http://${cfg.localAddress}:${toString cfg.port}${cfg.prometheusRemoteWrite.path}";
 
             queue_config = {
               capacity = 10000;
@@ -225,7 +236,7 @@ in
               inherit (cfg.grafanaDatasource) name isDefault;
               type = "prometheus"; # VictoriaMetrics is PromQL-compatible
               access = "proxy";
-              url = "http://127.0.0.1:${toString cfg.port}";
+              url = "http://${cfg.localAddress}:${toString cfg.port}";
               editable = false;
               jsonData = {
                 # VictoriaMetrics supports Prometheus-compatible API

--- a/modules/services/victoriametrics.nix
+++ b/modules/services/victoriametrics.nix
@@ -294,29 +294,35 @@ in
     # Open firewall if requested
     networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];
 
-    users.groups.${credentialGroup} = lib.mkIf hasHttpAuth { };
-    users.users.prometheus.extraGroups = lib.mkIf (
-      hasHttpAuth && (config.services.prometheus.enable or false)
-    ) (lib.mkAfter [ credentialGroup ]);
-    users.users.grafana.extraGroups = lib.mkIf (
-      hasHttpAuth && (config.sys.services.grafana.enable or false)
-    ) (lib.mkAfter [ credentialGroup ]);
+    users = {
+      users = {
+        prometheus.extraGroups = lib.mkIf (hasHttpAuth && (config.services.prometheus.enable or false)) (
+          lib.mkAfter [ credentialGroup ]
+        );
 
-    systemd.services.victoriametrics = lib.mkIf hasHttpAuth {
-      after = [ "sops-install-secrets.service" ];
-      requires = [ "sops-install-secrets.service" ];
+        grafana.extraGroups = lib.mkIf (hasHttpAuth && (config.sys.services.grafana.enable or false)) (
+          lib.mkAfter [ credentialGroup ]
+        );
+      };
+
+      groups.${credentialGroup} = lib.mkIf hasHttpAuth { };
     };
 
-    systemd.services.prometheus =
-      lib.mkIf (hasHttpAuth && (config.services.prometheus.enable or false))
-        {
-          after = [ "sops-install-secrets.service" ];
-          requires = [ "sops-install-secrets.service" ];
-        };
+    systemd.services = {
+      victoriametrics = lib.mkIf hasHttpAuth {
+        after = [ "sops-install-secrets.service" ];
+        requires = [ "sops-install-secrets.service" ];
+      };
 
-    systemd.services.grafana = lib.mkIf (hasHttpAuth && (config.sys.services.grafana.enable or false)) {
-      after = [ "sops-install-secrets.service" ];
-      requires = [ "sops-install-secrets.service" ];
+      prometheus = lib.mkIf (hasHttpAuth && (config.services.prometheus.enable or false)) {
+        after = [ "sops-install-secrets.service" ];
+        requires = [ "sops-install-secrets.service" ];
+      };
+
+      grafana = lib.mkIf (hasHttpAuth && (config.sys.services.grafana.enable or false)) {
+        after = [ "sops-install-secrets.service" ];
+        requires = [ "sops-install-secrets.service" ];
+      };
     };
 
     assertions = [

--- a/modules/services/victoriametrics.nix
+++ b/modules/services/victoriametrics.nix
@@ -307,16 +307,14 @@ in
       requires = [ "sops-install-secrets.service" ];
     };
 
-    systemd.services.prometheus = lib.mkIf (
-      hasHttpAuth && (config.services.prometheus.enable or false)
-    ) {
-      after = [ "sops-install-secrets.service" ];
-      requires = [ "sops-install-secrets.service" ];
-    };
+    systemd.services.prometheus =
+      lib.mkIf (hasHttpAuth && (config.services.prometheus.enable or false))
+        {
+          after = [ "sops-install-secrets.service" ];
+          requires = [ "sops-install-secrets.service" ];
+        };
 
-    systemd.services.grafana = lib.mkIf (
-      hasHttpAuth && (config.sys.services.grafana.enable or false)
-    ) {
+    systemd.services.grafana = lib.mkIf (hasHttpAuth && (config.sys.services.grafana.enable or false)) {
       after = [ "sops-install-secrets.service" ];
       requires = [ "sops-install-secrets.service" ];
     };
@@ -327,7 +325,13 @@ in
         message = "sys.services.victoriametrics.httpAuth.username and passwordFile must both be set or both be null";
       }
       {
-        assertion = lib.elem cfg.listenAddress [ "127.0.0.1" "::1" "localhost" ] || hasHttpAuth;
+        assertion =
+          lib.elem cfg.listenAddress [
+            "127.0.0.1"
+            "::1"
+            "localhost"
+          ]
+          || hasHttpAuth;
         message = "sys.services.victoriametrics requires HTTP Basic Authentication when listenAddress is not loopback";
       }
     ];

--- a/modules/virtualisation/microvm-base.nix
+++ b/modules/virtualisation/microvm-base.nix
@@ -2,11 +2,12 @@
   lib,
   config,
   pkgs,
+  consts,
   ...
 }:
 let
   cfg = config.sys.virtualisation.microvm;
-  registry = import ../../vms/vm-registry.nix;
+  registry = import ../../vms/vm-registry.nix { inherit consts; };
   networkDefaults = import ../../vms/microvm-network-defaults.nix;
   sharedBridgeName = networkDefaults.sharedBridge.name;
   sharedBridgeNetworkUnit = "10-${sharedBridgeName}";

--- a/tests/matrix-baseline.nix
+++ b/tests/matrix-baseline.nix
@@ -37,7 +37,8 @@ let
     ];
   };
   networkDefaults = import ../vms/microvm-network-defaults.nix;
-  matrixRegistry = (import ../vms/vm-registry.nix)."matrix-synapse";
+  consts = import ../lib/constants.nix;
+  matrixRegistry = (import ../vms/vm-registry.nix { inherit consts; })."matrix-synapse";
   matrixGateway = matrixRegistry.gateway or networkDefaults.defaultGateway;
   matrixInstance = hostCfg.sys.virtualisation.microvm.instances.matrix-synapse;
   nginxLocations = vmCfg.services.nginx.virtualHosts.matrix.locations;

--- a/tests/microvm-network-policy.nix
+++ b/tests/microvm-network-policy.nix
@@ -5,7 +5,8 @@
   wireguardVm,
 }:
 let
-  registry = import ../vms/vm-registry.nix;
+  consts = import ../lib/constants.nix;
+  registry = import ../vms/vm-registry.nix { inherit consts; };
   networkDefaults = import ../vms/microvm-network-defaults.nix;
   wireguardCfg = wireguardVm.config;
   wireguardFirewallCommands = wireguardCfg.networking.firewall.extraCommands;

--- a/tests/victoriametrics.nix
+++ b/tests/victoriametrics.nix
@@ -1,0 +1,76 @@
+{
+  blizzard,
+  snowfall,
+  pkgs,
+}:
+let
+  inherit (pkgs) lib;
+  consts = import ../lib/constants.nix;
+  blizzardCfg = blizzard.config;
+  snowfallCfg = snowfall.config;
+  vmCfg = blizzardCfg.sys.services.victoriametrics;
+  vmService = blizzardCfg.services.victoriametrics;
+  vmUnit = blizzardCfg.systemd.services.victoriametrics;
+  unauthenticatedRemote = blizzard.extendModules {
+    modules = [
+      {
+        sys.services.victoriametrics.httpAuth = lib.mkForce {
+          username = null;
+          passwordFile = null;
+        };
+      }
+    ];
+  };
+  passwordSecret = blizzardCfg.sops.secrets."victoriametrics/remote_write_password";
+  passwordPath = passwordSecret.path;
+  localRemoteWrite = lib.findFirst (
+    entry: entry.url == "http://${vmCfg.localAddress}:${toString vmCfg.port}${vmCfg.prometheusRemoteWrite.path}"
+  ) null blizzardCfg.services.prometheus.remoteWrite;
+  grafanaDatasource = lib.findFirst (
+    datasource: datasource.name == vmCfg.grafanaDatasource.name
+  ) null blizzardCfg.sys.services.grafana.provision.datasources;
+  remoteCfg = snowfallCfg.sys.services.victoriametricsRemoteWrite;
+  remoteWrite = lib.findFirst (
+    entry: entry.url == "http://${remoteCfg.vmHost}:${toString remoteCfg.vmPort}${remoteCfg.path}"
+  ) null snowfallCfg.services.prometheus.remoteWrite;
+in
+assert vmCfg.listenAddress == consts.tailscale.hosts.blizzard.ipv4;
+assert vmCfg.localAddress == consts.tailscale.hosts.blizzard.ipv4;
+assert vmCfg.port == consts.ports.host.victoriametrics;
+assert vmCfg.httpAuth.username == consts.victoriametrics.username;
+assert vmCfg.httpAuth.passwordFile == passwordPath;
+assert lib.any (
+  assertion:
+  !assertion.assertion
+  && assertion.message
+  == "sys.services.victoriametrics requires HTTP Basic Authentication when listenAddress is not loopback"
+) unauthenticatedRemote.config.assertions;
+assert passwordSecret.owner == "root";
+assert passwordSecret.group == "monitoring-credentials";
+assert passwordSecret.mode == "0440";
+assert vmService.listenAddress == "${vmCfg.listenAddress}:${toString vmCfg.port}";
+assert vmService.basicAuthUsername == consts.victoriametrics.username;
+assert vmService.basicAuthPasswordFile == passwordPath;
+assert lib.elem vmCfg.port blizzardCfg.networking.firewall.interfaces.tailscale0.allowedTCPPorts;
+assert !(lib.elem vmCfg.port blizzardCfg.networking.firewall.allowedTCPPorts);
+assert lib.elem "tailscaled-autoconnect.service" vmUnit.after;
+assert lib.elem "sops-install-secrets.service" vmUnit.after;
+assert lib.elem "sops-install-secrets.service" vmUnit.requires;
+assert lib.elem "monitoring-credentials" blizzardCfg.users.users.prometheus.extraGroups;
+assert lib.elem "monitoring-credentials" blizzardCfg.users.users.grafana.extraGroups;
+assert localRemoteWrite != null;
+assert localRemoteWrite.basic_auth.username == consts.victoriametrics.username;
+assert localRemoteWrite.basic_auth.password_file == passwordPath;
+assert grafanaDatasource != null;
+assert grafanaDatasource.basicAuth;
+assert grafanaDatasource.basicAuthUser == consts.victoriametrics.username;
+assert grafanaDatasource.secureJsonData.basicAuthPassword == "$__file{${passwordPath}}";
+assert remoteCfg.vmPort == consts.ports.host.victoriametrics;
+assert remoteCfg.basicAuth.username == consts.victoriametrics.username;
+assert remoteCfg.basicAuth.passwordFile == snowfallCfg.sops.secrets."victoriametrics/remote_write_password".path;
+assert remoteWrite != null;
+assert remoteWrite.basic_auth.username == consts.victoriametrics.username;
+assert remoteWrite.basic_auth.password_file == remoteCfg.basicAuth.passwordFile;
+assert lib.elem "monitoring-credentials" snowfallCfg.users.users.prometheus.extraGroups;
+assert lib.elem "sops-install-secrets.service" snowfallCfg.systemd.services.prometheus.requires;
+pkgs.runCommand "victoriametrics-tests" { } "touch $out"

--- a/tests/victoriametrics.nix
+++ b/tests/victoriametrics.nix
@@ -24,7 +24,9 @@ let
   passwordSecret = blizzardCfg.sops.secrets."victoriametrics/remote_write_password";
   passwordPath = passwordSecret.path;
   localRemoteWrite = lib.findFirst (
-    entry: entry.url == "http://${vmCfg.localAddress}:${toString vmCfg.port}${vmCfg.prometheusRemoteWrite.path}"
+    entry:
+    entry.url
+    == "http://${vmCfg.localAddress}:${toString vmCfg.port}${vmCfg.prometheusRemoteWrite.path}"
   ) null blizzardCfg.services.prometheus.remoteWrite;
   grafanaDatasource = lib.findFirst (
     datasource: datasource.name == vmCfg.grafanaDatasource.name
@@ -42,8 +44,9 @@ assert vmCfg.httpAuth.passwordFile == passwordPath;
 assert lib.any (
   assertion:
   !assertion.assertion
-  && assertion.message
-  == "sys.services.victoriametrics requires HTTP Basic Authentication when listenAddress is not loopback"
+  &&
+    assertion.message
+    == "sys.services.victoriametrics requires HTTP Basic Authentication when listenAddress is not loopback"
 ) unauthenticatedRemote.config.assertions;
 assert passwordSecret.owner == "root";
 assert passwordSecret.group == "monitoring-credentials";
@@ -67,7 +70,9 @@ assert grafanaDatasource.basicAuthUser == consts.victoriametrics.username;
 assert grafanaDatasource.secureJsonData.basicAuthPassword == "$__file{${passwordPath}}";
 assert remoteCfg.vmPort == consts.ports.host.victoriametrics;
 assert remoteCfg.basicAuth.username == consts.victoriametrics.username;
-assert remoteCfg.basicAuth.passwordFile == snowfallCfg.sops.secrets."victoriametrics/remote_write_password".path;
+assert
+  remoteCfg.basicAuth.passwordFile
+  == snowfallCfg.sops.secrets."victoriametrics/remote_write_password".path;
 assert remoteWrite != null;
 assert remoteWrite.basic_auth.username == consts.victoriametrics.username;
 assert remoteWrite.basic_auth.password_file == remoteCfg.basicAuth.passwordFile;

--- a/vms/README.md
+++ b/vms/README.md
@@ -162,7 +162,7 @@ modules). Their outputs are assembled in [vms/flake-microvms.nix](flake-microvms
 and merged into `nixosConfigurations` from [flake.nix](../flake.nix):
 
 ```nix
-microvmConfigurations = import ./vms/flake-microvms.nix { inherit inputs system VARS; };
+microvmConfigurations = import ./vms/flake-microvms.nix { inherit inputs system VARS consts; };
 
 nixosConfigurations = {
   # hosts ...
@@ -360,6 +360,9 @@ ______________________________________________________________________
 
 ### Creating a new VM
 
+1. Add or reuse the service port in [lib/constants.nix](../lib/constants.nix)
+   under `ports.vm`; host and secondary endpoints belong under their matching
+   namespaces.
 1. Add an entry to [vm-registry.nix](vm-registry.nix) with a unique CID, MAC,
    IP, service port, memory, and vCPU count.
 1. Create `vms/<service>.nix` importing `./base.nix` and adding the

--- a/vms/actual.nix
+++ b/vms/actual.nix
@@ -1,6 +1,6 @@
-_:
+{ consts, ... }:
 let
-  reg = (import ./vm-registry.nix).actual;
+  reg = (import ./vm-registry.nix { inherit consts; }).actual;
 in
 {
   imports = [

--- a/vms/adguard.nix
+++ b/vms/adguard.nix
@@ -3,10 +3,11 @@
   config,
   inputs,
   VARS,
+  consts,
   ...
 }:
 let
-  reg = (import ./vm-registry.nix).adguard;
+  reg = (import ./vm-registry.nix { inherit consts; }).adguard;
 in
 {
   imports = [

--- a/vms/bazarr.nix
+++ b/vms/bazarr.nix
@@ -1,6 +1,6 @@
-_:
+{ consts, ... }:
 let
-  reg = (import ./vm-registry.nix).bazarr;
+  reg = (import ./vm-registry.nix { inherit consts; }).bazarr;
   mediaShare = {
     source = "/rpool/unenc/media/data";
     mountPoint = "/data";

--- a/vms/brave.nix
+++ b/vms/brave.nix
@@ -7,7 +7,7 @@
   ...
 }:
 let
-  reg = (import ./vm-registry.nix).brave;
+  reg = (import ./vm-registry.nix { inherit consts; }).brave;
   vpnRoutes = [
     {
       Gateway = "10.100.0.1";
@@ -66,7 +66,7 @@ in
 
   networking.firewall.allowedTCPPorts = [
     reg.port
-    consts.braveHttpsPort
+    consts.ports.secondary.braveHttps
   ];
 
   systemd = {
@@ -107,7 +107,7 @@ in
 
         dataDir = "/var/lib/brave";
         httpPort = reg.port;
-        httpsPort = consts.braveHttpsPort;
+        httpsPort = consts.ports.secondary.braveHttps;
         networkMode = "bridge";
         timeZone = "Europe/Oslo";
         title = "Brave";

--- a/vms/brave.nix
+++ b/vms/brave.nix
@@ -3,6 +3,7 @@
   config,
   pkgs,
   inputs,
+  consts,
   ...
 }:
 let
@@ -65,7 +66,7 @@ in
 
   networking.firewall.allowedTCPPorts = [
     reg.port
-    11055
+    consts.braveHttpsPort
   ];
 
   systemd = {
@@ -106,7 +107,7 @@ in
 
         dataDir = "/var/lib/brave";
         httpPort = reg.port;
-        httpsPort = 11055;
+        httpsPort = consts.braveHttpsPort;
         networkMode = "bridge";
         timeZone = "Europe/Oslo";
         title = "Brave";

--- a/vms/firefly-importer.nix
+++ b/vms/firefly-importer.nix
@@ -4,10 +4,11 @@
   inputs,
   pkgs,
   VARS,
+  consts,
   ...
 }:
 let
-  registry = import ./vm-registry.nix;
+  registry = import ./vm-registry.nix { inherit consts; };
   reg = registry."firefly-importer";
   fireflyReg = registry.firefly;
   importerDomain = "finimport.${VARS.domains.public}";

--- a/vms/firefly.nix
+++ b/vms/firefly.nix
@@ -3,10 +3,11 @@
   config,
   inputs,
   VARS,
+  consts,
   ...
 }:
 let
-  reg = (import ./vm-registry.nix).firefly;
+  reg = (import ./vm-registry.nix { inherit consts; }).firefly;
 in
 {
   imports = [

--- a/vms/firefox.nix
+++ b/vms/firefox.nix
@@ -3,6 +3,7 @@
   config,
   pkgs,
   inputs,
+  consts,
   ...
 }:
 let
@@ -73,7 +74,7 @@ in
 
   networking.firewall.allowedTCPPorts = [
     reg.port
-    11053
+    consts.firefoxHttpsPort
   ];
 
   systemd = {
@@ -121,7 +122,7 @@ in
 
         dataDir = "/var/lib/firefox";
         httpPort = reg.port;
-        httpsPort = 11053;
+        httpsPort = consts.firefoxHttpsPort;
         networkMode = "bridge";
         timeZone = "Europe/Oslo";
         title = "Firefox";

--- a/vms/firefox.nix
+++ b/vms/firefox.nix
@@ -7,7 +7,7 @@
   ...
 }:
 let
-  reg = (import ./vm-registry.nix).firefox;
+  reg = (import ./vm-registry.nix { inherit consts; }).firefox;
   transferDir = "/home/admin/Downloads";
   vpnRoutes = [
     {
@@ -74,7 +74,7 @@ in
 
   networking.firewall.allowedTCPPorts = [
     reg.port
-    consts.firefoxHttpsPort
+    consts.ports.secondary.firefoxHttps
   ];
 
   systemd = {
@@ -122,7 +122,7 @@ in
 
         dataDir = "/var/lib/firefox";
         httpPort = reg.port;
-        httpsPort = consts.firefoxHttpsPort;
+        httpsPort = consts.ports.secondary.firefoxHttps;
         networkMode = "bridge";
         timeZone = "Europe/Oslo";
         title = "Firefox";

--- a/vms/flake-microvms.nix
+++ b/vms/flake-microvms.nix
@@ -2,6 +2,7 @@
   inputs,
   system,
   VARS,
+  consts,
   ...
 }:
 let
@@ -54,7 +55,7 @@ let
 
       specialArgs = {
         inherit inputs system VARS;
-        consts = import ../lib/constants.nix;
+        inherit consts;
       };
     };
 in

--- a/vms/flaresolverr.nix
+++ b/vms/flaresolverr.nix
@@ -1,6 +1,6 @@
-_:
+{ consts, ... }:
 let
-  reg = (import ./vm-registry.nix).flaresolverr;
+  reg = (import ./vm-registry.nix { inherit consts; }).flaresolverr;
 in
 {
   imports = [

--- a/vms/gitea.nix
+++ b/vms/gitea.nix
@@ -9,7 +9,7 @@
   ...
 }:
 let
-  reg = (import ./vm-registry.nix).gitea;
+  reg = (import ./vm-registry.nix { inherit consts; }).gitea;
 
 in
 {

--- a/vms/immich.nix
+++ b/vms/immich.nix
@@ -3,6 +3,7 @@
   inputs,
   VARS,
   lib,
+  consts,
   ...
 }:
 let
@@ -75,7 +76,7 @@ in
         clip.modelName = "ViT-SO400M-16-SigLIP2-384__webli";
         ocr.modelName = "LATIN__PP-OCRv5_mobile";
         urls = [
-          "http://10.100.0.1:3003"
+          "http://10.100.0.1:${toString consts.immichMachineLearningPort}"
         ];
       };
       oauth = {

--- a/vms/immich.nix
+++ b/vms/immich.nix
@@ -7,7 +7,7 @@
   ...
 }:
 let
-  reg = (import ./vm-registry.nix).immich;
+  reg = (import ./vm-registry.nix { inherit consts; }).immich;
   storage = import ./immich-storage.nix;
   # Pocket ID assigns this public identifier. Keep it in sync with the
   # restricted Immich client documented in docs/immich.md.
@@ -76,7 +76,7 @@ in
         clip.modelName = "ViT-SO400M-16-SigLIP2-384__webli";
         ocr.modelName = "LATIN__PP-OCRv5_mobile";
         urls = [
-          "http://10.100.0.1:${toString consts.immichMachineLearningPort}"
+          "http://10.100.0.1:${toString consts.ports.secondary.immichMachineLearning.hostPort}"
         ];
       };
       oauth = {

--- a/vms/lidarr.nix
+++ b/vms/lidarr.nix
@@ -1,6 +1,6 @@
-_:
+{ consts, ... }:
 let
-  reg = (import ./vm-registry.nix).lidarr;
+  reg = (import ./vm-registry.nix { inherit consts; }).lidarr;
   mediaShare = {
     source = "/rpool/unenc/media/data";
     mountPoint = "/data";

--- a/vms/matrix-synapse.nix
+++ b/vms/matrix-synapse.nix
@@ -4,10 +4,11 @@
   pkgs,
   inputs,
   VARS,
+  consts,
   ...
 }:
 let
-  reg = (import ./vm-registry.nix)."matrix-synapse";
+  reg = (import ./vm-registry.nix { inherit consts; })."matrix-synapse";
   networkDefaults = import ./microvm-network-defaults.nix;
   matrixGateway = reg.gateway or networkDefaults.defaultGateway;
   traefikLib = import ../lib/traefik.nix { inherit lib; };

--- a/vms/mealie.nix
+++ b/vms/mealie.nix
@@ -3,10 +3,11 @@
   config,
   inputs,
   VARS,
+  consts,
   ...
 }:
 let
-  reg = (import ./vm-registry.nix).mealie;
+  reg = (import ./vm-registry.nix { inherit consts; }).mealie;
 in
 {
   imports = [

--- a/vms/ombi.nix
+++ b/vms/ombi.nix
@@ -1,6 +1,6 @@
-_:
+{ consts, ... }:
 let
-  reg = (import ./vm-registry.nix).ombi;
+  reg = (import ./vm-registry.nix { inherit consts; }).ombi;
 in
 {
   imports = [

--- a/vms/overseerr.nix
+++ b/vms/overseerr.nix
@@ -1,6 +1,6 @@
-{ lib, ... }:
+{ lib, consts, ... }:
 let
-  reg = (import ./vm-registry.nix).overseerr;
+  reg = (import ./vm-registry.nix { inherit consts; }).overseerr;
 in
 {
   imports = [

--- a/vms/paperless.nix
+++ b/vms/paperless.nix
@@ -2,10 +2,11 @@
   config,
   inputs,
   VARS,
+  consts,
   ...
 }:
 let
-  reg = (import ./vm-registry.nix).paperless;
+  reg = (import ./vm-registry.nix { inherit consts; }).paperless;
   paperlessTmpDir = "/var/lib/paperless/tmp";
 in
 {

--- a/vms/pocket-id.nix
+++ b/vms/pocket-id.nix
@@ -3,10 +3,11 @@
   inputs,
   VARS,
   lib,
+  consts,
   ...
 }:
 let
-  reg = (import ./vm-registry.nix)."pocket-id";
+  reg = (import ./vm-registry.nix { inherit consts; })."pocket-id";
   dataDir = "/var/lib/pocket-id";
   blizzardSource = "${reg.gateway}/32";
   pocketIdVersion = lib.getVersion config.services.pocket-id.package;

--- a/vms/prowlarr.nix
+++ b/vms/prowlarr.nix
@@ -1,6 +1,6 @@
-_:
+{ consts, ... }:
 let
-  registry = import ./vm-registry.nix;
+  registry = import ./vm-registry.nix { inherit consts; };
   reg = registry.prowlarr;
   flaresolverrPort = registry.flaresolverr.port;
 in

--- a/vms/qbittorrent.nix
+++ b/vms/qbittorrent.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, consts, ... }:
 let
   reg = (import ./vm-registry.nix).qbittorrent;
   mediaShare = {
@@ -41,15 +41,15 @@ in
   networking.firewall = {
     allowedTCPPorts = [
       reg.port
-      50820
+      consts.qbittorrentTorrentPort
     ];
-    allowedUDPPorts = [ 50820 ];
+    allowedUDPPorts = [ consts.qbittorrentTorrentPort ];
   };
 
   sys.services.qbittorrent = {
     enable = true;
     webPort = reg.port;
-    torrentPort = 50820;
+    torrentPort = consts.qbittorrentTorrentPort;
     dataDir = "/var/lib/qbittorrent";
     openFirewall = false;
 

--- a/vms/qbittorrent.nix
+++ b/vms/qbittorrent.nix
@@ -1,6 +1,6 @@
 { pkgs, consts, ... }:
 let
-  reg = (import ./vm-registry.nix).qbittorrent;
+  reg = (import ./vm-registry.nix { inherit consts; }).qbittorrent;
   mediaShare = {
     source = "/rpool/unenc/media/data";
     mountPoint = "/data";
@@ -41,15 +41,15 @@ in
   networking.firewall = {
     allowedTCPPorts = [
       reg.port
-      consts.qbittorrentTorrentPort
+      consts.ports.network.qbittorrentTorrent
     ];
-    allowedUDPPorts = [ consts.qbittorrentTorrentPort ];
+    allowedUDPPorts = [ consts.ports.network.qbittorrentTorrent ];
   };
 
   sys.services.qbittorrent = {
     enable = true;
     webPort = reg.port;
-    torrentPort = consts.qbittorrentTorrentPort;
+    torrentPort = consts.ports.network.qbittorrentTorrent;
     dataDir = "/var/lib/qbittorrent";
     openFirewall = false;
 

--- a/vms/radarr.nix
+++ b/vms/radarr.nix
@@ -1,6 +1,6 @@
-_:
+{ consts, ... }:
 let
-  reg = (import ./vm-registry.nix).radarr;
+  reg = (import ./vm-registry.nix { inherit consts; }).radarr;
   mediaShare = {
     source = "/rpool/unenc/media/data";
     mountPoint = "/data";

--- a/vms/readarr.nix
+++ b/vms/readarr.nix
@@ -1,6 +1,6 @@
-_:
+{ consts, ... }:
 let
-  reg = (import ./vm-registry.nix).readarr;
+  reg = (import ./vm-registry.nix { inherit consts; }).readarr;
   mediaShare = {
     source = "/rpool/unenc/media/data";
     mountPoint = "/data";

--- a/vms/sabnzbd.nix
+++ b/vms/sabnzbd.nix
@@ -1,6 +1,6 @@
-_:
+{ consts, ... }:
 let
-  reg = (import ./vm-registry.nix).sabnzbd;
+  reg = (import ./vm-registry.nix { inherit consts; }).sabnzbd;
   mediaShare = {
     source = "/rpool/unenc/media/data";
     mountPoint = "/data";

--- a/vms/searx.nix
+++ b/vms/searx.nix
@@ -1,6 +1,6 @@
-{ pkgs, ... }:
+{ pkgs, consts, ... }:
 let
-  reg = (import ./vm-registry.nix).searx;
+  reg = (import ./vm-registry.nix { inherit consts; }).searx;
 in
 {
   imports = [

--- a/vms/sonarr.nix
+++ b/vms/sonarr.nix
@@ -1,6 +1,6 @@
-_:
+{ consts, ... }:
 let
-  reg = (import ./vm-registry.nix).sonarr;
+  reg = (import ./vm-registry.nix { inherit consts; }).sonarr;
   mediaShare = {
     source = "/rpool/unenc/media/data";
     mountPoint = "/data";

--- a/vms/tautulli.nix
+++ b/vms/tautulli.nix
@@ -1,6 +1,6 @@
-_:
+{ consts, ... }:
 let
-  reg = (import ./vm-registry.nix).tautulli;
+  reg = (import ./vm-registry.nix { inherit consts; }).tautulli;
 in
 {
   imports = [

--- a/vms/trigger.nix
+++ b/vms/trigger.nix
@@ -2,10 +2,11 @@
   config,
   inputs,
   VARS,
+  consts,
   ...
 }:
 let
-  reg = (import ./vm-registry.nix).trigger;
+  reg = (import ./vm-registry.nix { inherit consts; }).trigger;
 in
 {
   imports = [

--- a/vms/vm-registry.nix
+++ b/vms/vm-registry.nix
@@ -14,8 +14,11 @@
 #   dns          - DNS server (default: 1.1.1.1; some VMs use internal resolver 10.100.0.11)
 #   tapId        - Override TAP interface name (default: "vm-${name}", needed when name is too long)
 #   hostBridge   - Optional dedicated host bridge; requires gateway and is created only while enabled
+{
+  consts,
+  ...
+}:
 let
-  consts = import ../lib/constants.nix;
   validate = import ./validate-vm-registry.nix;
 in
 validate {
@@ -24,7 +27,7 @@ validate {
     cid = 100;
     mac = "02:00:00:00:00:01";
     ip = "10.100.0.10";
-    port = consts.adguardPort;
+    port = consts.ports.vm.adguard;
     mem = 3072;
     vcpu = 1;
   };
@@ -34,7 +37,7 @@ validate {
     cid = 101;
     mac = "02:00:00:00:00:02";
     ip = "10.100.0.51";
-    port = consts.actualPort;
+    port = consts.ports.vm.actual;
     mem = 1024;
     vcpu = 1;
   };
@@ -44,7 +47,7 @@ validate {
     cid = 102;
     mac = "02:00:00:00:00:03";
     ip = "10.100.0.12";
-    port = consts.searxPort;
+    port = consts.ports.vm.searx;
     mem = 2048;
     vcpu = 1;
   };
@@ -54,7 +57,7 @@ validate {
     cid = 104;
     mac = "02:00:00:00:00:05";
     ip = "10.100.0.41";
-    port = consts.ombiPort;
+    port = consts.ports.vm.ombi;
     mem = 1024;
     vcpu = 1;
   };
@@ -64,7 +67,7 @@ validate {
     cid = 105;
     mac = "02:00:00:00:00:06";
     ip = "10.100.0.42";
-    port = consts.tautulliPort;
+    port = consts.ports.vm.tautulli;
     mem = 1024;
     vcpu = 1;
   };
@@ -74,7 +77,7 @@ validate {
     cid = 106;
     mac = "02:00:00:00:00:07";
     ip = "10.100.0.50";
-    port = consts.giteaPort;
+    port = consts.ports.vm.gitea;
     mem = 2048;
     vcpu = 2;
   };
@@ -84,7 +87,7 @@ validate {
     cid = 107;
     mac = "02:00:00:00:00:08";
     ip = "10.100.0.21";
-    port = consts.sonarrPort;
+    port = consts.ports.vm.sonarr;
     mem = 1024;
     vcpu = 1;
   };
@@ -94,7 +97,7 @@ validate {
     cid = 108;
     mac = "02:00:00:00:00:09";
     ip = "10.100.0.22";
-    port = consts.radarrPort;
+    port = consts.ports.vm.radarr;
     mem = 1024;
     vcpu = 1;
   };
@@ -104,7 +107,7 @@ validate {
     cid = 109;
     mac = "02:00:00:00:00:0A";
     ip = "10.100.0.20";
-    port = consts.prowlarrPort;
+    port = consts.ports.vm.prowlarr;
     mem = 1024;
     vcpu = 1;
   };
@@ -114,7 +117,7 @@ validate {
     cid = 110;
     mac = "02:00:00:00:00:0B";
     ip = "10.100.0.23";
-    port = consts.bazarrPort;
+    port = consts.ports.vm.bazarr;
     mem = 1024;
     vcpu = 1;
   };
@@ -124,7 +127,7 @@ validate {
     cid = 111;
     mac = "02:00:00:00:00:0C";
     ip = "10.100.0.24";
-    port = consts.readarrPort;
+    port = consts.ports.vm.readarr;
     mem = 1024;
     vcpu = 1;
   };
@@ -134,7 +137,7 @@ validate {
     cid = 112;
     mac = "02:00:00:00:00:0D";
     ip = "10.100.0.26";
-    port = consts.lidarrPort;
+    port = consts.ports.vm.lidarr;
     mem = 1024;
     vcpu = 1;
   };
@@ -144,7 +147,7 @@ validate {
     cid = 113;
     mac = "02:00:00:00:00:0E";
     ip = "10.100.0.30";
-    port = consts.qbittorrentPort;
+    port = consts.ports.vm.qbittorrent;
     mem = 2048;
     vcpu = 1;
     gateway = "10.100.0.11";
@@ -156,7 +159,7 @@ validate {
     cid = 114;
     mac = "02:00:00:00:00:0F";
     ip = "10.100.0.40";
-    port = consts.overseerrPort;
+    port = consts.ports.vm.overseerr;
     mem = 1024;
     vcpu = 1;
   };
@@ -166,7 +169,7 @@ validate {
     cid = 115;
     mac = "02:00:00:00:00:10";
     ip = "10.100.0.52";
-    port = consts.firefoxPort;
+    port = consts.ports.vm.firefox;
     mem = 4096;
     vcpu = 4;
     gateway = "10.100.0.11";
@@ -177,7 +180,7 @@ validate {
     cid = 116;
     mac = "02:00:00:00:00:11";
     ip = "10.100.0.11";
-    port = consts.wireguardPort;
+    port = consts.ports.vm.wireguard;
     mem = 512;
     vcpu = 1;
   };
@@ -187,7 +190,7 @@ validate {
     cid = 117;
     mac = "02:00:00:00:00:12";
     ip = "10.100.0.31";
-    port = consts.sabnzbdPort;
+    port = consts.ports.vm.sabnzbd;
     mem = 1024;
     vcpu = 1;
     gateway = "10.100.0.11";
@@ -201,7 +204,7 @@ validate {
     cid = 118;
     mac = "02:00:00:00:00:13";
     ip = "10.100.0.13";
-    port = consts.flaresolverrPort;
+    port = consts.ports.vm.flaresolverr;
     mem = 512;
     vcpu = 1;
   };
@@ -211,7 +214,7 @@ validate {
     cid = 119;
     mac = "02:00:00:00:00:14";
     ip = "10.100.0.60";
-    port = consts.matrixSynapsePort;
+    port = consts.ports.vm.matrixSynapse;
     mem = 4096;
     vcpu = 4;
     tapId = "vm-matrix";
@@ -222,7 +225,7 @@ validate {
     cid = 120;
     mac = "02:00:00:00:00:15";
     ip = "10.100.0.61";
-    port = consts.paperlessPort;
+    port = consts.ports.vm.paperless;
     mem = 8192;
     vcpu = 4;
     tapId = "vm-paperless";
@@ -233,7 +236,7 @@ validate {
     cid = 121;
     mac = "02:00:00:00:00:16";
     ip = "10.100.0.62";
-    port = consts.fireflyPort;
+    port = consts.ports.vm.firefly;
     mem = 2048;
     vcpu = 2;
   };
@@ -243,7 +246,7 @@ validate {
     cid = 122; # Fixed: was 116 (conflicted with wireguard)
     mac = "02:00:00:00:00:17"; # Fixed: was 11 (conflicted with wireguard)
     ip = "10.100.0.54";
-    port = consts.bravePort;
+    port = consts.ports.vm.brave;
     mem = 4096;
     vcpu = 4;
     gateway = "10.100.0.11";
@@ -254,7 +257,7 @@ validate {
     cid = 123;
     mac = "02:00:00:00:00:18";
     ip = "10.100.0.63";
-    port = consts.fireflyImporterPort;
+    port = consts.ports.vm.fireflyImporter;
     mem = 512;
     vcpu = 1;
     tapId = "vm-ff-import";
@@ -265,7 +268,7 @@ validate {
     cid = 124;
     mac = "02:00:00:00:00:19";
     ip = "10.100.0.70";
-    port = consts.immichPort;
+    port = consts.ports.vm.immich;
     mem = 8192;
     vcpu = 4;
   };
@@ -275,7 +278,7 @@ validate {
     cid = 125;
     mac = "02:00:00:00:00:1A";
     ip = "10.100.0.71";
-    port = consts.mealiePort;
+    port = consts.ports.vm.mealie;
     mem = 1024;
     vcpu = 1;
   };
@@ -285,7 +288,7 @@ validate {
     cid = 126;
     mac = "02:00:00:00:00:1B";
     ip = "10.100.0.80";
-    port = consts.triggerPort;
+    port = consts.ports.vm.trigger;
     mem = 12288;
     vcpu = 6;
   };
@@ -298,7 +301,7 @@ validate {
     prefixLength = 30;
     gateway = "10.100.1.1";
     hostBridge = "pocket-id-br0";
-    port = consts.pocketIdPort;
+    port = consts.ports.vm.pocketId;
     mem = 1024;
     vcpu = 1;
   };

--- a/vms/vm-registry.nix
+++ b/vms/vm-registry.nix
@@ -7,7 +7,7 @@
 #   mac          - TAP interface MAC address (must be unique)
 #   ip           - Static IP on the VM's bridge network
 #   prefixLength - IPv4 prefix length (default: 24)
-#   port         - Primary service port (used by firewall, traefik, expose)
+#   port         - Primary service port (sourced from lib/constants.nix; used by firewall, traefik, expose)
 #   mem          - RAM in MiB
 #   vcpu         - Virtual CPU count (default: 1)
 #   gateway      - Default gateway (default: 10.100.0.1; VPN and dedicated networks override it)
@@ -15,6 +15,7 @@
 #   tapId        - Override TAP interface name (default: "vm-${name}", needed when name is too long)
 #   hostBridge   - Optional dedicated host bridge; requires gateway and is created only while enabled
 let
+  consts = import ../lib/constants.nix;
   validate = import ./validate-vm-registry.nix;
 in
 validate {
@@ -23,7 +24,7 @@ validate {
     cid = 100;
     mac = "02:00:00:00:00:01";
     ip = "10.100.0.10";
-    port = 11010;
+    port = consts.adguardPort;
     mem = 3072;
     vcpu = 1;
   };
@@ -33,7 +34,7 @@ validate {
     cid = 101;
     mac = "02:00:00:00:00:02";
     ip = "10.100.0.51";
-    port = 11051;
+    port = consts.actualPort;
     mem = 1024;
     vcpu = 1;
   };
@@ -43,7 +44,7 @@ validate {
     cid = 102;
     mac = "02:00:00:00:00:03";
     ip = "10.100.0.12";
-    port = 11012;
+    port = consts.searxPort;
     mem = 2048;
     vcpu = 1;
   };
@@ -53,7 +54,7 @@ validate {
     cid = 104;
     mac = "02:00:00:00:00:05";
     ip = "10.100.0.41";
-    port = 11041;
+    port = consts.ombiPort;
     mem = 1024;
     vcpu = 1;
   };
@@ -63,7 +64,7 @@ validate {
     cid = 105;
     mac = "02:00:00:00:00:06";
     ip = "10.100.0.42";
-    port = 11042;
+    port = consts.tautulliPort;
     mem = 1024;
     vcpu = 1;
   };
@@ -73,7 +74,7 @@ validate {
     cid = 106;
     mac = "02:00:00:00:00:07";
     ip = "10.100.0.50";
-    port = 11050;
+    port = consts.giteaPort;
     mem = 2048;
     vcpu = 2;
   };
@@ -83,7 +84,7 @@ validate {
     cid = 107;
     mac = "02:00:00:00:00:08";
     ip = "10.100.0.21";
-    port = 11021;
+    port = consts.sonarrPort;
     mem = 1024;
     vcpu = 1;
   };
@@ -93,7 +94,7 @@ validate {
     cid = 108;
     mac = "02:00:00:00:00:09";
     ip = "10.100.0.22";
-    port = 11022;
+    port = consts.radarrPort;
     mem = 1024;
     vcpu = 1;
   };
@@ -103,7 +104,7 @@ validate {
     cid = 109;
     mac = "02:00:00:00:00:0A";
     ip = "10.100.0.20";
-    port = 11020;
+    port = consts.prowlarrPort;
     mem = 1024;
     vcpu = 1;
   };
@@ -113,7 +114,7 @@ validate {
     cid = 110;
     mac = "02:00:00:00:00:0B";
     ip = "10.100.0.23";
-    port = 11023;
+    port = consts.bazarrPort;
     mem = 1024;
     vcpu = 1;
   };
@@ -123,7 +124,7 @@ validate {
     cid = 111;
     mac = "02:00:00:00:00:0C";
     ip = "10.100.0.24";
-    port = 11024;
+    port = consts.readarrPort;
     mem = 1024;
     vcpu = 1;
   };
@@ -133,7 +134,7 @@ validate {
     cid = 112;
     mac = "02:00:00:00:00:0D";
     ip = "10.100.0.26";
-    port = 11028;
+    port = consts.lidarrPort;
     mem = 1024;
     vcpu = 1;
   };
@@ -143,7 +144,7 @@ validate {
     cid = 113;
     mac = "02:00:00:00:00:0E";
     ip = "10.100.0.30";
-    port = 11030;
+    port = consts.qbittorrentPort;
     mem = 2048;
     vcpu = 1;
     gateway = "10.100.0.11";
@@ -155,7 +156,7 @@ validate {
     cid = 114;
     mac = "02:00:00:00:00:0F";
     ip = "10.100.0.40";
-    port = 11040;
+    port = consts.overseerrPort;
     mem = 1024;
     vcpu = 1;
   };
@@ -165,7 +166,7 @@ validate {
     cid = 115;
     mac = "02:00:00:00:00:10";
     ip = "10.100.0.52";
-    port = 11052;
+    port = consts.firefoxPort;
     mem = 4096;
     vcpu = 4;
     gateway = "10.100.0.11";
@@ -176,7 +177,7 @@ validate {
     cid = 116;
     mac = "02:00:00:00:00:11";
     ip = "10.100.0.11";
-    port = 56943;
+    port = consts.wireguardPort;
     mem = 512;
     vcpu = 1;
   };
@@ -186,7 +187,7 @@ validate {
     cid = 117;
     mac = "02:00:00:00:00:12";
     ip = "10.100.0.31";
-    port = 11031;
+    port = consts.sabnzbdPort;
     mem = 1024;
     vcpu = 1;
     gateway = "10.100.0.11";
@@ -200,7 +201,7 @@ validate {
     cid = 118;
     mac = "02:00:00:00:00:13";
     ip = "10.100.0.13";
-    port = 11013;
+    port = consts.flaresolverrPort;
     mem = 512;
     vcpu = 1;
   };
@@ -210,7 +211,7 @@ validate {
     cid = 119;
     mac = "02:00:00:00:00:14";
     ip = "10.100.0.60";
-    port = 11060;
+    port = consts.matrixSynapsePort;
     mem = 4096;
     vcpu = 4;
     tapId = "vm-matrix";
@@ -221,7 +222,7 @@ validate {
     cid = 120;
     mac = "02:00:00:00:00:15";
     ip = "10.100.0.61";
-    port = 11061;
+    port = consts.paperlessPort;
     mem = 8192;
     vcpu = 4;
     tapId = "vm-paperless";
@@ -232,7 +233,7 @@ validate {
     cid = 121;
     mac = "02:00:00:00:00:16";
     ip = "10.100.0.62";
-    port = 11062;
+    port = consts.fireflyPort;
     mem = 2048;
     vcpu = 2;
   };
@@ -242,7 +243,7 @@ validate {
     cid = 122; # Fixed: was 116 (conflicted with wireguard)
     mac = "02:00:00:00:00:17"; # Fixed: was 11 (conflicted with wireguard)
     ip = "10.100.0.54";
-    port = 11054;
+    port = consts.bravePort;
     mem = 4096;
     vcpu = 4;
     gateway = "10.100.0.11";
@@ -253,7 +254,7 @@ validate {
     cid = 123;
     mac = "02:00:00:00:00:18";
     ip = "10.100.0.63";
-    port = 11063;
+    port = consts.fireflyImporterPort;
     mem = 512;
     vcpu = 1;
     tapId = "vm-ff-import";
@@ -264,7 +265,7 @@ validate {
     cid = 124;
     mac = "02:00:00:00:00:19";
     ip = "10.100.0.70";
-    port = 11070;
+    port = consts.immichPort;
     mem = 8192;
     vcpu = 4;
   };
@@ -274,7 +275,7 @@ validate {
     cid = 125;
     mac = "02:00:00:00:00:1A";
     ip = "10.100.0.71";
-    port = 11071;
+    port = consts.mealiePort;
     mem = 1024;
     vcpu = 1;
   };
@@ -284,7 +285,7 @@ validate {
     cid = 126;
     mac = "02:00:00:00:00:1B";
     ip = "10.100.0.80";
-    port = 11080;
+    port = consts.triggerPort;
     mem = 12288;
     vcpu = 6;
   };
@@ -297,7 +298,7 @@ validate {
     prefixLength = 30;
     gateway = "10.100.1.1";
     hostBridge = "pocket-id-br0";
-    port = 11081;
+    port = consts.pocketIdPort;
     mem = 1024;
     vcpu = 1;
   };

--- a/vms/wireguard.nix
+++ b/vms/wireguard.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  registry = import ./vm-registry.nix;
+  registry = import ./vm-registry.nix { inherit consts; };
   reg = registry.wireguard;
   qbtIp = registry.qbittorrent.ip;
   wireguardInterface = "wg0";
@@ -26,10 +26,10 @@ let
       "-D FORWARD -i ${wireguardInterface} -o ens3 -m state --state RELATED,ESTABLISHED -j ACCEPT"
       "-D FORWARD -i ens3 ! -o ${wireguardInterface} -j REJECT"
       "-D OUTPUT ! -o ${wireguardInterface} -m mark ! --mark ${toString wireguardFwmark} -m addrtype ! --dst-type LOCAL -j REJECT"
-      "-t nat -D PREROUTING -i ${wireguardInterface} -p tcp --dport ${toString consts.qbittorrentTorrentPort} -j DNAT --to-destination ${qbtIp}:${toString consts.qbittorrentTorrentPort}"
-      "-t nat -D PREROUTING -i ${wireguardInterface} -p udp --dport ${toString consts.qbittorrentTorrentPort} -j DNAT --to-destination ${qbtIp}:${toString consts.qbittorrentTorrentPort}"
-      "-D FORWARD -i ${wireguardInterface} -o ens3 -p tcp --dport ${toString consts.qbittorrentTorrentPort} -j ACCEPT"
-      "-D FORWARD -i ${wireguardInterface} -o ens3 -p udp --dport ${toString consts.qbittorrentTorrentPort} -j ACCEPT"
+      "-t nat -D PREROUTING -i ${wireguardInterface} -p tcp --dport ${toString consts.ports.network.qbittorrentTorrent} -j DNAT --to-destination ${qbtIp}:${toString consts.ports.network.qbittorrentTorrent}"
+      "-t nat -D PREROUTING -i ${wireguardInterface} -p udp --dport ${toString consts.ports.network.qbittorrentTorrent} -j DNAT --to-destination ${qbtIp}:${toString consts.ports.network.qbittorrentTorrent}"
+      "-D FORWARD -i ${wireguardInterface} -o ens3 -p tcp --dport ${toString consts.ports.network.qbittorrentTorrent} -j ACCEPT"
+      "-D FORWARD -i ${wireguardInterface} -o ens3 -p udp --dport ${toString consts.ports.network.qbittorrentTorrent} -j ACCEPT"
     ]
     ++ map (network: "-D OUTPUT -d ${network} -j ACCEPT") homeNetworks
   );
@@ -50,8 +50,8 @@ let
     -A WG_FORWARD -i ens3 -o ${wireguardInterface} -j ACCEPT
     -A WG_FORWARD -i ${wireguardInterface} -o ens3 -m state --state RELATED,ESTABLISHED -j ACCEPT
     -A WG_FORWARD -i ens3 ! -o ${wireguardInterface} -j REJECT
-    -A WG_FORWARD -i ${wireguardInterface} -o ens3 -p tcp --dport ${toString consts.qbittorrentTorrentPort} -j ACCEPT
-    -A WG_FORWARD -i ${wireguardInterface} -o ens3 -p udp --dport ${toString consts.qbittorrentTorrentPort} -j ACCEPT
+    -A WG_FORWARD -i ${wireguardInterface} -o ens3 -p tcp --dport ${toString consts.ports.network.qbittorrentTorrent} -j ACCEPT
+    -A WG_FORWARD -i ${wireguardInterface} -o ens3 -p udp --dport ${toString consts.ports.network.qbittorrentTorrent} -j ACCEPT
     -A WG_FORWARD -j RETURN
     ${homeNetworkFirewallRules}
     -A WG_OUTPUT ! -o ${wireguardInterface} -m mark ! --mark ${toString wireguardFwmark} -m addrtype ! --dst-type LOCAL -j REJECT
@@ -63,8 +63,8 @@ let
     *nat
     :WG_PREROUTING - [0:0]
     -F WG_PREROUTING
-    -A WG_PREROUTING -i ${wireguardInterface} -p tcp --dport ${toString consts.qbittorrentTorrentPort} -j DNAT --to-destination ${qbtIp}:${toString consts.qbittorrentTorrentPort}
-    -A WG_PREROUTING -i ${wireguardInterface} -p udp --dport ${toString consts.qbittorrentTorrentPort} -j DNAT --to-destination ${qbtIp}:${toString consts.qbittorrentTorrentPort}
+    -A WG_PREROUTING -i ${wireguardInterface} -p tcp --dport ${toString consts.ports.network.qbittorrentTorrent} -j DNAT --to-destination ${qbtIp}:${toString consts.ports.network.qbittorrentTorrent}
+    -A WG_PREROUTING -i ${wireguardInterface} -p udp --dport ${toString consts.ports.network.qbittorrentTorrent} -j DNAT --to-destination ${qbtIp}:${toString consts.ports.network.qbittorrentTorrent}
     -A WG_PREROUTING -j RETURN
     COMMIT
     EOF

--- a/vms/wireguard.nix
+++ b/vms/wireguard.nix
@@ -1,4 +1,9 @@
-{ lib, pkgs, consts, ... }:
+{
+  lib,
+  pkgs,
+  consts,
+  ...
+}:
 let
   registry = import ./vm-registry.nix;
   reg = registry.wireguard;

--- a/vms/wireguard.nix
+++ b/vms/wireguard.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, ... }:
+{ lib, pkgs, consts, ... }:
 let
   registry = import ./vm-registry.nix;
   reg = registry.wireguard;
@@ -21,10 +21,10 @@ let
       "-D FORWARD -i ${wireguardInterface} -o ens3 -m state --state RELATED,ESTABLISHED -j ACCEPT"
       "-D FORWARD -i ens3 ! -o ${wireguardInterface} -j REJECT"
       "-D OUTPUT ! -o ${wireguardInterface} -m mark ! --mark ${toString wireguardFwmark} -m addrtype ! --dst-type LOCAL -j REJECT"
-      "-t nat -D PREROUTING -i ${wireguardInterface} -p tcp --dport 50820 -j DNAT --to-destination ${qbtIp}:50820"
-      "-t nat -D PREROUTING -i ${wireguardInterface} -p udp --dport 50820 -j DNAT --to-destination ${qbtIp}:50820"
-      "-D FORWARD -i ${wireguardInterface} -o ens3 -p tcp --dport 50820 -j ACCEPT"
-      "-D FORWARD -i ${wireguardInterface} -o ens3 -p udp --dport 50820 -j ACCEPT"
+      "-t nat -D PREROUTING -i ${wireguardInterface} -p tcp --dport ${toString consts.qbittorrentTorrentPort} -j DNAT --to-destination ${qbtIp}:${toString consts.qbittorrentTorrentPort}"
+      "-t nat -D PREROUTING -i ${wireguardInterface} -p udp --dport ${toString consts.qbittorrentTorrentPort} -j DNAT --to-destination ${qbtIp}:${toString consts.qbittorrentTorrentPort}"
+      "-D FORWARD -i ${wireguardInterface} -o ens3 -p tcp --dport ${toString consts.qbittorrentTorrentPort} -j ACCEPT"
+      "-D FORWARD -i ${wireguardInterface} -o ens3 -p udp --dport ${toString consts.qbittorrentTorrentPort} -j ACCEPT"
     ]
     ++ map (network: "-D OUTPUT -d ${network} -j ACCEPT") homeNetworks
   );
@@ -45,8 +45,8 @@ let
     -A WG_FORWARD -i ens3 -o ${wireguardInterface} -j ACCEPT
     -A WG_FORWARD -i ${wireguardInterface} -o ens3 -m state --state RELATED,ESTABLISHED -j ACCEPT
     -A WG_FORWARD -i ens3 ! -o ${wireguardInterface} -j REJECT
-    -A WG_FORWARD -i ${wireguardInterface} -o ens3 -p tcp --dport 50820 -j ACCEPT
-    -A WG_FORWARD -i ${wireguardInterface} -o ens3 -p udp --dport 50820 -j ACCEPT
+    -A WG_FORWARD -i ${wireguardInterface} -o ens3 -p tcp --dport ${toString consts.qbittorrentTorrentPort} -j ACCEPT
+    -A WG_FORWARD -i ${wireguardInterface} -o ens3 -p udp --dport ${toString consts.qbittorrentTorrentPort} -j ACCEPT
     -A WG_FORWARD -j RETURN
     ${homeNetworkFirewallRules}
     -A WG_OUTPUT ! -o ${wireguardInterface} -m mark ! --mark ${toString wireguardFwmark} -m addrtype ! --dst-type LOCAL -j REJECT
@@ -58,8 +58,8 @@ let
     *nat
     :WG_PREROUTING - [0:0]
     -F WG_PREROUTING
-    -A WG_PREROUTING -i ${wireguardInterface} -p tcp --dport 50820 -j DNAT --to-destination ${qbtIp}:50820
-    -A WG_PREROUTING -i ${wireguardInterface} -p udp --dport 50820 -j DNAT --to-destination ${qbtIp}:50820
+    -A WG_PREROUTING -i ${wireguardInterface} -p tcp --dport ${toString consts.qbittorrentTorrentPort} -j DNAT --to-destination ${qbtIp}:${toString consts.qbittorrentTorrentPort}
+    -A WG_PREROUTING -i ${wireguardInterface} -p udp --dport ${toString consts.qbittorrentTorrentPort} -j DNAT --to-destination ${qbtIp}:${toString consts.qbittorrentTorrentPort}
     -A WG_PREROUTING -j RETURN
     COMMIT
     EOF


### PR DESCRIPTION
Replace hardcoded ports and addresses across various service configurations with constants for improved maintainability and clarity. Update documentation to reflect these changes and ensure consistent usage of shared service endpoints.