### PR TITLE
🧹 chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -749,11 +749,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1787691609,
-        "narHash": "sha256-vgJ3RwFpiKEdnzvm5mtAvH3dUdmoUMqs8q5y2BYxl5M=",
+        "lastModified": 1787702270,
+        "narHash": "sha256-fiVtu2X8JqSsV+kQBNRLSn4cSyZbWgrPdlBnTrBlEIE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ea17bd23f0694cbf2d691995db5568f72ca2ddd0",
+        "rev": "e0cc0f1f7c13e34a3f4110c64a19d6b4e5298b15",
         "type": "github"
       },
       "original": {
@@ -765,11 +765,11 @@
     },
     "nixpkgs-stable-small": {
       "locked": {
-        "lastModified": 1787649511,
-        "narHash": "sha256-VOm5exor76Oo+N883Oz5uWcCLXnOwJH/AAMPn0rj91Q=",
+        "lastModified": 1787684635,
+        "narHash": "sha256-86iffy9eS4Ji0eAB0DscntLc7SlxTCZDalGT3N8Xy1w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3d800596f30107bcd4a3e1b312b316292a17d57c",
+        "rev": "535f9e6d8ddef9ee287da5cffe6d67dc4723eb42",
         "type": "github"
       },
       "original": {
@@ -864,11 +864,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787691552,
-        "narHash": "sha256-OfCsUbzHz7fox7zH497usI5QslwMho3oUUUmjoSn8F8=",
+        "lastModified": 1787695503,
+        "narHash": "sha256-ntoGPUFOI1Kw0/Xar/O7CkWvlvTcIdalzswthfwPz6s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fda2441c5f9b47135cfb4de52dbace1f5af34307",
+        "rev": "b1cb8706be1e94a9c1c37c638873c9878c0ceb0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nix-secrets':
    'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=ed7ae72bf5ed04692b00a4a3ae44fa7020e24c79' (2026-08-25)
  → 'git+ssh://git@github.com/telometto/nix-secrets.git?ref=refs/heads/master&rev=ed7ae72bf5ed04692b00a4a3ae44fa7020e24c79' (2026-08-25)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/ea17bd2' (2026-08-25)
  → 'github:NixOS/nixpkgs/e0cc0f1' (2026-08-25)
• Updated input 'nixpkgs-stable-small':
    'github:NixOS/nixpkgs/3d80059' (2026-08-25)
  → 'github:NixOS/nixpkgs/535f9e6' (2026-08-25)
• Updated input 'nur':
    'github:nix-community/NUR/fda2441' (2026-08-25)
  → 'github:nix-community/NUR/b1cb870' (2026-08-25)
```