### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -197,11 +197,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787661347,
-        "narHash": "sha256-THmnBAdAIV+jT348f3r/vyoeb6ilhcVLwVXkBU7Pai8=",
+        "lastModified": 1787680808,
+        "narHash": "sha256-9168tNt0NZdtlx5RM5huEuc9NCWMLACJA9O4UK/l2Zc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "52c3a5881c821ad7367bbde075e52b76cdb378ab",
+        "rev": "6840c9a8f50722944eb106ce8bb237c138584f2a",
         "type": "github"
       },
       "original": {
@@ -749,11 +749,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1787670526,
-        "narHash": "sha256-ewvTn0x8EcsrLqpJMQlMx9FoZmY7hdwLk9eT7D/ekYA=",
+        "lastModified": 1787680695,
+        "narHash": "sha256-2ZkmZ3ddPBiOb/xwW0oFDQQyEbr2zado38Tl5ufWB8g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b41534db4ca4ed3f4f385d69e31a8ce94442fdb7",
+        "rev": "2a98f9e1f62fb6ae066f3d92da5a58ce34d6f2c4",
         "type": "github"
       },
       "original": {
@@ -797,11 +797,11 @@
     },
     "nixpkgs-unstable-small": {
       "locked": {
-        "lastModified": 1787642242,
-        "narHash": "sha256-o7cd8Z4pejj8clfwmJGJiRp8PJ496VV0QASk1XLoKLU=",
+        "lastModified": 1787673450,
+        "narHash": "sha256-VpX10752K0aIHRedU/tYY3jWr1+4rAx0JU4Hr+b8QQM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c31f86faf4b060a186e94ee258278de30c69b90b",
+        "rev": "103cb3a0b62b1d0a4560d265cdfbc0af064f6767",
         "type": "github"
       },
       "original": {
@@ -864,11 +864,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787670098,
-        "narHash": "sha256-HonnkAB+VFaPw3/hjn+S3raDHDuaRL3vw6Lc0HhHvE0=",
+        "lastModified": 1787680575,
+        "narHash": "sha256-zH56ad9Z+QuxXqHMU9ElMmDuRdn8e2GDdl/AhX//O30=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3e15dafb26fab064883ec040fd06d54e3ffb7969",
+        "rev": "0c1160380251dc4526ab72231f9d68290050c4a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'hm-master':
    'github:nix-community/home-manager/52c3a58' (2026-08-25)
  → 'github:nix-community/home-manager/6840c9a' (2026-08-25)
• Updated input 'nix-secrets':
    'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=ed7ae72bf5ed04692b00a4a3ae44fa7020e24c79' (2026-08-25)
  → 'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=ed7ae72bf5ed04692b00a4a3ae44fa7020e24c79' (2026-08-25)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/b41534d' (2026-08-25)
  → 'github:NixOS/nixpkgs/2a98f9e' (2026-08-25)
• Updated input 'nixpkgs-unstable-small':
    'github:NixOS/nixpkgs/c31f86f' (2026-08-25)
  → 'github:NixOS/nixpkgs/103cb3a' (2026-08-25)
• Updated input 'nur':
    'github:nix-community/NUR/3e15daf' (2026-08-25)
  → 'github:nix-community/NUR/0c11603' (2026-08-25)
```