### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -749,11 +749,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1787643690,
-        "narHash": "sha256-aUTix741ZkoSraIdU6wEMBopzxLDrqAICyIUdcK4+8Q=",
+        "lastModified": 1787646868,
+        "narHash": "sha256-kJuUV4S4ZNqQI4DXYqdCfXq/e3/Fi3zUbZBCJUtHgS4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b28ebc26b07cb65fe144c31b28ac38e8e006b3bd",
+        "rev": "b81f108792a4a28bd81846ae4aed37419a5506bf",
         "type": "github"
       },
       "original": {
@@ -797,11 +797,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1787608092,
-        "narHash": "sha256-/U5miYtjahf4VLsSwvct6ZJAQZKvTqFQnw6fAQQ9eKM=",
+        "lastModified": 1787642242,
+        "narHash": "sha256-o7cd8Z4pejj8clfwmJGJiRp8PJ496VV0QASk1XLoKLU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "00ca96cb74b778f8c999d5075624fc10636520fc",
+        "rev": "c31f86faf4b060a186e94ee258278de30c69b90b",
         "type": "github"
       },
       "original": {
@@ -864,11 +864,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787645076,
-        "narHash": "sha256-V8AuM6F+sqUcll3FOHZvpKGfA3rM2bW5ibvZ0dkolUw=",
+        "lastModified": 1787648665,
+        "narHash": "sha256-VgqjMenzOlc90UKwn3qBLrb9vzOlFWW+rjiF82YoyvQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ada06bdbcb422429cb8aee917205020aff6d1307",
+        "rev": "a1d967e8229a2f35b08901ca8174f55f30fdc65f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nix-secrets':
    'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=ed7ae72bf5ed04692b00a4a3ae44fa7020e24c79' (2026-08-25)
  → 'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=ed7ae72bf5ed04692b00a4a3ae44fa7020e24c79' (2026-08-25)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/b28ebc2' (2026-08-25)
  → 'github:NixOS/nixpkgs/b81f108' (2026-08-25)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/00ca96c' (2026-08-24)
  → 'github:NixOS/nixpkgs/c31f86f' (2026-08-25)
• Updated input 'nur':
    'github:nix-community/NUR/ada06bd' (2026-08-25)
  → 'github:nix-community/NUR/a1d967e' (2026-08-25)
```