### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -749,11 +749,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1787646868,
-        "narHash": "sha256-kJuUV4S4ZNqQI4DXYqdCfXq/e3/Fi3zUbZBCJUtHgS4=",
+        "lastModified": 1787658983,
+        "narHash": "sha256-0CpyR7q7UqtmduorKH7Z8sjvKPk/8vAG4UwAIRwuE/U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b81f108792a4a28bd81846ae4aed37419a5506bf",
+        "rev": "2aad47b9aff970c0066c7732679bb1a0272840a7",
         "type": "github"
       },
       "original": {
@@ -765,11 +765,11 @@
     },
     "nixpkgs-stable-small": {
       "locked": {
-        "lastModified": 1787615910,
-        "narHash": "sha256-4pG4Blm+mokuS18v/RSMWIUWOw28K+XxRJo6RNn409w=",
+        "lastModified": 1787649511,
+        "narHash": "sha256-VOm5exor76Oo+N883Oz5uWcCLXnOwJH/AAMPn0rj91Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fd37132eee9fb7a1f7a3e3396f288fb558608d22",
+        "rev": "3d800596f30107bcd4a3e1b312b316292a17d57c",
         "type": "github"
       },
       "original": {
@@ -864,11 +864,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787648665,
-        "narHash": "sha256-VgqjMenzOlc90UKwn3qBLrb9vzOlFWW+rjiF82YoyvQ=",
+        "lastModified": 1787653254,
+        "narHash": "sha256-xBo0bSNNUvieRHJ3FYbX0bnLl/vTI+NtXU5WH+gkzgI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a1d967e8229a2f35b08901ca8174f55f30fdc65f",
+        "rev": "1b4587e134b480335d7a543e84a431032a596459",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nix-secrets':
    'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=ed7ae72bf5ed04692b00a4a3ae44fa7020e24c79' (2026-08-25)
  → 'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=ed7ae72bf5ed04692b00a4a3ae44fa7020e24c79' (2026-08-25)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/b81f108' (2026-08-25)
  → 'github:NixOS/nixpkgs/2aad47b' (2026-08-25)
• Updated input 'nixpkgs-stable-small':
    'github:NixOS/nixpkgs/fd37132' (2026-08-24)
  → 'github:NixOS/nixpkgs/3d80059' (2026-08-25)
• Updated input 'nur':
    'github:nix-community/NUR/a1d967e' (2026-08-25)
  → 'github:nix-community/NUR/1b4587e' (2026-08-25)
```